### PR TITLE
Add share button and OG meta tags to movie pages

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -81,6 +81,32 @@ $(document).ready(function () {
         setTimeout(() => window.removeEventListener('beforeunload', handler), 150);
     });
 
+    /* ── Share button ──────────────────────────────────────────────────── */
+    $('#share-btn').on('click', function () {
+        const $btn = $(this);
+        const url  = window.location.href;
+        const icon = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>';
+
+        function onCopied() {
+            $btn.text('Copied!');
+            setTimeout(function () { $btn.html(icon); }, 2000);
+        }
+
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(url).then(onCopied);
+        } else {
+            const ta = document.createElement('textarea');
+            ta.value = url;
+            ta.style.position = 'fixed';
+            ta.style.opacity  = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            onCopied();
+        }
+    });
+
     /* ── Accordion ─────────────────────────────────────────────────────── */
     $(document).on('click', '.accordion-header', function () {
         $(this).closest('.accordion-section').toggleClass('accordion-open');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="description" content="Random Movie Picker — find the perfect film for tonight.">
+    @yield('meta')
     <script>!function(){var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);if(m)document.documentElement.dataset.theme=m[1]}()</script>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @yield('scripts', '')

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,5 +1,26 @@
 @extends('layouts.app')
 @section('page_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
+@php
+    $ogTitle       = ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie') . ' — MoviePickr';
+    $ogDescription = $omdbInfo->Plot && $omdbInfo->Plot !== 'N/A' ? $omdbInfo->Plot : ($tmdbInfo->overview ?? 'Discover this movie on MoviePickr.');
+    $ogImage       = $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w780' . $tmdbInfo->poster_path : '';
+    $ogUrl         = url()->current();
+@endphp
+@section('meta')
+    <meta property="og:type"        content="video.movie">
+    <meta property="og:url"         content="{{ $ogUrl }}">
+    <meta property="og:title"       content="{{ $ogTitle }}">
+    <meta property="og:description" content="{{ $ogDescription }}">
+    @if($ogImage)
+    <meta property="og:image"       content="{{ $ogImage }}">
+    @endif
+    <meta name="twitter:card"        content="summary_large_image">
+    <meta name="twitter:title"       content="{{ $ogTitle }}">
+    <meta name="twitter:description" content="{{ $ogDescription }}">
+    @if($ogImage)
+    <meta name="twitter:image"       content="{{ $ogImage }}">
+    @endif
+@endsection
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
@@ -14,8 +35,16 @@
     {{-- Title row --}}
     <div class="flex items-start justify-between gap-4 mb-4 flex-wrap">
         <div>
-            <h1 class="text-3xl md:text-4xl font-bold text-white leading-tight">
+            <h1 class="text-3xl md:text-4xl font-bold text-white leading-tight flex items-center gap-3 flex-wrap">
                 {{ $tmdbInfo->title ?? $omdbInfo->Title }}
+                <button type="button" id="share-btn" title="Copy link"
+                    class="text-gray-600 hover:text-gray-300 transition-colors shrink-0"
+                    style="line-height:1">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
+                        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                    </svg>
+                </button>
             </h1>
             <p class="text-gray-500 text-sm mt-1">
                 {{ $omdbInfo->Year ?? date('Y', strtotime($tmdbInfo->release_date ?? '')) }}


### PR DESCRIPTION
## Summary

- Open Graph and Twitter meta tags on every movie detail page (title, description, poster image) — sharing a link in iMessage, Slack, or Discord will show a rich preview card
- Share button (copy-link) placed inline with the movie title, styled as a subtle icon so it can't be misclicked while going for the main action buttons
- Clipboard API with `execCommand` fallback for HTTP/localhost contexts

## Test plan

- [x] Share a movie URL from the deployed prod site and verify the rich preview appears in iMessage / Slack
- [x] Click the share icon — URL copies to clipboard and icon briefly shows "Copied!"
- [x] Verify "Pick Another" and "Adjust Criteria" buttons are unaffected