### PR TITLE
Watchlist: genre multi-select, sticky bar with Roll button

### DIFF
--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -1,6 +1,20 @@
+import TomSelect from 'tom-select';
+
+let genreSelect = null;
+
 $(document).ready(function () {
 
     const csrf = () => $('meta[name="csrf-token"]').attr('content');
+
+    // Init genre multi-select
+    if (document.getElementById('genre-select')) {
+        genreSelect = new TomSelect('#genre-select', {
+            plugins: ['remove_button'],
+            placeholder: 'Filter by genre…',
+            onItemAdd() { this.setTextboxValue(''); this.refreshOptions(); },
+            onChange() { applyFilters(); },
+        });
+    }
 
     // Save / unsave toggle on movie detail page
     $(document).on('click', '.watchlist-toggle', function () {
@@ -71,12 +85,10 @@ $(document).ready(function () {
         });
     });
 
-    // Combined filter: status tab + genre chips
+    // Combined filter: status tab + genre select
     function applyFilters() {
         const status = $('.watchlist-filter.active').data('filter');
-        const activeGenres = new Set(
-            $('.genre-chip.active').map(function () { return $(this).data('genre'); }).get()
-        );
+        const activeGenres = new Set(genreSelect ? genreSelect.getValue() : []);
 
         $('.watchlist-card').each(function () {
             const cardStatus = $(this).attr('data-status');
@@ -97,11 +109,6 @@ $(document).ready(function () {
         applyFilters();
     });
 
-    $(document).on('click', '.genre-chip', function () {
-        $(this).toggleClass('active border-accent text-accent bg-accent/10 border-white/10 bg-white/5 text-gray-400');
-        applyFilters();
-    });
-
     $('#watchlist-roll').on('click', function () {
         const visible = $('.watchlist-card:visible');
         if (!visible.length) {
@@ -112,7 +119,7 @@ $(document).ready(function () {
             return;
         }
         const status = $('.watchlist-filter.active').data('filter') || 'all';
-        const genres = $('.genre-chip.active').map(function () { return $(this).data('genre'); }).get().join(',');
+        const genres = genreSelect ? genreSelect.getValue().join(',') : '';
         const picked = visible.eq(Math.floor(Math.random() * visible.length));
         let url = picked.find('a').first().attr('href') + '?wl_status=' + status;
         if (genres) url += '&wl_genres=' + encodeURIComponent(genres);

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -2,32 +2,16 @@
 @section('page_title', 'My Watchlist — MoviePickr')
 @section('hide_footer', true)
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-24">
 
     <div class="mb-6">
-        <div class="flex items-center justify-between gap-4 flex-wrap mb-3">
-            <h1 class="text-2xl font-bold text-white">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
-            @if($items->isNotEmpty())
-                <div class="flex items-center gap-2 flex-wrap">
-                    <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all" data-filter="all">All</button>
-                        <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="saved">To Watch</button>
-                        <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="watched">Watched</button>
-                    </div>
-                    <button id="watchlist-roll" class="text-xs px-3 py-1.5 rounded-lg bg-accent text-white hover:bg-accent/80 transition-all font-medium">
-                        ⚄ Roll
-                    </button>
-                </div>
-            @endif
-        </div>
+        <h1 class="text-2xl font-bold text-white mb-4">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
         @if($items->isNotEmpty() && $genres->isNotEmpty())
-            <div class="flex flex-wrap gap-1.5">
+            <select id="genre-select" multiple placeholder="Filter by genre...">
                 @foreach($genres as $genre)
-                    <button type="button"
-                            class="genre-chip text-xs px-2.5 py-1 rounded-full border border-white/10 bg-white/5 text-gray-400 hover:text-white hover:border-white/20 transition-all"
-                            data-genre="{{ $genre }}">{{ $genre }}</button>
+                    <option value="{{ $genre }}">{{ $genre }}</option>
                 @endforeach
-            </div>
+            </select>
         @endif
     </div>
 
@@ -93,4 +77,19 @@
     @endif
 
 </div>
+
+{{-- Sticky bar --}}
+@if($items->isNotEmpty())
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
+        <div class="flex gap-1 bg-white/5 p-1 rounded-lg flex-shrink-0">
+            <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all" data-filter="all">All</button>
+            <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="saved">To Watch</button>
+            <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="watched">Watched</button>
+        </div>
+        <button id="watchlist-roll" class="btn-accent px-6">⚄ Roll</button>
+    </div>
+</div>
+@endif
+
 @endsection


### PR DESCRIPTION
## Summary
- Replaced genre filter chips with a TomSelect multi-select dropdown (tag-style, with remove buttons)
- Moved status filter tabs (All / To Watch / Watched) and Roll button into a sticky bottom bar
- Roll button now uses `btn-accent` styling for better visibility
- Header simplified to just title + count + genre select

## Test plan
- [x] Watchlist page loads with TomSelect genre dropdown
- [x] Selecting genres filters cards correctly
- [x] Deselecting genres restores cards
- [x] Status tabs in sticky bar filter correctly
- [x] Combined genre + status filter works
- [x] Roll picks a random visible card and navigates with correct query params
- [x] Count updates when filters change
- [x] Empty watchlist still renders without sticky bar