### PR TITLE
Fix bottom spacing and criteria modal button order

### DIFF
--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,10 +1,11 @@
 @extends('layouts.app')
 @section('page_title', $title ?? 'Batch — MoviePickr')
+@section('footer_pb', 'pb-20')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-36">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-36 sm:pb-20">
 
     @if(isset($providersArray) && isset($all_genres))
         @include('includes.criteria-modal')

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -1,10 +1,11 @@
 @extends('layouts.app')
 @section('page_title', 'Criteria — MoviePickr')
+@section('footer_pb', 'pb-20 sm:pb-6')
 @section('scripts')
     @vite(['resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-2xl mx-auto px-4 py-10 pb-24 sm:pb-10">
+<div class="max-w-2xl mx-auto px-4 py-10 pb-24 sm:pb-4">
 
     <div class="mb-8">
         <h1 class="text-3xl font-bold text-white">Movie Criteria</h1>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -175,7 +175,7 @@
     </section>
 
     {{-- Contact --}}
-    <section class="max-w-2xl mx-auto px-4 py-16">
+    <section class="max-w-2xl mx-auto px-4 pt-16 pb-8">
         <div class="section-header text-center">
             <h2 class="text-2xl font-bold text-white mb-3">Contact</h2>
             <div class="section-divider mb-8"></div>

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -156,8 +156,8 @@
                 {{-- Actions --}}
                 <div class="flex gap-2 pt-4 border-t border-white/5">
                     <button type="button" id="modal-btn-reset" class="btn-secondary flex-1 text-sm">Reset</button>
-                    <button type="submit" class="btn-accent flex-1 text-sm" formaction="/movie?a=true">Find Movie</button>
                     <button type="submit" class="btn-secondary flex-1 text-sm" formaction="/multiple?a=true">Multiple</button>
+                    <button type="submit" class="btn-accent flex-1 text-sm long-single" formaction="/movie?a=true">Find Movie</button>
                 </div>
 
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -101,7 +101,7 @@
         @yield('content')
     </main>
 
-    <footer class="border-t border-white/5 mt-16 py-6 text-center text-xs text-gray-600">
+    <footer class="border-t border-white/5 mt-8 pt-6 @yield('footer_pb', 'pb-6') text-center text-xs text-gray-600">
         © Martynas Jankauskas {{ date('Y') }}
     </footer>
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,10 +1,11 @@
 @extends('layouts.app')
 @section('page_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
+@section('footer_pb', 'pb-20')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-36">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-36 sm:pb-20">
 
     @if (isset($trailer))
         @include('includes.trailer-modal')


### PR DESCRIPTION
## Summary

- Reduced footer top margin (`mt-16` → `mt-8`) to remove excessive gap above footer on all pages
- Footer bottom padding now controlled per-page via `@yield('footer_pb')` — only movie, batch, and criteria (mobile) opt into `pb-20` to clear their sticky bars; all other pages use the default `pb-6`
- Reduced homepage contact section bottom padding to avoid double-stacking with footer margin
- Reduced batch/movie desktop bottom padding (`pb-36 sm:pb-20`) — sticky bar is only ~60px tall on desktop
- Criteria page desktop padding tightened (`sm:pb-4`) — no sticky bar on desktop
- Criteria modal: swapped button order to Reset | Multiple | Find Movie so the primary action is always rightmost