### PR TITLE
Batch & watchlist improvements

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -25,10 +25,11 @@ class MovieController extends Controller
         $providersArray = $movieService->buildProvidersArray($tmdb);
 
         if ($request->query('i') !== null) {
-            session()->forget('userInput');
+            session()->forget(['userInput', 'batchUrl']);
         }
 
         $movieCriteria = session('userInput');
+        $batchUrl      = session('batchUrl');
         $similarMovies = null;
         $similarTitle  = 'Similar Movies';
         $linkSuffix    = '';
@@ -84,7 +85,7 @@ class MovieController extends Controller
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',
-            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray'
+            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl'
         ));
     }
 }

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -40,13 +40,20 @@ class MoviePickController extends Controller
         $all_genres         = $movieService->genres($tmdb);
         $movie_genres       = $movieService->movieGenresMap($movies['results'], $all_genres);
 
+        session(['batchUrl' => url('/multiple')]);
+
+        $savedIds = auth()->check()
+            ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
+            : [];
+
         return view('batch', [
-            'movies'        => $movies,
-            'user_input'    => session('userInput'),
-            'all_genres'    => $all_genres,
-            'movie_genres'  => $movie_genres,
+            'movies'         => $movies,
+            'user_input'     => session('userInput'),
+            'all_genres'     => $all_genres,
+            'movie_genres'   => $movie_genres,
             'providersArray' => $movieService->buildProvidersArray($tmdb),
-            'tag'           => 'Movies picked for you',
+            'tag'            => 'Movies picked for you',
+            'savedIds'       => $savedIds,
         ]);
     }
 

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -84,11 +84,19 @@ class RouletteController extends Controller
         $movies['results'] = $movieService->pickBatch($movies['results']);
         $all_genres        = $movieService->genres($tmdb);
 
+        session(['userInput' => array_merge($criteria, ['total_pages' => $movies['total_pages'] ?? 500])]);
+        session(['batchUrl'  => request()->url()]);
+
+        $savedIds = auth()->check()
+            ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
+            : [];
+
         return view('batch', [
             'movies'       => $movies,
             'movie_genres' => $movieService->movieGenresMap($movies['results'], $all_genres),
             'tag'          => $roulette->name,
             'title'        => $roulette->name . ' — MoviePickr',
+            'savedIds'     => $savedIds,
         ]);
     }
 }

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -87,6 +87,8 @@ $(document).ready(function () {
 
             $(this).toggle(statusMatch && genreMatch);
         });
+
+        $('#wl-count').text('(' + $('.watchlist-card:visible').length + ')');
     }
 
     $(document).on('click', '.watchlist-filter', function () {

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -2,7 +2,7 @@
 @section('page_title', $title ?? 'Batch — MoviePickr')
 @section('footer_pb', 'pb-20')
 @section('scripts')
-    @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
+    @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])
 @endsection
 @section('content')
 <div class="max-w-7xl mx-auto px-4 py-8 sm:pb-20 batch-wrapper">
@@ -19,7 +19,7 @@
     </div>
 
     {{-- Carousel --}}
-    @include('includes.carousel', ['allMovies' => $movies, 'name' => 'swiper-multiple', 'genres' => $movie_genres])
+    @include('includes.carousel', ['allMovies' => $movies, 'name' => 'swiper-multiple', 'genres' => $movie_genres, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds ?? []])
 
 </div>
 

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -3,37 +3,63 @@
         @foreach ($allMovies['results'] as $result)
             @if(isset($result['release_date']))
             <div class="swiper-slide h-auto">
-                <a href="{{ url('movie/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}" class="block group long-movie" data-name="{{ $result['title'] }}">
-                    <div class="card card-hover h-full flex flex-col overflow-hidden">
-                        {{-- Poster --}}
-                        <div class="carousel-poster aspect-[2/3] bg-white/[0.03] overflow-hidden">
-                            @if($result['poster_path'])
-                                <img
-                                    src="https://image.tmdb.org/t/p/w500{{ $result['poster_path'] }}"
-                                    alt="{{ $result['title'] }}"
-                                    class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                                    loading="lazy"
-                                >
-                            @else
-                                <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-3">
-                                    No poster
-                                </div>
-                            @endif
-                        </div>
-                        {{-- Info --}}
-                        <div class="p-3 flex flex-col gap-1 flex-1">
-                            <h4 class="text-sm font-medium text-white leading-snug line-clamp-2 group-hover:text-accent transition-colors duration-200">
-                                {{ $result['title'] }}
-                            </h4>
-                            <p class="text-xs text-gray-500 mt-auto">
-                                {{ date('Y', strtotime($result['release_date'])) }}
-                                @if($genres !== [] && isset($genres[$result['id']]))
-                                    · <span class="text-gray-600">{{ $genres[$result['id']] }}</span>
+                <div class="relative">
+                    <a href="{{ url('movie/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}" class="block group long-movie" data-name="{{ $result['title'] }}">
+                        <div class="card card-hover h-full flex flex-col overflow-hidden">
+                            {{-- Poster --}}
+                            <div class="carousel-poster aspect-[2/3] bg-white/[0.03] overflow-hidden">
+                                @if($result['poster_path'])
+                                    <img
+                                        src="https://image.tmdb.org/t/p/w500{{ $result['poster_path'] }}"
+                                        alt="{{ $result['title'] }}"
+                                        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                                        loading="lazy"
+                                    >
+                                @else
+                                    <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-3">
+                                        No poster
+                                    </div>
                                 @endif
-                            </p>
+                            </div>
+                            {{-- Info --}}
+                            <div class="p-3 flex flex-col gap-1 flex-1">
+                                <h4 class="text-sm font-medium text-white leading-snug line-clamp-2 group-hover:text-accent transition-colors duration-200">
+                                    {{ $result['title'] }}
+                                </h4>
+                                <p class="text-xs text-gray-500 mt-auto">
+                                    {{ date('Y', strtotime($result['release_date'])) }}
+                                    @if($genres !== [] && isset($genres[$result['id']]))
+                                        · <span class="text-gray-600">{{ $genres[$result['id']] }}</span>
+                                    @endif
+                                </p>
+                            </div>
                         </div>
-                    </div>
-                </a>
+                    </a>
+
+                    {{-- TMDB score: top-left --}}
+                    @if(($showScore ?? false) && !empty($result['vote_average']) && $result['vote_average'] > 0)
+                        <div class="absolute top-2 left-2 bg-black/70 text-accent text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">
+                            ★ {{ number_format($result['vote_average'], 1) }}
+                        </div>
+                    @endif
+
+                    {{-- Save button: top-right --}}
+                    @if($showSave ?? false)
+                        @auth
+                            @php $isSaved = in_array($result['id'], $savedIds ?? []); @endphp
+                            <button type="button"
+                                class="absolute top-2 right-2 watchlist-toggle bg-black/70 text-white text-xs px-2 py-1 rounded hover:bg-black/90 transition-all z-10"
+                                data-tmdb-id="{{ $result['id'] }}"
+                                data-title="{{ $result['title'] }}"
+                                data-poster="{{ $result['poster_path'] }}"
+                                data-year="{{ date('Y', strtotime($result['release_date'])) }}"
+                                data-genres="{{ $genres[$result['id']] ?? '' }}"
+                                data-saved="{{ $isSaved ? '1' : '0' }}">
+                                {{ $isSaved ? '★' : '☆' }}
+                            </button>
+                        @endauth
+                    @endif
+                </div>
             </div>
             @endif
         @endforeach

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -211,6 +211,9 @@
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex gap-3 sm:justify-end">
         <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Adjust Criteria</button>
+        @if(!empty($batchUrl))
+            <a href="{{ $batchUrl }}" class="btn-secondary flex-1 sm:flex-none text-center">← Batch</a>
+        @endif
         @auth
             <button type="button" class="btn-secondary flex-1 sm:flex-none watchlist-toggle"
                 data-tmdb-id="{{ $tmdbInfo->id }}"

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -5,7 +5,7 @@
 
     <div class="mb-6">
         <div class="flex items-center justify-between gap-4 flex-wrap mb-3">
-            <h1 class="text-2xl font-bold text-white">My Watchlist</h1>
+            <h1 class="text-2xl font-bold text-white">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
             @if($items->isNotEmpty())
                 <div class="flex items-center gap-2 flex-wrap">
                     <div class="flex gap-1 bg-white/5 p-1 rounded-lg">


### PR DESCRIPTION
## Summary
- Roulette → batch → movie flow now preserves roulette criteria: similar movies carousel uses roulette filters and Pick Another keeps rolling from the same pool; Back to Batch button appears in the movie sticky bar
- Batch carousel cards now show TMDB score (top-left) and a save-to-watchlist toggle (top-right)
- Watchlist page shows movie count next to the heading, updates dynamically when filtering

## Test plan
- [x] Visit a roulette batch, click a movie — confirm "More with Same Criteria" shows roulette-filtered results and "← Batch" button is visible
- [x] Click "Pick Another" from that movie — confirm it still uses roulette criteria
- [x] Click "← Batch" — confirm it returns to the roulette batch page
- [x] On a batch page — confirm each card shows a ★ score top-left
- [x] Sign in, open a batch — confirm ☆/★ save toggle appears top-right on each card and correctly saves/removes from watchlist
- [x] Watchlist page — confirm total count shows in heading and updates when filtering by genre or status