### PR TITLE
Roulettes v2: DB-backed collections with poster auto-fetch

### DIFF
--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -2,50 +2,114 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Roulette;
 use App\Services\TmdbClient;
 use App\Services\MovieService;
+use App\Services\RouletteTagMapper;
 use Illuminate\View\View;
 
 class RouletteController extends Controller
 {
-    private const ROULETTES = [
-        'horror' => [
-            'criteria' => ['with_genres' => [27], 'with_watch_providers' => [8]],
-            'tag'      => 'Netflix Horror Movies',
-            'title'    => 'Netflix Horror — MoviePickr',
-        ],
-        'doc' => [
-            'criteria' => ['with_genres' => [99], 'with_watch_providers' => [8]],
-            'tag'      => 'Netflix Documentaries',
-            'title'    => 'Netflix Documentaries — MoviePickr',
-        ],
-        'animovies' => [
-            'criteria' => ['with_genres' => [16], 'with_watch_providers' => [8], 'with_original_language' => 'ja'],
-            'tag'      => 'Netflix Anime Movies',
-            'title'    => 'Netflix Anime Movies — MoviePickr',
-        ],
-    ];
-
-    public function index(): View
+    public function index(TmdbClient $tmdb): View
     {
-        return view('roulettes');
+        $roulettes = Roulette::where('is_public', true)
+            ->orderBy('is_system', 'desc')
+            ->orderBy('id')
+            ->get();
+
+        // Fetch and persist poster paths for any roulette that doesn't have them yet.
+        // Runs once per roulette ever; subsequent loads read from DB.
+        $mapper = new RouletteTagMapper();
+        foreach ($roulettes->whereNull('poster_paths') as $roulette) {
+            try {
+                // Strip platform for poster fetch — provider IDs vary by region.
+                // Genre/era/language tags are enough to get representative images.
+                $tagsForPosters = array_diff_key($roulette->tags, ['platform' => true]);
+                $criteria         = $mapper->toCriteria($tagsForPosters);
+                $criteria['page'] = 1;
+                $results          = $tmdb->discover($criteria, 'US');
+                $paths            = [];
+                foreach ($results['results'] ?? [] as $movie) {
+                    if (!empty($movie['poster_path'])) {
+                        $paths[] = $movie['poster_path'];
+                        break;
+                    }
+                }
+                $roulette->update(['poster_paths' => $paths ?: null]);
+            } catch (\Throwable) {
+                // leave null, will retry next request
+            }
+        }
+
+        $platformLabels = [
+            'netflix' => 'Netflix',
+            'prime'   => 'Prime Video',
+            'hbo'     => 'HBO',
+            'disney'  => 'Disney+',
+            'apple'   => 'Apple TV+',
+        ];
+
+        $grouped = $roulettes->groupBy(function (Roulette $r) use ($platformLabels) {
+            $tags = $r->tags;
+            if (!empty($tags['platform'])) {
+                return $platformLabels[$tags['platform'][0]] ?? 'Other';
+            }
+            if (!empty($tags['era'])) return 'By Decade';
+            // Anime: animation genre + Japanese language (without platform)
+            if (!empty($tags['language']) && in_array('ja', (array) $tags['language'])
+                && !empty($tags['genre']) && in_array('animation', (array) $tags['genre'])) {
+                return 'Anime';
+            }
+            if (!empty($tags['language'])) return 'World Cinema';
+            return 'By Genre';
+        });
+
+        $groupOrder = ['By Decade', ...array_values($platformLabels), 'World Cinema', 'Anime', 'By Genre'];
+        $grouped    = collect($groupOrder)
+            ->filter(fn($g) => $grouped->has($g))
+            ->mapWithKeys(fn($g) => [$g => $grouped[$g]]);
+
+        $sortKeys = [
+            'By Decade'    => ['new-releases','2020s-picks','2010s-picks','2000s-gems','90s-nostalgia','80s-classics','70s-picks','60s-picks','50s-picks','classic-hollywood'],
+            'Netflix'      => ['netflix-drama','netflix-comedy','netflix-thriller','netflix-action','netflix-romance','netflix-horror','netflix-scifi','netflix-docs','netflix-crime','netflix-mystery','netflix-fantasy','netflix-animation','netflix-adventure','netflix-family','netflix-history','netflix-war','netflix-western','netflix-anime'],
+            'Prime Video'  => ['prime-action','prime-drama','prime-thrillers','prime-comedy','prime-horror','prime-scifi','prime-adventure','prime-romance','prime-documentary','prime-crime','prime-mystery','prime-fantasy','prime-family','prime-history','prime-animation','prime-war','prime-western'],
+            'HBO'          => ['hbo-drama','hbo-thriller','hbo-crime','hbo-comedy','hbo-action','hbo-horror','hbo-scifi','hbo-romance','hbo-documentary','hbo-mystery','hbo-adventure','hbo-fantasy','hbo-history','hbo-family','hbo-war','hbo-animation','hbo-western'],
+            'Disney+'      => ['disney-family','disney-action','disney-adventure','disney-animation','disney-fantasy','disney-comedy','disney-scifi','disney-drama','disney-romance','disney-mystery','disney-history','disney-documentary','disney-thriller','disney-crime','disney-war','disney-horror','disney-western'],
+            'Apple TV+'    => ['apple-originals','apple-drama','apple-thriller','apple-scifi','apple-action','apple-comedy','apple-romance','apple-mystery','apple-documentary','apple-adventure','apple-crime','apple-fantasy','apple-history','apple-family','apple-animation','apple-war','apple-horror','apple-western'],
+            'World Cinema' => ['korean-cinema','japanese-cinema','french-cinema','spanish-cinema','italian-cinema','chinese-cinema','bollywood','german-cinema','turkish-cinema','portuguese-cinema','lithuanian-cinema'],
+            'Anime'        => ['anime','anime-action','anime-fantasy','anime-adventure','anime-drama','anime-scifi','anime-comedy','anime-romance','anime-horror','anime-thriller','anime-mystery','anime-crime','anime-family','anime-history','anime-war','anime-western','anime-documentary'],
+            'By Genre'     => ['genre-action','genre-drama','genre-comedy','genre-thriller','genre-horror','genre-scifi','feel-good-romance','crime-heist','genre-mystery','genre-adventure','genre-animation','genre-documentary','genre-fantasy','genre-family','genre-history','genre-war','genre-western'],
+        ];
+
+        $grouped = $grouped->map(function ($items, $groupName) use ($sortKeys) {
+            if (!isset($sortKeys[$groupName])) {
+                return $items;
+            }
+            $order = array_flip($sortKeys[$groupName]);
+            return $items->sortBy(fn($r) => $order[$r->slug] ?? 999)->values();
+        });
+
+        return view('roulettes', compact('grouped'));
     }
 
-    public function pick(string $type, MovieService $movieService, TmdbClient $tmdb): View
+    public function pick(string $slug, MovieService $movieService, TmdbClient $tmdb): View
     {
-        $config  = self::ROULETTES[$type] ?? abort(404);
-        $country = $movieService->getUserCountry();
+        $roulette = Roulette::where('slug', $slug)->where('is_public', true)->firstOrFail();
 
-        $criteria            = $movieService->resolveRoulettePage($tmdb, $config['criteria'], $type, $country);
-        $movies              = $tmdb->discover($criteria, $country);
-        $movies['results']   = $movieService->pickBatch($movies['results']);
-        $all_genres          = $movieService->genres($tmdb);
+        $mapper   = new RouletteTagMapper();
+        $base     = $mapper->toCriteria($roulette->tags);
+        $country  = $movieService->getUserCountry();
+
+        $criteria          = $movieService->resolveRoulettePage($tmdb, $base, $slug, $country);
+        $movies            = $tmdb->discover($criteria, $country);
+        $movies['results'] = $movieService->pickBatch($movies['results']);
+        $all_genres        = $movieService->genres($tmdb);
 
         return view('batch', [
             'movies'       => $movies,
             'movie_genres' => $movieService->movieGenresMap($movies['results'], $all_genres),
-            'tag'          => $config['tag'],
-            'title'        => $config['title'],
+            'tag'          => $roulette->name,
+            'title'        => $roulette->name . ' — MoviePickr',
         ]);
     }
 }

--- a/app/Models/Roulette.php
+++ b/app/Models/Roulette.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Roulette extends Model
+{
+    protected $fillable = [
+        'name', 'slug', 'description', 'tags', 'tag_fingerprint',
+        'featured_movie_ids', 'poster_paths', 'is_system', 'user_id', 'is_public',
+    ];
+
+    protected $casts = [
+        'tags'               => 'array',
+        'featured_movie_ids' => 'array',
+        'poster_paths'       => 'array',
+        'is_system'          => 'boolean',
+        'is_public'          => 'boolean',
+    ];
+
+    public static function fingerprintFromTags(array $tags): string
+    {
+        $pairs = [];
+        foreach ($tags as $type => $values) {
+            foreach ((array) $values as $value) {
+                $pairs[] = $type . ':' . $value;
+            }
+        }
+        sort($pairs);
+        return implode('|', $pairs);
+    }
+}

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services;
+
+class RouletteTagMapper
+{
+    private const PLATFORM_IDS = [
+        'netflix' => 8,
+        'prime'   => 119,
+        'hbo'     => 1899,
+        'disney'  => 337,
+        'apple'   => 350,
+    ];
+
+    private const GENRE_IDS = [
+        'action'      => 28,
+        'adventure'   => 12,
+        'animation'   => 16,
+        'comedy'      => 35,
+        'crime'       => 80,
+        'documentary' => 99,
+        'drama'       => 18,
+        'family'      => 10751,
+        'fantasy'     => 14,
+        'history'     => 36,
+        'horror'      => 27,
+        'mystery'     => 9648,
+        'romance'     => 10749,
+        'sci-fi'      => 878,
+        'thriller'    => 53,
+        'war'         => 10752,
+        'western'     => 37,
+    ];
+
+    private const ERA_RANGES = [
+        'pre-1950' => ['lte' => 1949],
+        '1950s'    => ['gte' => 1950, 'lte' => 1959],
+        '1960s'    => ['gte' => 1960, 'lte' => 1969],
+        '1970s'    => ['gte' => 1970, 'lte' => 1979],
+        '1980s'    => ['gte' => 1980, 'lte' => 1989],
+        '1990s'    => ['gte' => 1990, 'lte' => 1999],
+        '2000s'    => ['gte' => 2000, 'lte' => 2009],
+        '2010s'    => ['gte' => 2010, 'lte' => 2019],
+        '2020s'    => ['gte' => 2020],
+    ];
+
+    public function toCriteria(array $tags): array
+    {
+        $criteria = [];
+
+        if (!empty($tags['platform'])) {
+            $ids = array_values(array_filter(
+                array_map(fn($p) => self::PLATFORM_IDS[$p] ?? null, (array) $tags['platform'])
+            ));
+            if ($ids) {
+                $criteria['with_watch_providers'] = $ids;
+            }
+        }
+
+        if (!empty($tags['genre'])) {
+            $ids = array_values(array_filter(
+                array_map(fn($g) => self::GENRE_IDS[$g] ?? null, (array) $tags['genre'])
+            ));
+            if ($ids) {
+                $criteria['with_genres'] = $ids;
+            }
+        }
+
+        if (!empty($tags['language'])) {
+            $criteria['with_original_language'] = $tags['language'][0];
+        }
+
+        if (!empty($tags['era'])) {
+            $era   = (array) $tags['era'];
+            $range = $era[0] === 'recent'
+                ? ['gte' => (int) date('Y') - 2]
+                : (self::ERA_RANGES[$era[0]] ?? null);
+
+            if ($range) {
+                if (isset($range['gte'])) {
+                    $criteria['primary_release_date.gte'] = $range['gte'];
+                }
+                if (isset($range['lte'])) {
+                    $criteria['primary_release_date.lte'] = $range['lte'];
+                }
+            }
+        }
+
+        return $criteria;
+    }
+}

--- a/database/migrations/2026_05_19_131125_create_roulettes_table.php
+++ b/database/migrations/2026_05_19_131125_create_roulettes_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roulettes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->json('tags');
+            $table->string('tag_fingerprint')->unique();
+            $table->json('featured_movie_ids')->nullable();
+            $table->boolean('is_system')->default(true);
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->boolean('is_public')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roulettes');
+    }
+};

--- a/database/migrations/2026_05_19_134514_add_poster_paths_to_roulettes_table.php
+++ b/database/migrations/2026_05_19_134514_add_poster_paths_to_roulettes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('roulettes', function (Blueprint $table) {
+            $table->json('poster_paths')->nullable()->after('featured_movie_ids');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('roulettes', function (Blueprint $table) {
+            $table->dropColumn('poster_paths');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,6 +8,6 @@ class DatabaseSeeder extends Seeder
 {
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(RouletteSeeder::class);
     }
 }

--- a/database/seeders/RouletteSeeder.php
+++ b/database/seeders/RouletteSeeder.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Roulette;
+use Illuminate\Database\Seeder;
+
+class RouletteSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $genreLabel = [
+            'action'      => 'Action',      'adventure'   => 'Adventure',
+            'animation'   => 'Animation',   'comedy'      => 'Comedy',
+            'crime'       => 'Crime',       'documentary' => 'Documentary',
+            'drama'       => 'Drama',       'family'      => 'Family',
+            'fantasy'     => 'Fantasy',     'history'     => 'History',
+            'horror'      => 'Horror',      'mystery'     => 'Mystery',
+            'romance'     => 'Romance',     'sci-fi'      => 'Sci-Fi',
+            'thriller'    => 'Thriller',    'war'         => 'War',
+            'western'     => 'Western',
+        ];
+
+        $genreDesc = [
+            'action'      => 'High-octane stunts, chases, and heroes saving the day.',
+            'adventure'   => 'Epic journeys, daring quests, and bigger-than-life heroes.',
+            'animation'   => 'Animated films for all ages — heartwarming, hilarious, and breathtaking.',
+            'comedy'      => 'Guaranteed laughs — from dry wit to full-blown absurdity.',
+            'crime'       => 'Heists, detectives, gangsters, and criminal masterminds.',
+            'documentary' => 'Real stories that inform, inspire, and sometimes shock.',
+            'drama'       => 'Powerful stories and complex human experiences.',
+            'family'      => 'Wholesome fun and heartfelt stories for all ages.',
+            'fantasy'     => 'Dragons, magic, prophecies, and otherworldly adventures.',
+            'history'     => 'Dramatic stories drawn from the pages of history.',
+            'horror'      => 'Spine-chilling scares, supernatural dread, and psychological horror.',
+            'mystery'     => 'Whodunits, hidden clues, and satisfying reveals.',
+            'romance'     => 'Love stories to warm your heart — or make it ache.',
+            'sci-fi'      => 'Futuristic worlds, space exploration, and the limits of imagination.',
+            'thriller'    => 'Edge-of-your-seat tension, twists, and pulse-pounding suspense.',
+            'war'         => 'Stories of conflict, heroism, sacrifice, and the human cost of war.',
+            'western'     => 'Gunslingers, outlaws, lawmen, and the wide-open frontier.',
+        ];
+
+        $slugGenre = fn(string $g) => str_replace('sci-fi', 'scifi', $g);
+
+        // Genres per platform in popularity order for that platform
+        $platforms = [
+            'netflix' => [
+                'label'  => 'Netflix',
+                'genres' => ['drama', 'comedy', 'thriller', 'action', 'romance', 'horror', 'sci-fi', 'documentary', 'crime', 'mystery', 'fantasy', 'animation', 'adventure', 'family', 'history', 'war', 'western'],
+            ],
+            'prime' => [
+                'label'  => 'Prime Video',
+                'genres' => ['action', 'drama', 'thriller', 'comedy', 'horror', 'sci-fi', 'adventure', 'romance', 'documentary', 'crime', 'mystery', 'fantasy', 'family', 'history', 'animation', 'war', 'western'],
+            ],
+            'hbo' => [
+                'label'  => 'HBO',
+                'genres' => ['drama', 'thriller', 'crime', 'comedy', 'action', 'horror', 'sci-fi', 'romance', 'documentary', 'mystery', 'adventure', 'fantasy', 'history', 'family', 'war', 'animation', 'western'],
+            ],
+            'disney' => [
+                'label'  => 'Disney+',
+                'genres' => ['family', 'action', 'adventure', 'animation', 'fantasy', 'comedy', 'sci-fi', 'drama', 'romance', 'mystery', 'history', 'documentary', 'thriller', 'crime', 'war', 'horror', 'western'],
+            ],
+            'apple' => [
+                'label'  => 'Apple TV+',
+                'genres' => ['drama', 'thriller', 'sci-fi', 'action', 'comedy', 'romance', 'mystery', 'documentary', 'adventure', 'crime', 'fantasy', 'history', 'family', 'animation', 'war', 'horror', 'western'],
+            ],
+        ];
+
+        // Generated slug → existing DB slug (preserves bookmarkable URLs)
+        $slugOverrides = [
+            'netflix-documentary' => 'netflix-docs',
+            'prime-thriller'      => 'prime-thrillers',
+        ];
+
+        // Custom names for entries with existing branding
+        $customNames = [
+            'netflix-horror'  => 'Netflix Horror',
+            'netflix-docs'    => 'Netflix Documentaries',
+            'netflix-scifi'   => 'Netflix Sci-Fi',
+            'prime-thrillers' => 'Prime Thrillers',
+            'prime-comedy'    => 'Prime Comedy',
+            'hbo-drama'       => 'HBO Drama',
+            'disney-family'   => 'Disney+ Family',
+        ];
+
+        // Custom descriptions for entries with existing copy
+        $customDescs = [
+            'netflix-horror'  => 'Supernatural encounters, psychological thrillers, and international scares from Netflix\'s horror selection.',
+            'netflix-docs'    => 'True crime, environmental issues, social justice, and historical events — told with compelling narratives.',
+            'netflix-scifi'   => 'Space exploration, dystopian futures, and mind-bending concepts from Netflix\'s science fiction catalogue.',
+            'prime-thrillers' => 'Edge-of-your-seat suspense, gut-punch twists, and slow-burn tension from Prime Video.',
+            'prime-comedy'    => 'Laughs guaranteed — rom-coms, absurdist gems, and crowd-pleasers from Prime Video.',
+            'hbo-drama'       => 'Prestige storytelling, complex characters, and Emmy-worthy performances from HBO.',
+            'disney-family'   => 'Animated classics, live-action adventures, and fun for all ages from Disney+.',
+        ];
+
+        $roulettes = [];
+
+        // ── Era: newest to oldest ─────────────────────────────────────────────
+        $roulettes[] = ['name' => 'New Releases',     'slug' => 'new-releases',     'description' => 'Hot off the press — films from the last two years.',                                           'tags' => ['era' => ['recent']]];
+        $roulettes[] = ['name' => 'The 2020s',        'slug' => '2020s-picks',      'description' => 'Contemporary cinema — from pandemic-era stories to today\'s global hits.',                    'tags' => ['era' => ['2020s']]];
+        $roulettes[] = ['name' => 'The 2010s',        'slug' => '2010s-picks',      'description' => 'A defining decade of superhero epics, streaming originals, and award-winning indie hits.',    'tags' => ['era' => ['2010s']]];
+        $roulettes[] = ['name' => 'The 2000s',        'slug' => '2000s-gems',       'description' => 'Overlooked and beloved films from the early 2000s you might have missed.',                   'tags' => ['era' => ['2000s']]];
+        $roulettes[] = ['name' => 'The Nineties',     'slug' => '90s-nostalgia',    'description' => 'Blockbusters and indie gems from cinema\'s golden decade — grunge, CGI breakthroughs, and classics.', 'tags' => ['era' => ['1990s']]];
+        $roulettes[] = ['name' => 'The Eighties',     'slug' => '80s-classics',     'description' => 'Iconic films that defined a decade — blockbuster action, cult horror, and coming-of-age gems.', 'tags' => ['era' => ['1980s']]];
+        $roulettes[] = ['name' => 'The Seventies',    'slug' => '70s-picks',        'description' => 'Raw, gritty, and groundbreaking — the golden age of New Hollywood.',                         'tags' => ['era' => ['1970s']]];
+        $roulettes[] = ['name' => 'The Sixties',      'slug' => '60s-picks',        'description' => 'Revolution on and off screen — the bold, rule-breaking cinema of the 1960s.',                'tags' => ['era' => ['1960s']]];
+        $roulettes[] = ['name' => 'The Fifties',      'slug' => '50s-picks',        'description' => 'Post-war optimism, sci-fi paranoia, and enduring beauty — cinema of the 1950s.',              'tags' => ['era' => ['1950s']]];
+        $roulettes[] = ['name' => 'Classic Hollywood','slug' => 'classic-hollywood','description' => 'Golden age masterpieces — timeless cinema from the earliest era of film.',                    'tags' => ['era' => ['pre-1950']]];
+
+        // ── Platform × Genre (all 17 genres each) ────────────────────────────
+        foreach ($platforms as $platformKey => $config) {
+            foreach ($config['genres'] as $genre) {
+                $generatedSlug = $platformKey . '-' . $slugGenre($genre);
+                $slug = $slugOverrides[$generatedSlug] ?? $generatedSlug;
+                $roulettes[] = [
+                    'name'        => $customNames[$slug]  ?? ($config['label'] . ' ' . $genreLabel[$genre]),
+                    'slug'        => $slug,
+                    'description' => $customDescs[$slug]  ?? $genreDesc[$genre],
+                    'tags'        => ['platform' => [$platformKey], 'genre' => [$genre]],
+                ];
+            }
+        }
+
+        // ── Special platform entries (unique tag combinations) ────────────────
+        $roulettes[] = [
+            'name'        => 'Netflix Anime Movies',
+            'slug'        => 'netflix-anime',
+            'description' => 'Action, fantasy, romance, sci-fi — a rich selection of anime films spanning classics and Netflix originals.',
+            'tags'        => ['platform' => ['netflix'], 'genre' => ['animation'], 'language' => ['ja']],
+        ];
+        $roulettes[] = [
+            'name'        => 'Apple TV+ Originals',
+            'slug'        => 'apple-originals',
+            'description' => 'Award-winning originals from Apple\'s growing library — from intimate dramas to epic sci-fi.',
+            'tags'        => ['platform' => ['apple']],
+        ];
+
+        // ── World Cinema ──────────────────────────────────────────────────────
+        $worldCinema = [
+            ['name' => 'Korean Cinema',      'slug' => 'korean-cinema',      'lang' => 'ko', 'desc' => 'From revenge thrillers to romantic dramas — the best of Korean film, new wave and beyond.'],
+            ['name' => 'Japanese Cinema',    'slug' => 'japanese-cinema',    'lang' => 'ja', 'desc' => 'Art house gems, animated masterpieces, and genre-defining classics from Japan.'],
+            ['name' => 'French Cinema',      'slug' => 'french-cinema',      'lang' => 'fr', 'desc' => 'Romance, philosophy, and cinematic flair — from the French New Wave to modern auteurs.'],
+            ['name' => 'Spanish Cinema',     'slug' => 'spanish-cinema',     'lang' => 'es', 'desc' => 'Passion, intensity, and dark humour — the best of Spanish-language film.'],
+            ['name' => 'Italian Cinema',     'slug' => 'italian-cinema',     'lang' => 'it', 'desc' => 'From neorealism to Fellini and beyond — the enduring richness of Italian film.'],
+            ['name' => 'Chinese Cinema',     'slug' => 'chinese-cinema',     'lang' => 'zh', 'desc' => 'Epic historical dramas, martial arts, and contemporary art house from China.'],
+            ['name' => 'Bollywood',          'slug' => 'bollywood',          'lang' => 'hi', 'desc' => 'Colour, music, drama, and spectacle — the infectious energy of Hindi cinema.'],
+            ['name' => 'German Cinema',      'slug' => 'german-cinema',      'lang' => 'de', 'desc' => 'From Expressionism to New German Cinema — powerful and distinctive storytelling.'],
+            ['name' => 'Turkish Cinema',     'slug' => 'turkish-cinema',     'lang' => 'tr', 'desc' => 'A rising force in world cinema — gripping dramas and genre films from Turkey.'],
+            ['name' => 'Portuguese Cinema',  'slug' => 'portuguese-cinema',  'lang' => 'pt', 'desc' => 'Brazilian and Portuguese film — from vibrant dramas to quiet, moving art house.'],
+            ['name' => 'Lithuanian Cinema',  'slug' => 'lithuanian-cinema',  'lang' => 'lt', 'desc' => 'Intimate dramas, dark comedies, and quietly powerful stories from Lithuania.'],
+        ];
+        foreach ($worldCinema as $entry) {
+            $roulettes[] = [
+                'name'        => $entry['name'],
+                'slug'        => $entry['slug'],
+                'description' => $entry['desc'],
+                'tags'        => ['language' => [$entry['lang']]],
+            ];
+        }
+
+        // ── Anime (animation + Japanese language, sorted by popularity) ──────
+        $animeGenres = ['action', 'fantasy', 'adventure', 'drama', 'sci-fi', 'comedy', 'romance', 'horror', 'thriller', 'mystery', 'crime', 'family', 'history', 'war', 'western', 'documentary'];
+        $animeDescs  = [
+            'action'      => 'High-energy battles, epic heroes, and relentless action — the best anime action films.',
+            'fantasy'     => 'Dragons, magic, and otherworldly adventures — anime fantasy at its finest.',
+            'adventure'   => 'Epic quests, unforgettable journeys, and daring heroes in animated form.',
+            'drama'       => 'Emotionally powerful stories and complex characters — anime drama that stays with you.',
+            'sci-fi'      => 'Mechs, dystopias, and mind-bending futures — anime science fiction.',
+            'comedy'      => 'Hilarious, absurd, and heartwarming — the funniest anime films.',
+            'romance'     => 'Tender love stories and bittersweet emotions — anime romance.',
+            'horror'      => 'Supernatural dread, psychological scares, and dark atmospheres — anime horror.',
+            'thriller'    => 'Suspense, twists, and pulse-pounding tension — anime thrillers.',
+            'mystery'     => 'Hidden truths, clever detectives, and satisfying reveals — anime mystery.',
+            'crime'       => 'Heists, gang wars, and criminal underworlds — anime crime films.',
+            'family'      => 'Heartwarming stories for all ages — classic and modern anime family films.',
+            'history'     => 'Samurai, feudal Japan, and historical epics — anime history.',
+            'war'         => 'Conflict, sacrifice, and the human cost of battle — anime war films.',
+            'western'     => 'Gunslingers and outlaws reimagined through anime — a rare and striking genre.',
+            'documentary' => 'Behind-the-scenes, nature, and real-world stories told through animation.',
+        ];
+
+        // General anime entry (all animation, Japanese language)
+        $roulettes[] = [
+            'name'        => 'Anime Films',
+            'slug'        => 'anime',
+            'description' => 'The best of Japanese animation — from Studio Ghibli classics to modern hits across every genre.',
+            'tags'        => ['genre' => ['animation'], 'language' => ['ja']],
+        ];
+
+        foreach ($animeGenres as $genre) {
+            $roulettes[] = [
+                'name'        => 'Anime ' . $genreLabel[$genre],
+                'slug'        => 'anime-' . $slugGenre($genre),
+                'description' => $animeDescs[$genre],
+                'tags'        => ['genre' => ['animation', $genre], 'language' => ['ja']],
+            ];
+        }
+
+        // ── Standalone Genres ─────────────────────────────────────────────────
+        $standaloneGenres = ['action', 'adventure', 'animation', 'comedy', 'crime', 'documentary', 'drama', 'family', 'fantasy', 'history', 'horror', 'mystery', 'romance', 'sci-fi', 'thriller', 'war', 'western'];
+        $standaloneNames  = ['crime' => 'Crime & Heist', 'romance' => 'Feel-Good Romance'];
+        $standaloneSlugs  = ['crime' => 'crime-heist',   'romance' => 'feel-good-romance'];
+        foreach ($standaloneGenres as $genre) {
+            $roulettes[] = [
+                'name'        => $standaloneNames[$genre] ?? $genreLabel[$genre] . ' Films',
+                'slug'        => $standaloneSlugs[$genre] ?? 'genre-' . $slugGenre($genre),
+                'description' => $genreDesc[$genre],
+                'tags'        => ['genre' => [$genre]],
+            ];
+        }
+
+        // ── Persist ───────────────────────────────────────────────────────────
+        foreach ($roulettes as $data) {
+            $data['tag_fingerprint'] = Roulette::fingerprintFromTags($data['tags']);
+            $data['is_system']       = true;
+            $data['is_public']       = true;
+
+            Roulette::updateOrCreate(['slug' => $data['slug']], $data);
+        }
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -138,6 +138,12 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
 
+    .roulette-row {
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+    .roulette-row::-webkit-scrollbar { display: none; }
+
     /* Mood shortcut tile */
     .mood-tile {
         display: flex;

--- a/resources/views/roulettes.blade.php
+++ b/resources/views/roulettes.blade.php
@@ -8,67 +8,90 @@
             <h1 class="text-3xl font-bold text-white">Movie Roulettes</h1>
             <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20">Beta</span>
         </div>
-        <p class="text-gray-500 text-sm mt-1">Curated collections — just hit Roll. More coming soon.</p>
+        <p class="text-gray-500 text-sm mt-1">Curated collections — just hit Roll.</p>
         <div class="section-divider mt-3"></div>
     </div>
 
-    <div class="grid md:grid-cols-3 gap-4 md:gap-5">
+    @php
+        $platformLogos = [
+            'netflix' => 'https://image.tmdb.org/t/p/w92/pbpMk2JmcoNnQwx5JGpXngfoWtp.jpg',
+            'prime'   => 'https://image.tmdb.org/t/p/w92/pvske1MyAoymrs5bguRfVqYiM9a.jpg',
+            'hbo'     => 'https://image.tmdb.org/t/p/w92/jbe4gVSfRlbPTdESXhEKpornsfu.jpg',
+            'disney'  => 'https://image.tmdb.org/t/p/w92/97yvRBw1GzX7fXprcF80er19ot.jpg',
+            'apple'   => 'https://image.tmdb.org/t/p/w92/mcbz1LgtErU9p4UdbZ0rG6RTWHX.jpg',
+        ];
+        $tagLabels = [
+            'netflix' => 'Netflix', 'prime' => 'Prime', 'hbo' => 'HBO', 'disney' => 'Disney+', 'apple' => 'Apple TV+',
+            'action' => 'Action', 'adventure' => 'Adventure', 'animation' => 'Animation', 'comedy' => 'Comedy',
+            'crime' => 'Crime', 'documentary' => 'Documentary', 'drama' => 'Drama', 'family' => 'Family',
+            'fantasy' => 'Fantasy', 'history' => 'History', 'horror' => 'Horror', 'mystery' => 'Mystery',
+            'romance' => 'Romance', 'sci-fi' => 'Sci-Fi', 'thriller' => 'Thriller', 'war' => 'War', 'western' => 'Western',
+            'pre-1950' => 'Classic', '1950s' => '50s', '1960s' => '60s', '1970s' => '70s',
+            '1980s' => '80s', '1990s' => '90s', '2000s' => '2000s', '2010s' => '2010s', '2020s' => '2020s', 'recent' => 'Recent',
+            'ko' => 'Korean', 'ja' => 'Japanese', 'fr' => 'French', 'es' => 'Spanish',
+            'de' => 'German', 'it' => 'Italian', 'zh' => 'Chinese', 'hi' => 'Hindi',
+            'tr' => 'Turkish', 'pt' => 'Portuguese',
+        ];
+    @endphp
 
-        {{-- Netflix Horror --}}
-        <div class="card card-hover overflow-hidden flex flex-row md:flex-col">
-            <div class="relative w-28 flex-shrink-0 md:w-auto md:h-44 self-stretch overflow-hidden">
-                <img src="https://static1.srcdn.com/wordpress/wp-content/uploads/2019/10/the-grudge-banner.jpg?q=50&fit=crop&w=740&h=370&dpr=1.5"
-                    class="absolute inset-0 w-full h-full object-cover opacity-70"
-                    alt="Horror">
-                <div class="absolute inset-0 bg-gradient-to-r md:bg-gradient-to-t from-[#111]/90 to-transparent"></div>
-                <img src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/227_Netflix_logo-512.png"
-                    class="absolute bottom-2 right-2 h-5 md:h-8 drop-shadow-lg">
-            </div>
-            <div class="p-4 md:p-5 flex flex-col flex-1">
-                <h2 class="text-base font-semibold text-white mb-1.5 md:mb-2">Netflix Horror</h2>
-                <p class="text-sm text-gray-400 leading-relaxed flex-1">
-                    Supernatural encounters, psychological thrillers, and international scares from Netflix's horror selection.
-                </p>
-                <a href="/roulettes/netflix/horror" class="btn-accent mt-3 md:mt-4 self-start text-sm">Roll</a>
+    @foreach ($grouped as $groupName => $roulettes)
+        <div class="mb-10">
+            <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">{{ $groupName }}</h2>
+
+            <div class="flex gap-3 overflow-x-auto pb-2 roulette-row">
+                @foreach ($roulettes as $roulette)
+                    @php
+                        $tags     = $roulette->tags;
+                        $platform = $tags['platform'][0] ?? null;
+                        $logo     = $platform ? ($platformLogos[$platform] ?? null) : null;
+                        $allTags  = collect($tags)->flatten()
+                                        ->reject(fn($v) => isset($tags['platform']) && in_array($v, $tags['platform']))
+                                        ->map(fn($v) => $tagLabels[$v] ?? $v);
+                        $poster   = $roulette->poster_paths[0] ?? null;
+                    @endphp
+
+                    <a href="/roulettes/{{ $roulette->slug }}"
+                       class="group relative flex-shrink-0 w-36 md:w-44 rounded-xl overflow-hidden block bg-slate-900">
+                        <div class="aspect-[2/3] relative overflow-hidden">
+
+                            @if($poster)
+                                <img src="https://image.tmdb.org/t/p/w342{{ $poster }}"
+                                     class="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                                     loading="lazy">
+                            @else
+                                <div class="absolute inset-0 bg-gradient-to-br from-slate-700 to-slate-900"></div>
+                            @endif
+
+                            {{-- Gradient overlay --}}
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent"></div>
+
+                            {{-- Platform logo --}}
+                            @if($logo)
+                                <img src="{{ $logo }}"
+                                     class="absolute top-2 right-2 h-5 drop-shadow-lg"
+                                     loading="lazy">
+                            @endif
+
+                            {{-- Bottom content --}}
+                            <div class="absolute bottom-0 left-0 right-0 p-3">
+                                @if($allTags->isNotEmpty())
+                                    <div class="flex gap-1 mb-1.5 flex-wrap">
+                                        @foreach($allTags as $tag)
+                                            <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/10 text-gray-400 border border-white/10">{{ $tag }}</span>
+                                        @endforeach
+                                    </div>
+                                @endif
+                                <h3 class="text-sm font-semibold text-white leading-snug">{{ $roulette->name }}</h3>
+                                <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Roll →</span>
+                            </div>
+
+                        </div>
+                    </a>
+
+                @endforeach
             </div>
         </div>
+    @endforeach
 
-        {{-- Netflix Documentaries --}}
-        <div class="card card-hover overflow-hidden flex flex-row md:flex-col">
-            <div class="relative w-28 flex-shrink-0 md:w-auto md:h-44 self-stretch overflow-hidden">
-                <div class="absolute inset-0 bg-gradient-to-br from-slate-700 to-slate-900"></div>
-                <div class="absolute inset-0 bg-gradient-to-r md:bg-gradient-to-t from-[#111]/90 to-transparent"></div>
-                <img src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/227_Netflix_logo-512.png"
-                    class="absolute bottom-2 right-2 h-5 md:h-8 drop-shadow-lg">
-            </div>
-            <div class="p-4 md:p-5 flex flex-col flex-1">
-                <h2 class="text-base font-semibold text-white mb-1.5 md:mb-2">Netflix Documentaries</h2>
-                <p class="text-sm text-gray-400 leading-relaxed flex-1">
-                    True crime, environmental issues, social justice, and historical events — told with compelling narratives.
-                </p>
-                <a href="/roulettes/netflix/doc" class="btn-accent mt-3 md:mt-4 self-start text-sm">Roll</a>
-            </div>
-        </div>
-
-        {{-- Netflix Anime --}}
-        <div class="card card-hover overflow-hidden flex flex-row md:flex-col">
-            <div class="relative w-28 flex-shrink-0 md:w-auto md:h-44 self-stretch overflow-hidden">
-                <img src="https://i.pinimg.com/originals/4c/8e/26/4c8e267ee4446e733bb17564337083f7.jpg"
-                    class="absolute inset-0 w-full h-full object-cover opacity-70"
-                    alt="Anime">
-                <div class="absolute inset-0 bg-gradient-to-r md:bg-gradient-to-t from-[#111]/90 to-transparent"></div>
-                <img src="https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/227_Netflix_logo-512.png"
-                    class="absolute bottom-2 right-2 h-5 md:h-8 drop-shadow-lg">
-            </div>
-            <div class="p-4 md:p-5 flex flex-col flex-1">
-                <h2 class="text-base font-semibold text-white mb-1.5 md:mb-2">Netflix Anime Movies</h2>
-                <p class="text-sm text-gray-400 leading-relaxed flex-1">
-                    Action, fantasy, romance, sci-fi — a rich selection of anime films spanning classics and Netflix originals.
-                </p>
-                <a href="/roulettes/netflix/animovies" class="btn-accent mt-3 md:mt-4 self-start text-sm">Roll</a>
-            </div>
-        </div>
-
-    </div>
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,8 +41,13 @@ Route::match(['get', 'post'], '/movie',    [MoviePickController::class, 'single'
 Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
 Route::get('/movie/{id}', MovieController::class)->name('movie');
 
-Route::get('/roulettes',                [RouletteController::class, 'index']);
-Route::get('/roulettes/netflix/{type}', [RouletteController::class, 'pick']);
+Route::get('/roulettes',        [RouletteController::class, 'index']);
+Route::get('/roulettes/{slug}', [RouletteController::class, 'pick']);
+
+// Legacy roulette URLs → redirect to new slugs
+Route::get('/roulettes/netflix/horror',    fn() => redirect('/roulettes/netflix-horror', 301));
+Route::get('/roulettes/netflix/doc',       fn() => redirect('/roulettes/netflix-docs', 301));
+Route::get('/roulettes/netflix/animovies', fn() => redirect('/roulettes/netflix-anime', 301));
 
 // Obfuscated utility routes (cache/config clear, scheduler trigger)
 Route::get('/fdsdfsds', function () {


### PR DESCRIPTION
## Summary

- **DB-backed roulettes** — `Roulette` model with JSON `tags` (platform/genre/era/language), `tag_fingerprint` unique column for deduplication, and `poster_paths` persisted from TMDB discover on first load (fetched once, read from DB forever after)
- **142 seeded roulettes** — all 17 genres × 5 platforms sorted by each platform's genre popularity, 10 decades newest-to-oldest, 11 world cinema countries, 17 standalone genres, 17 anime (animation + Japanese language)
- **Netflix-style UI** — horizontal scroll rows per category, portrait 2:3 poster cards with gradient overlay, platform logo, tag badges, and full-card Roll link
- **Per-group sort order** defined in controller via slug arrays — no extra DB column needed
- Legacy redirect routes preserved for old `/roulettes/netflix/*` URLs

## Deployment notes

Requires running migrations and seeder on the server after deploy:
```
php artisan migrate --force
php artisan db:seed --class=RouletteSeeder
```

## Test plan

- [x] `/roulettes` loads all groups in correct order (By Decade newest-first, platforms by genre popularity)
- [x] Poster images auto-fetch on first load and persist (no re-fetch on subsequent loads)
- [x] Rolling a roulette (`/roulettes/{slug}`) returns a batch of movies
- [x] Legacy URLs (`/roulettes/netflix/horror`) redirect correctly
- [x] Anime row shows only animation + Japanese entries; World Cinema unaffected