### PR TITLE
Mobile UI tweaks and UX fixes

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -24,6 +24,10 @@ class MovieController extends Controller
 
         $providersArray = $movieService->buildProvidersArray($tmdb);
 
+        if ($request->query('i') !== null) {
+            session()->forget('userInput');
+        }
+
         $movieCriteria = session('userInput');
         $similarMovies = null;
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -373,6 +373,29 @@ html[data-theme="light"] {
     }
     .swiper-button-disabled { opacity: 0.25 !important; }
 
+    /* Accordion */
+    .accordion-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.25s ease;
+    }
+    .accordion-section.accordion-open .accordion-body {
+        max-height: 600px;
+        overflow: visible;
+    }
+    .accordion-chevron {
+        transition: transform 0.25s ease;
+    }
+    .accordion-section.accordion-open .accordion-chevron {
+        transform: rotate(180deg);
+    }
+
+    /* Mobile sticky bar — safe area aware bottom padding */
+    .sticky-bar-safe {
+        padding-top: 0.75rem;
+        padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    }
+
     /* Hero gradient */
     .hero-fade {
         background: linear-gradient(to bottom, transparent, rgba(15,15,15,0.4), #0f0f0f);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -80,6 +80,11 @@ $(document).ready(function () {
         setTimeout(() => window.removeEventListener('beforeunload', handler), 150);
     });
 
+    /* ── Accordion ─────────────────────────────────────────────────────── */
+    $(document).on('click', '.accordion-header', function () {
+        $(this).closest('.accordion-section').toggleClass('accordion-open');
+    });
+
     /* ── Auto-dismiss alerts ───────────────────────────────────────────── */
     setTimeout(function () {
         $('.alert-msg').fadeOut(400, function () { $(this).remove(); });

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -83,6 +83,10 @@ $(document).ready(function () {
         if (!window['_ts_modal-with_cast']) {
             makePeopleTs('modal-with_cast', 'Acting');
             makePeopleTs('modal-with_crew', null);
+            $.getJSON('/userinput', function (data) {
+                restorePeople(data['with_cast'], 'modal-with_cast');
+                restorePeople(data['with_crew'], 'modal-with_crew');
+            });
         }
     });
 

--- a/resources/js/custom/trailerModal.js
+++ b/resources/js/custom/trailerModal.js
@@ -38,12 +38,12 @@ $(document).ready(function () {
     /* â”€â”€ Tom Select: genres â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
     if (document.getElementById('modal-with_genres')) {
         window._ts_modal_with_genres = new TomSelect('#modal-with_genres', {
-            plugins: ['remove_button'], placeholder: 'Select genresâ€¦', maxOptions: null,
+            plugins: ['remove_button'], placeholder: 'Select genres...', maxOptions: null,
         });
     }
     if (document.getElementById('modal-without_genres')) {
         window._ts_modal_without_genres = new TomSelect('#modal-without_genres', {
-            plugins: ['remove_button'], placeholder: 'Exclude genresâ€¦', maxOptions: null,
+            plugins: ['remove_button'], placeholder: 'Exclude genres...', maxOptions: null,
         });
     }
 
@@ -58,7 +58,7 @@ $(document).ready(function () {
     if (document.getElementById('modal-with_watch_providers')) {
         window._ts_modal_providers = new TomSelect('#modal-with_watch_providers', {
             plugins: ['remove_button'],
-            placeholder: 'Select servicesâ€¦',
+            placeholder: 'Select services...',
             maxOptions: null,
             render: {
                 option: function (data, escape) {

--- a/resources/js/custom/trailerModal.js
+++ b/resources/js/custom/trailerModal.js
@@ -1,10 +1,10 @@
-﻿import TomSelect from 'tom-select';
+import TomSelect from 'tom-select';
 import 'jquery-flexdatalist/jquery.flexdatalist.min';
 
 $(document).ready(function () {
     const tmdb = window.TMDB_API_KEY;
 
-    /* â”€â”€ Step wizard inside the adjust-form modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Step wizard inside the adjust-form modal -------------- */
     let currentStep = 1;
     const totalSteps = 5;
 
@@ -35,7 +35,7 @@ $(document).ready(function () {
 
     if ($('#modal-step-1').length) showStep(1);
 
-    /* â”€â”€ Tom Select: genres â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Tom Select: genres ------------------------------------ */
     if (document.getElementById('modal-with_genres')) {
         window._ts_modal_with_genres = new TomSelect('#modal-with_genres', {
             plugins: ['remove_button'], placeholder: 'Select genres...', maxOptions: null,
@@ -47,14 +47,14 @@ $(document).ready(function () {
         });
     }
 
-    /* â”€â”€ Tom Select: language â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Tom Select: language ---------------------------------- */
     if (document.getElementById('modal-with_original_language')) {
         window._ts_modal_lang = new TomSelect('#modal-with_original_language', {
             maxOptions: null, create: false,
         });
     }
 
-    /* â”€â”€ Tom Select: streaming providers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Tom Select: streaming providers ---------------------- */
     if (document.getElementById('modal-with_watch_providers')) {
         window._ts_modal_providers = new TomSelect('#modal-with_watch_providers', {
             plugins: ['remove_button'],
@@ -77,52 +77,8 @@ $(document).ready(function () {
         });
     }
 
-    /* â”€â”€ Flexdatalist: cast & crew in modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-    if ($('.modal-cast').length) {
-        $('.modal-cast').flexdatalist({
-            minLength: 0, maxShownResults: 4, textProperty: 'name', valueProperty: 'id',
-            selectionRequired: true, visibleProperties: ['name'], searchContain: true,
-            searchIn: 'name', multiple: true, searchDelay: 800,
-        });
-    }
-    if ($('.modal-crew').length) {
-        $('.modal-crew').flexdatalist({
-            minLength: 0, maxShownResults: 4, textProperty: 'name', valueProperty: 'id',
-            selectionRequired: true, visibleProperties: ['name'], searchContain: true,
-            searchIn: 'name', multiple: true, searchDelay: 800,
-        });
-    }
-
-    let castTimer, crewTimer;
-    $('#modal-with_cast-flexdatalist').on('keyup', function () {
-        clearTimeout(castTimer);
-        const val = $(this).val();
-        castTimer = setTimeout(function () { fetchPeople(val, 'Acting', '.modal-cast'); }, 500);
-    }).on('keydown', function () { clearTimeout(castTimer); });
-
-    $('#modal-with_crew-flexdatalist').on('keyup', function () {
-        clearTimeout(crewTimer);
-        const val = $(this).val();
-        crewTimer = setTimeout(function () { fetchPeople(val, null, '.modal-crew'); }, 500);
-    }).on('keydown', function () { clearTimeout(crewTimer); });
-
-    function fetchPeople(name, dept, target) {
-        if (!name || !tmdb) return;
-        $.getJSON('https://api.themoviedb.org/3/search/person?api_key=' + tmdb + '&language=en-US&query=' + encodeURIComponent(name) + '&page=1&include_adult=false')
-            .done(function (data) {
-                const results = [];
-                $.each(data.results, function (i, item) {
-                    if (!dept || item.known_for_department === dept) results.push(item);
-                    if (results.length >= 4) return false;
-                });
-                $(target).flexdatalist('data', results);
-            });
-    }
-
-    /* â”€â”€ Restore session data â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Restore session data ---------------------------------- */
     $.getJSON('/userinput', function (data) {
-        restorePeople(data['with_cast'], '.modal-cast');
-        restorePeople(data['with_crew'], '.modal-crew');
 
         if (data['with_genres'] && window._ts_modal_with_genres) {
             window._ts_modal_with_genres.setValue(data['with_genres'].split(','), true);
@@ -143,23 +99,7 @@ $(document).ready(function () {
         if (data['vote_count_gte'])           $('#modal-vote_count_gte').val(data['vote_count_gte']);
     });
 
-    function restorePeople(ids, target) {
-        if (!ids || !tmdb) return;
-        const idArr = ids.split(',');
-        const resolved = [];
-        $.each(idArr, function (i, id) {
-            $.getJSON('https://api.themoviedb.org/3/person/' + id + '?api_key=' + tmdb + '&language=en-US')
-                .done(function (d) {
-                    resolved.push({ id: id, name: d.name });
-                    if (resolved.length === idArr.length) {
-                        $(target).flexdatalist('data', resolved);
-                        $(target).flexdatalist('value', resolved.map(r => r.id).join(','));
-                    }
-                });
-        });
-    }
-
-    /* â”€â”€ Auto-dismiss errors â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+    /* -- Auto-dismiss errors ----------------------------------- */
     setTimeout(function () {
         $('.alert-msg').fadeOut(400, function () { $(this).remove(); });
     }, 4000);

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -29,12 +29,12 @@
 </div>
 
 {{-- Mobile sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 sm:hidden bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
+<div class="fixed bottom-0 left-0 right-0 sm:hidden bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="flex gap-3">
-        <a href="{{ Request::url() }}" class="btn-accent flex-1 text-center">New Batch</a>
         @if(isset($providersArray) && isset($all_genres))
             <button type="button" class="btn-secondary flex-1" data-modal-open="modal-form">Adjust</button>
         @endif
+        <a href="{{ Request::url() }}" class="btn-accent flex-1 text-center">New Batch</a>
     </div>
 </div>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -42,7 +42,7 @@
             <h2 class="text-2xl font-bold text-white mb-3">Trending Today</h2>
             <div class="section-divider"></div>
         </div>
-        @include('includes.carousel', ['allMovies' => $trending, 'name' => 'swiper-trending', 'genres' => []])
+        @include('includes.carousel', ['allMovies' => $trending, 'name' => 'swiper-trending', 'genres' => [], 'clearCriteria' => true])
     </section>
 
     {{-- About --}}

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -3,7 +3,7 @@
         @foreach ($allMovies['results'] as $result)
             @if(isset($result['release_date']))
             <div class="swiper-slide h-auto">
-                <a href="{{ url('movie/'.$result['id']) }}" class="block group long-movie" data-name="{{ $result['title'] }}">
+                <a href="{{ url('movie/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : '' }}" class="block group long-movie" data-name="{{ $result['title'] }}">
                     <div class="card card-hover h-full flex flex-col overflow-hidden">
                         {{-- Poster --}}
                         <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden">

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -1,5 +1,10 @@
 @php
     if ($user_input === 'default') $user_input = [];
+    $openYear     = !empty($user_input['primary_release_date_gte'] ?? '') || !empty($user_input['primary_release_date_lte'] ?? '');
+    $openGenres   = !empty($user_input['with_genres'] ?? []) || !empty($user_input['without_genres'] ?? []);
+    $openStreaming = !empty($user_input['with_watch_providers'] ?? []);
+    $openPeople   = !empty($user_input['with_cast'] ?? []) || !empty($user_input['with_crew'] ?? []);
+    $openScores   = !empty($user_input['vote_average_gte'] ?? '') || !empty($user_input['vote_average_lte'] ?? '') || !empty($user_input['vote_count_gte'] ?? '');
 @endphp
 
 <div id="modal-form" class="modal-wrap hidden">
@@ -9,126 +14,139 @@
 
         <form method="POST" autocomplete="off" action="/movie?a=true" id="modal-criteria">
             @csrf
-            <div class="p-5 flex flex-col gap-5">
+            <div class="p-5 pb-4 flex flex-col">
 
-                <div>
+                <div class="mb-2">
                     <h2 class="text-lg font-bold text-white">Adjust Criteria</h2>
-                    <p class="text-xs text-gray-500 mt-0.5">Fill in what you want, leave the rest blank.</p>
+                    <p class="text-xs text-gray-500 mt-0.5">Tap a section to expand. Leave anything blank to ignore it.</p>
                 </div>
 
                 {{-- Years --}}
-                <div>
-                    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Release Year</h3>
-                    <div class="grid grid-cols-2 gap-3">
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">From</label>
-                            <input type="text" class="input-dark bg-input"
-                                name="primary_release_date_gte"
-                                placeholder="1874"
-                                value="{{ $user_input['primary_release_date_gte'] ?? '' }}">
-                        </div>
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">To</label>
-                            <input type="text" class="input-dark bg-input"
-                                name="primary_release_date_lte"
-                                placeholder="{{ date('Y') }}"
-                                value="{{ $user_input['primary_release_date_lte'] ?? '' }}">
+                <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Release Year</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 grid grid-cols-2 gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">From</label>
+                                <input type="text" class="input-dark" name="primary_release_date_gte" placeholder="1874" value="{{ $user_input['primary_release_date_gte'] ?? '' }}">
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">To</label>
+                                <input type="text" class="input-dark" name="primary_release_date_lte" placeholder="{{ date('Y') }}" value="{{ $user_input['primary_release_date_lte'] ?? '' }}">
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 {{-- Genres --}}
-                <div class="border-t border-white/5 pt-4">
-                    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Genres</h3>
-                    <div class="flex flex-col gap-3">
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Include</label>
-                            <select name="with_genres[]" id="modal-with_genres" multiple>
-                                @foreach ($all_genres as $genre)
-                                    <option value="{{ $genre->id }}"
-                                        {{ isset($user_input['with_genres']) && in_array($genre->id, (array)$user_input['with_genres']) ? 'selected' : '' }}>
-                                        {{ $genre->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Exclude</label>
-                            <select name="without_genres[]" id="modal-without_genres" multiple>
-                                @foreach ($all_genres as $genre)
-                                    <option value="{{ $genre->id }}"
-                                        {{ isset($user_input['without_genres']) && in_array($genre->id, (array)$user_input['without_genres']) ? 'selected' : '' }}>
-                                        {{ $genre->name }}
-                                    </option>
-                                @endforeach
-                            </select>
+                <div class="accordion-section border-t border-white/5 {{ $openGenres ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Genres</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Include</label>
+                                <select name="with_genres[]" id="modal-with_genres" multiple>
+                                    @foreach ($all_genres as $genre)
+                                        <option value="{{ $genre->id }}"
+                                            {{ isset($user_input['with_genres']) && in_array($genre->id, (array)$user_input['with_genres']) ? 'selected' : '' }}>
+                                            {{ $genre->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Exclude</label>
+                                <select name="without_genres[]" id="modal-without_genres" multiple>
+                                    @foreach ($all_genres as $genre)
+                                        <option value="{{ $genre->id }}"
+                                            {{ isset($user_input['without_genres']) && in_array($genre->id, (array)$user_input['without_genres']) ? 'selected' : '' }}>
+                                            {{ $genre->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 {{-- Streaming --}}
-                <div class="border-t border-white/5 pt-4">
-                    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Streaming</h3>
-                    <div class="flex flex-col gap-3">
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Language</label>
-                            @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? 'en'])
-                        </div>
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Services</label>
-                            <select id="modal-with_watch_providers" name="with_watch_providers[]" multiple>
-                                @foreach($providersArray as $value)
-                                    <option value="{{ $value['id'] }}"
-                                        data-logo="{{ $value['logo'] }}"
-                                        {{ isset($user_input['with_watch_providers']) && in_array($value['id'], (array)$user_input['with_watch_providers']) ? 'selected' : '' }}>
-                                        {{ $value['name'] }}
-                                    </option>
-                                @endforeach
-                            </select>
+                <div class="accordion-section border-t border-white/5 {{ $openStreaming ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Streaming</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Language</label>
+                                @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? 'en'])
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Services</label>
+                                <select id="modal-with_watch_providers" name="with_watch_providers[]" multiple>
+                                    @foreach($providersArray as $value)
+                                        <option value="{{ $value['id'] }}"
+                                            data-logo="{{ $value['logo'] }}"
+                                            {{ isset($user_input['with_watch_providers']) && in_array($value['id'], (array)$user_input['with_watch_providers']) ? 'selected' : '' }}>
+                                            {{ $value['name'] }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 {{-- People --}}
-                <div class="border-t border-white/5 pt-4">
-                    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">People</h3>
-                    <div class="flex flex-col gap-3">
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Actors</label>
-                            <select id="modal-with_cast" name="with_cast[]" multiple></select>
-                            <p class="text-xs text-gray-600 mt-1">Type to search, you can add multiple</p>
-                        </div>
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Crew</label>
-                            <select id="modal-with_crew" name="with_crew[]" multiple></select>
-                            <p class="text-xs text-gray-600 mt-1">Directors, writers, producers — you can add multiple</p>
+                <div class="accordion-section border-t border-white/5 {{ $openPeople ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">People</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Actors</label>
+                                <select id="modal-with_cast" name="with_cast[]" multiple></select>
+                                <p class="text-xs text-gray-600 mt-1">Type to search, you can add multiple</p>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Crew</label>
+                                <select id="modal-with_crew" name="with_crew[]" multiple></select>
+                                <p class="text-xs text-gray-600 mt-1">Directors, writers, producers</p>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 {{-- Scores --}}
-                <div class="border-t border-white/5 pt-4">
-                    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Scores</h3>
-                    <div class="flex flex-col gap-3">
-                        <div class="grid grid-cols-2 gap-3">
-                            <div>
-                                <label class="block text-sm text-gray-400 mb-1">Min Score</label>
-                                <input type="text" class="input-dark bg-input"
-                                    name="vote_average_gte"
-                                    placeholder="0" value="{{ $user_input['vote_average_gte'] ?? '' }}">
+                <div class="accordion-section border-t border-white/5 {{ $openScores ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Scores</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div class="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label class="block text-sm text-gray-400 mb-1">Min Score</label>
+                                    <input type="text" class="input-dark" name="vote_average_gte" placeholder="0" value="{{ $user_input['vote_average_gte'] ?? '' }}">
+                                </div>
+                                <div>
+                                    <label class="block text-sm text-gray-400 mb-1">Max Score</label>
+                                    <input type="text" class="input-dark" name="vote_average_lte" placeholder="10" value="{{ $user_input['vote_average_lte'] ?? '' }}">
+                                </div>
                             </div>
                             <div>
-                                <label class="block text-sm text-gray-400 mb-1">Max Score</label>
-                                <input type="text" class="input-dark bg-input"
-                                    name="vote_average_lte"
-                                    placeholder="10" value="{{ $user_input['vote_average_lte'] ?? '' }}">
+                                <label class="block text-sm text-gray-400 mb-1">Min Vote Count</label>
+                                <input type="text" class="input-dark" name="vote_count_gte" placeholder="10" value="{{ $user_input['vote_count_gte'] ?? '' }}">
                             </div>
-                        </div>
-                        <div>
-                            <label class="block text-sm text-gray-400 mb-1">Min Vote Count</label>
-                            <input type="text" class="input-dark bg-input"
-                                name="vote_count_gte"
-                                placeholder="10" value="{{ $user_input['vote_count_gte'] ?? '' }}">
                         </div>
                     </div>
                 </div>
@@ -136,12 +154,10 @@
                 @include('errors.error')
 
                 {{-- Actions --}}
-                <div class="flex items-center justify-between pt-4 border-t border-white/5">
-                    <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
-                    <div class="flex gap-2">
-                        <button type="submit" class="btn-accent" formaction="/movie?a=true">Find Movie</button>
-                        <button type="submit" class="btn-secondary" formaction="/multiple?a=true">Multiple</button>
-                    </div>
+                <div class="flex gap-2 pt-4 border-t border-white/5">
+                    <button type="button" id="modal-btn-reset" class="btn-secondary flex-1 text-sm">Reset</button>
+                    <button type="submit" class="btn-accent flex-1 text-sm" formaction="/movie?a=true">Find Movie</button>
+                    <button type="submit" class="btn-secondary flex-1 text-sm" formaction="/multiple?a=true">Multiple</button>
                 </div>
 
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,7 @@
     <title>@yield('page_title', 'MoviePickr')</title>
     <link rel="icon" href="{{ URL::asset('/images/icon.png') }}"/>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="description" content="Random Movie Picker — find the perfect film for tonight.">
     <script>!function(){var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);if(m)document.documentElement.dataset.theme=m[1]}()</script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -36,8 +36,8 @@
     {{-- Main content grid --}}
     <div class="flex gap-3 md:grid md:grid-cols-[220px_1fr] md:gap-6 mb-8">
 
-        {{-- Poster --}}
-        <div class="w-[38%] md:w-auto flex-shrink-0">
+        {{-- Poster + trailer button --}}
+        <div class="w-[38%] md:w-auto flex-shrink-0 flex flex-col gap-2">
             @if($tmdbInfo->poster_path)
                 <img src="https://image.tmdb.org/t/p/original{{ $tmdbInfo->poster_path }}"
                     alt="{{ $tmdbInfo->title }}"
@@ -48,6 +48,9 @@
                 <div class="w-full aspect-[2/3] card flex items-center justify-center text-gray-600 text-xs text-center px-2">
                     No poster available
                 </div>
+            @endif
+            @if(isset($trailer))
+                <button type="button" class="btn-accent text-sm w-full" data-modal-open="trailer-modal">▶ Trailer</button>
             @endif
         </div>
 
@@ -69,25 +72,17 @@
             </div>
             @endif
 
-            {{-- Trailer + streaming --}}
-            <div class="flex flex-wrap gap-2 md:gap-3 items-center">
-                @if(isset($trailer))
-                    <button type="button" class="btn-accent text-sm" data-modal-open="trailer-modal">▶ Trailer</button>
-                @else
-                    <button class="btn-secondary text-sm opacity-50 cursor-default" disabled>No Trailer</button>
-                @endif
-
-                @if ($watchProviders != null)
-                    <div class="flex items-center gap-2 flex-wrap">
-                        @foreach($watchProviders->flatrate as $stream)
-                            <a href="{{ $watchProviders->link }}" target="_blank" title="Watch on streaming">
-                                <img src="https://image.tmdb.org/t/p/w45{{ $stream->logo_path }}"
-                                    class="h-8 w-8 rounded-md border border-white/10 hover:border-white/30 transition-colors">
-                            </a>
-                        @endforeach
-                    </div>
-                @endif
-            </div>
+            {{-- Streaming --}}
+            @if ($watchProviders != null)
+                <div class="flex items-center gap-2 flex-wrap">
+                    @foreach($watchProviders->flatrate as $stream)
+                        <a href="{{ $watchProviders->link }}" target="_blank" title="Watch on streaming">
+                            <img src="https://image.tmdb.org/t/p/w45{{ $stream->logo_path }}"
+                                class="h-8 w-8 rounded-md border border-white/10 hover:border-white/30 transition-colors">
+                        </a>
+                    @endforeach
+                </div>
+            @endif
 
             {{-- Plot --}}
             <div>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -221,10 +221,10 @@
 </div>
 
 {{-- Mobile sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 sm:hidden bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
+<div class="fixed bottom-0 left-0 right-0 sm:hidden bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="flex gap-3">
-        <a href="/movie" class="btn-accent long-single flex-1 text-center">Pick Another</a>
         <button type="button" class="btn-secondary flex-1" data-modal-open="modal-form">Adjust</button>
+        <a href="/movie" class="btn-accent long-single flex-1 text-center">Pick Another</a>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary

- **Mobile sticky bar**: swapped button order (Adjust left, Pick Another right) on movie and batch pages; fixed iOS Safari gap with `viewport-fit=cover` + `env(safe-area-inset-bottom)`
- **Criteria modal**: collapsible accordion sections (auto-expand when values are set), equal-width action buttons
- **Trailer button**: moved under the poster at poster width instead of inline with streaming icons
- **Garbled characters**: fixed double-encoded UTF-8 in `trailerModal.js` comments and Tom Select placeholders
- **Modal people backfill**: actors/crew now correctly restore saved values when the adjust-criteria modal is opened
- **Criteria clearing**: navigating to a movie from homepage trending cards now clears saved criteria so "Pick Another" is random; Pick Another and New Batch buttons still preserve criteria

## Test plan

- [x] Mobile: sticky bar shows Adjust on left, Pick Another on right (movie page and batch page)
- [x] iPhone Safari: no gap below sticky bar when browser nav collapses
- [x] Criteria modal: each section collapses/expands; sections with saved values open automatically
- [x] Trailer button appears below the poster at poster width
- [x] Adjust criteria modal: actors/crew fields populate with previously selected people
- [x] Homepage trending card → movie page → Pick Another picks a random movie (no criteria)
- [x] Movie page Pick Another → same criteria preserved