### PR TITLE
Add Today / This Week trending toggle on homepage

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -13,6 +13,10 @@ class HomeController extends Controller
             ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
             : [];
 
-        return view('home', ['trending' => $tmdb->trending(), 'savedIds' => $savedIds]);
+        return view('home', [
+            'trendingDay'  => $tmdb->trending('day'),
+            'trendingWeek' => $tmdb->trending('week'),
+            'savedIds'     => $savedIds,
+        ]);
     }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -121,12 +121,17 @@ class TmdbClient implements ApiMovie
     }
 
     /**
-     * Daily trending movies, cached for 30 minutes.
+     * Trending movies cached until TMDB next updates that list (midnight UTC for day, Monday midnight for week).
      */
-    public function trending(): array
+    public function trending(string $period = 'day'): array
     {
-        return Cache::remember('tmdb_trending', now()->addMinutes(30), function () {
-            $response = $this->client->get('https://api.themoviedb.org/3/trending/movie/day');
+        $period = $period === 'week' ? 'week' : 'day';
+        $ttl = $period === 'day'
+            ? now('UTC')->diffInSeconds(\Carbon\Carbon::tomorrow('UTC'))
+            : now('UTC')->diffInSeconds(\Carbon\Carbon::now('UTC')->startOfWeek(\Carbon\Carbon::MONDAY)->addWeek());
+
+        return Cache::remember("tmdb_trending_{$period}", $ttl, function () use ($period) {
+            $response = $this->client->get("https://api.themoviedb.org/3/trending/movie/{$period}");
             return json_decode($response->getBody()->getContents(), true);
         });
     }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -133,7 +133,8 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
 
-    .watchlist-filter.active {
+    .watchlist-filter.active,
+    .trend-toggle.active {
         background-color: var(--bg-surface);
         color: var(--text-primary);
     }

--- a/resources/js/custom/carousel.js
+++ b/resources/js/custom/carousel.js
@@ -38,6 +38,7 @@ $(document).ready(function () {
             const isWeek = this.id === 'trend-week';
             $('#trend-day, #trend-week').toggleClass('active', false).addClass('text-gray-400');
             $(this).addClass('active').removeClass('text-gray-400');
+            $('#trend-label').text(isWeek ? 'This Week' : 'Today');
             $('#trending-day').toggleClass('hidden', isWeek);
             $('#trending-week').toggleClass('hidden', !isWeek);
 

--- a/resources/js/custom/carousel.js
+++ b/resources/js/custom/carousel.js
@@ -29,9 +29,23 @@ $(document).ready(function () {
         },
     };
 
-    if ($('.swiper-trending').length) {
-        const s = new Swiper('.swiper-trending', sharedConfig);
-        addWheelControl(s, document.querySelector('.swiper-trending'));
+    if ($('.swiper-trending-day').length) {
+        const s = new Swiper('.swiper-trending-day', sharedConfig);
+        addWheelControl(s, document.querySelector('.swiper-trending-day'));
+        let weekSwiper = null;
+
+        $('#trend-day, #trend-week').on('click', function () {
+            const isWeek = this.id === 'trend-week';
+            $('#trend-day, #trend-week').toggleClass('active', false).addClass('text-gray-400');
+            $(this).addClass('active').removeClass('text-gray-400');
+            $('#trending-day').toggleClass('hidden', isWeek);
+            $('#trending-week').toggleClass('hidden', !isWeek);
+
+            if (isWeek && !weekSwiper) {
+                weekSwiper = new Swiper('.swiper-trending-week', sharedConfig);
+                addWheelControl(weekSwiper, document.querySelector('.swiper-trending-week'));
+            }
+        });
     }
 
     if ($('.swiper-similar').length) {

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -150,11 +150,21 @@
 
     {{-- Trending --}}
     <section class="max-w-7xl mx-auto px-4 py-12">
-        <div class="section-header">
-            <h2 class="text-2xl font-bold text-white mb-3">Trending Today</h2>
-            <div class="section-divider"></div>
+        <div class="flex items-end justify-between mb-3">
+            <h2 class="text-2xl font-bold text-white">Trending</h2>
+            <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
+                <button id="trend-day" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Today</button>
+                <button id="trend-week" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">This Week</button>
+            </div>
         </div>
-        @include('includes.carousel', ['allMovies' => $trending, 'name' => 'swiper-trending', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        <div class="section-divider mb-4"></div>
+
+        <div id="trending-day">
+            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-day', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        </div>
+        <div id="trending-week" class="hidden">
+            @include('includes.carousel', ['allMovies' => $trendingWeek, 'name' => 'swiper-trending-week', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        </div>
     </section>
 
     {{-- About --}}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -151,7 +151,7 @@
     {{-- Trending --}}
     <section class="max-w-7xl mx-auto px-4 py-12">
         <div class="flex items-end justify-between mb-3">
-            <h2 class="text-2xl font-bold text-white">Trending</h2>
+            <h2 class="text-2xl font-bold text-white">Trending <span id="trend-label">Today</span></h2>
             <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
                 <button id="trend-day" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Today</button>
                 <button id="trend-week" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">This Week</button>


### PR DESCRIPTION
## Summary
- Added Today / This Week toggle above the trending carousel on the homepage
- Heading updates to "Trending Today" or "Trending This Week" on switch
- Week carousel is lazy-initialized (Swiper only created on first click)
- Each period cached until TMDB next updates it: daily at midnight UTC, weekly at Monday midnight UTC — no wasted API calls

## Test plan
- [x] Homepage loads showing "Trending Today" with Today tab active
- [x] Clicking "This Week" switches heading, carousel, and active tab
- [x] Switching back to "Today" works correctly
- [x] Save and score overlays work on both carousels