### PR TITLE
Improve carousels: loop, peek effect, trackpad swipe

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -381,14 +381,14 @@ html[data-theme="light"] {
 
     /* Carousel: full-height cards on mobile */
     @media (max-width: 639px) {
-        /* Batch: fills viewport minus nav (64) + page header (~90) + sticky bar (~90) */
+        /* Batch: nav(64) + top padding(32) + header(~60) + sticky bar(~70) */
         .swiper-multiple {
-            height: calc(100dvh - 244px);
+            height: calc(100dvh - 226px);
         }
-        /* Trending / similar: generous cap so the card never spills off screen */
+        /* Trending / similar: nav(64) + section header(~80) + breathing room */
         .swiper-trending,
         .swiper-similar {
-            height: calc(100dvh - 220px);
+            height: calc(100dvh - 200px);
         }
         .swiper-multiple .swiper-slide,
         .swiper-trending .swiper-slide,

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -405,29 +405,6 @@ html[data-theme="light"] {
         }
     }
 
-    /* Swiper overrides */
-    .swiper-button-next,
-    .swiper-button-prev {
-        color: #c0393a !important;
-        background: var(--bg-overlay-btn);
-        width: 36px !important;
-        height: 36px !important;
-        border-radius: 50%;
-        border: 1px solid var(--border);
-        transition: border-color 0.2s, background 0.2s;
-    }
-    .swiper-button-next:hover,
-    .swiper-button-prev:hover {
-        background: var(--bg-overlay-hover);
-        border-color: rgba(192,57,58,0.4);
-    }
-    .swiper-button-next::after,
-    .swiper-button-prev::after {
-        font-size: 13px !important;
-        font-weight: 800;
-    }
-    .swiper-button-disabled { opacity: 0.25 !important; }
-
     /* Accordion */
     .accordion-body {
         max-height: 0;

--- a/resources/js/custom/carousel.js
+++ b/resources/js/custom/carousel.js
@@ -8,7 +8,7 @@ $(document).ready(function () {
     if ($('.swiper-trending').length) {
         new Swiper('.swiper-trending', {
             modules: [Navigation, Autoplay],
-            slidesPerView: 1,
+            slidesPerView: 1.15,
             spaceBetween: 12,
             loop: true,
             autoplay: { delay: 7000, disableOnInteraction: false, pauseOnMouseEnter: true },
@@ -26,7 +26,7 @@ $(document).ready(function () {
     if ($('.swiper-similar').length) {
         new Swiper('.swiper-similar', {
             modules: [Navigation, Autoplay],
-            slidesPerView: 1,
+            slidesPerView: 1.15,
             spaceBetween: 12,
             loop: true,
             autoplay: { delay: 7000, disableOnInteraction: false, pauseOnMouseEnter: true },
@@ -44,10 +44,9 @@ $(document).ready(function () {
     if ($('.swiper-multiple').length) {
         new Swiper('.swiper-multiple', {
             modules: [Navigation],
-            slidesPerView: 1,
+            slidesPerView: 1.15,
             spaceBetween: 12,
-            loop: false,
-            autoHeight: false,
+            loop: true,
             navigation: {
                 prevEl: '.swiper-multiple .swiper-button-prev',
                 nextEl: '.swiper-multiple .swiper-button-next',

--- a/resources/js/custom/carousel.js
+++ b/resources/js/custom/carousel.js
@@ -1,60 +1,37 @@
 import Swiper from 'swiper';
-import { Navigation, Autoplay } from 'swiper/modules';
+import { Autoplay, Mousewheel } from 'swiper/modules';
 
 $(document).ready(function () {
 
-    const isMobile = () => window.innerWidth < 600;
+    const sharedConfig = {
+        modules: [Mousewheel],
+        slidesPerView: 1.15,
+        spaceBetween: 12,
+        loop: true,
+        mousewheel: { forceToAxis: true },
+        breakpoints: {
+            600:  { slidesPerView: 2, spaceBetween: 12 },
+            1024: { slidesPerView: 4, spaceBetween: 16 },
+        },
+    };
 
     if ($('.swiper-trending').length) {
         new Swiper('.swiper-trending', {
-            modules: [Navigation, Autoplay],
-            slidesPerView: 1.15,
-            spaceBetween: 12,
-            loop: true,
+            ...sharedConfig,
+            modules: [Autoplay, Mousewheel],
             autoplay: { delay: 7000, disableOnInteraction: false, pauseOnMouseEnter: true },
-            navigation: {
-                prevEl: '.swiper-trending .swiper-button-prev',
-                nextEl: '.swiper-trending .swiper-button-next',
-            },
-            breakpoints: {
-                600:  { slidesPerView: 2, spaceBetween: 12 },
-                1024: { slidesPerView: 4, spaceBetween: 16 },
-            },
         });
     }
 
     if ($('.swiper-similar').length) {
         new Swiper('.swiper-similar', {
-            modules: [Navigation, Autoplay],
-            slidesPerView: 1.15,
-            spaceBetween: 12,
-            loop: true,
+            ...sharedConfig,
+            modules: [Autoplay, Mousewheel],
             autoplay: { delay: 7000, disableOnInteraction: false, pauseOnMouseEnter: true },
-            navigation: {
-                prevEl: '.swiper-similar .swiper-button-prev',
-                nextEl: '.swiper-similar .swiper-button-next',
-            },
-            breakpoints: {
-                600:  { slidesPerView: 2, spaceBetween: 12 },
-                1024: { slidesPerView: 4, spaceBetween: 16 },
-            },
         });
     }
 
     if ($('.swiper-multiple').length) {
-        new Swiper('.swiper-multiple', {
-            modules: [Navigation],
-            slidesPerView: 1.15,
-            spaceBetween: 12,
-            loop: true,
-            navigation: {
-                prevEl: '.swiper-multiple .swiper-button-prev',
-                nextEl: '.swiper-multiple .swiper-button-next',
-            },
-            breakpoints: {
-                600:  { slidesPerView: 2, spaceBetween: 12 },
-                1024: { slidesPerView: 4, spaceBetween: 16 },
-            },
-        });
+        new Swiper('.swiper-multiple', sharedConfig);
     }
 });

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -38,6 +38,4 @@
             @endif
         @endforeach
     </div>
-    <div class="swiper-button-prev"></div>
-    <div class="swiper-button-next"></div>
 </div>


### PR DESCRIPTION
## Summary
- Enable loop and peek effect on all carousels (1.15 slides visible on mobile so next card is partially visible)
- Recalculate mobile carousel heights so cards fit within the viewport without being cut off
- Replace nav buttons with mousewheel/trackpad swipe — `forceToAxis: true` so horizontal swipes navigate the carousel without hijacking vertical page scroll; works with Magic Mouse too

## Test plan
- [x] Mobile: cards fit fully on screen, swipe between them
- [x] Mobile: no nav buttons visible
- [x] Desktop: trackpad horizontal swipe navigates carousel
- [x] Desktop: vertical scroll still scrolls the page (not the carousel)
- [x] Magic Mouse horizontal swipe navigates carousel
- [x] Loop works — swiping past the last card wraps to first