### PR TITLE
Add score and save button overlays to homepage and movie page carousels

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,6 +9,10 @@ class HomeController extends Controller
 {
     public function __invoke(TmdbClient $tmdb): View
     {
-        return view('home', ['trending' => $tmdb->trending()]);
+        $savedIds = auth()->check()
+            ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
+            : [];
+
+        return view('home', ['trending' => $tmdb->trending(), 'savedIds' => $savedIds]);
     }
 }

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -82,10 +82,13 @@ class MovieController extends Controller
         $trailer    = $movieService->getTrailer($tmdbInfo->videos->results ?? []);
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');
+        $savedIds   = auth()->check()
+            ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
+            : [];
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',
-            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl'
+            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds'
         ));
     }
 }

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -31,7 +31,8 @@ $(document).ready(function () {
         })
         .done(function (res) {
             btn.data('saved', res.saved ? '1' : '0');
-            btn.text(res.saved ? '★ Saved' : '☆ Save');
+            const star = btn.data('format') === 'star';
+            btn.text(res.saved ? (star ? '★' : '★ Saved') : (star ? '☆' : '☆ Save'));
         })
         .always(function () { btn.prop('disabled', false); });
     });

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('scripts')
-    @vite(['resources/js/custom/carousel.js'])
+    @vite(['resources/js/custom/carousel.js', 'resources/js/custom/watchlist.js'])
 @endsection
 @section('content')
 
@@ -154,7 +154,7 @@
             <h2 class="text-2xl font-bold text-white mb-3">Trending Today</h2>
             <div class="section-divider"></div>
         </div>
-        @include('includes.carousel', ['allMovies' => $trending, 'name' => 'swiper-trending', 'genres' => [], 'clearCriteria' => true])
+        @include('includes.carousel', ['allMovies' => $trending, 'name' => 'swiper-trending', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
     </section>
 
     {{-- About --}}

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -39,9 +39,9 @@
                     </a>
 
                     {{-- TMDB score: top-left --}}
-                    @if(($showScore ?? false) && !empty($result['vote_average']) && $result['vote_average'] > 0)
-                        <div class="absolute top-2 left-2 bg-black/70 text-accent text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">
-                            ★ {{ number_format($result['vote_average'], 1) }}
+                    @if($showScore ?? false)
+                        <div class="absolute top-2 left-2 bg-black/70 text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none {{ !empty($result['vote_average']) && $result['vote_average'] > 0 ? 'text-accent' : 'text-gray-500' }}">
+                            ★ {{ !empty($result['vote_average']) && $result['vote_average'] > 0 ? number_format($result['vote_average'], 1) : '—' }}
                         </div>
                     @endif
 

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -51,6 +51,7 @@
                             @php $isSaved = in_array($result['id'], $savedIds ?? []); @endphp
                             <button type="button"
                                 class="absolute top-2 right-2 watchlist-toggle bg-black/70 text-white text-xs px-2 py-1 rounded hover:bg-black/90 transition-all z-10"
+                                data-format="star"
                                 data-tmdb-id="{{ $result['id'] }}"
                                 data-title="{{ $result['title'] }}"
                                 data-poster="{{ $result['poster_path'] }}"

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -215,7 +215,7 @@
             <h2 class="text-xl font-bold text-white mb-3">{{ $similarTitle }}</h2>
             <div class="section-divider"></div>
         </div>
-        @include('includes.carousel', ['allMovies' => $similarMovies, 'name' => 'swiper-similar', 'genres' => [], 'linkSuffix' => $linkSuffix])
+        @include('includes.carousel', ['allMovies' => $similarMovies, 'name' => 'swiper-similar', 'genres' => [], 'linkSuffix' => $linkSuffix, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
     </div>
     @endif
 


### PR DESCRIPTION
## Summary
- Added TMDB score (★ top-left) and save button (☆/★ top-right) overlays to the homepage trending carousel
- Same overlays added to the similar movies carousel on the movie detail page
- Save button uses short star-only text (★/☆) in carousel context vs "★ Saved / ☆ Save" on the movie page
- HomeController and MovieController now pass `$savedIds` to their views so saved state is accurate on page load

## Test plan
- [x] Homepage trending carousel shows score top-left on each card
- [x] Signed-in user sees ☆/★ save button top-right; toggling saves/removes correctly
- [x] Saved movies show ★ on page load
- [x] Movie page similar carousel has the same overlays
- [x] Unauthenticated users see no save button (auth guard in carousel template)