### PR TITLE
Add mood shortcuts to homepage

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -128,6 +128,35 @@ html[data-theme="light"] {
     }
     .btn-secondary:active { transform: scale(0.97); }
 
+    /* Mood shortcut tile */
+    .mood-tile {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 1.25rem 0.75rem;
+        background-color: var(--bg-surface);
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        color: var(--text-muted);
+        cursor: pointer;
+        transition: border-color 0.2s, background-color 0.2s, color 0.2s, transform 0.1s;
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        width: 100%;
+    }
+    .mood-tile:hover {
+        border-color: rgba(192,57,58,0.45);
+        background-color: var(--bg-surface-hover);
+        color: var(--text-primary);
+        transform: translateY(-1px);
+    }
+    .mood-tile:active { transform: scale(0.97); }
+    .mood-tile svg { width: 1.4rem; height: 1.4rem; }
+
     /* Glass card */
     .card {
         background-color: var(--bg-surface);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -68,7 +68,8 @@ $(document).ready(function () {
     });
 
     $(document).on('click', '.long-single', function () {
-        const handler = () => showLoading('Looking for a perfect movie!');
+        const text = $(this).data('loading') || 'Looking for a perfect movie!';
+        const handler = () => showLoading(text);
         window.addEventListener('beforeunload', handler, { once: true });
         setTimeout(() => window.removeEventListener('beforeunload', handler), 150);
     });

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -36,6 +36,102 @@
         </div>
     </section>
 
+    {{-- Mood shortcuts --}}
+    <section class="max-w-7xl mx-auto px-4 py-12 border-b border-white/5">
+        <div class="section-header">
+            <h2 class="text-2xl font-bold text-white mb-3">I'm in the mood for…</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
+
+            {{-- Funny --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="35">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"/>
+                        <path d="M8 13s1.5 3 4 3 4-3 4-3"/>
+                        <line x1="9" y1="9" x2="9.01" y2="9"/>
+                        <line x1="15" y1="9" x2="15.01" y2="9"/>
+                    </svg>
+                    <span>Funny</span>
+                </button>
+            </form>
+
+            {{-- Intense --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="53">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                    </svg>
+                    <span>Intense</span>
+                </button>
+            </form>
+
+            {{-- Feel-good --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="18">
+                <input type="hidden" name="vote_average_gte" value="7.5">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"/>
+                        <line x1="12" y1="1" x2="12" y2="3"/>
+                        <line x1="12" y1="21" x2="12" y2="23"/>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                        <line x1="1" y1="12" x2="3" y2="12"/>
+                        <line x1="21" y1="12" x2="23" y2="12"/>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                    </svg>
+                    <span>Feel-good</span>
+                </button>
+            </form>
+
+            {{-- Dark --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="27">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+                    </svg>
+                    <span>Dark</span>
+                </button>
+            </form>
+
+            {{-- Romantic --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="10749">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
+                    </svg>
+                    <span>Romantic</span>
+                </button>
+            </form>
+
+            {{-- Mindless --}}
+            <form method="POST" action="/movie?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="28">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"/>
+                        <polygon points="10 8 16 12 10 16 10 8"/>
+                    </svg>
+                    <span>Mindless</span>
+                </button>
+            </form>
+
+        </div>
+    </section>
+
     {{-- Trending --}}
     <section class="max-w-7xl mx-auto px-4 py-12">
         <div class="section-header">


### PR DESCRIPTION
## Summary

- Adds a \"I'm in the mood for…\" section between the hero and trending sections on the homepage
- Six tiles (Funny, Intense, Feel-good, Dark, Romantic, Mindless) each map to a TMDB genre and immediately pick a movie on click
- Each tile shows a custom loading message via a new `data-loading` attribute on `.long-single` elements, falling back to the existing default text

## Test plan

- [x] Click each mood tile and verify it picks a movie matching the expected genre
- [x] Verify the loading overlay shows the correct custom message per tile
- [x] Verify other `.long-single` elements (nav random button, etc.) still show the default loading text
- [x] Check layout on mobile (3-col) and desktop (6-col)
- [x] Check light theme renders correctly