### PR TITLE
TMDB/JustWatch ToS attribution and JustWatch streaming links

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -96,7 +96,7 @@ class MovieController extends Controller
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',
-            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds'
+            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country'
         ));
     }
 }

--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -16,8 +16,12 @@ class TmdbProxyController extends Controller
             return response()->json([]);
         }
 
+        $exclude = $request->string('exclude_dept')->value();
+
         $results = collect($tmdb->searchPeople($query)['results'] ?? [])
-            ->when($dept, fn($c) => $c->where('known_for_department', $dept))
+            ->when($dept,    fn($c) => $c->where('known_for_department', $dept))
+            ->when($exclude, fn($c) => $c->where('known_for_department', '!=', $exclude))
+            ->sortByDesc('popularity')
             ->take(4)
             ->values()
             ->all();

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -60,12 +60,16 @@ class TmdbClient implements ApiMovie
             $input['primary_release_date.gte'] = '1970-01-01';
         }
 
-        $input['vote_count.gte']  ??= 10;
+        $hasPeople = isset($input['with_cast']) || isset($input['with_crew']);
+
+        $input['vote_count.gte']  ??= $hasPeople ? 0 : 10;
         $input['sort_by']         ??= $this->randomSort();
-        $input['with_runtime.gte'] = 40;
         $input['language']          = 'en-US';
         $input['include_adult']     = 'false';
         $input['include_video']     = 'false';
+        if (!$hasPeople) {
+            $input['with_runtime.gte'] = 40;
+        }
 
         // Relax constraints for very old films
         if ($smallYear < 1950) {

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -50,6 +50,7 @@ $(document).ready(function () {
             timer = setTimeout(function () {
                 const params = { q: query };
                 if (dept) params.dept = dept;
+                else params.exclude_dept = 'Acting';
                 $.getJSON('/tmdb/search/people', params)
                     .done(function (data) {
                         data.forEach(function (p) {

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -28,6 +28,14 @@ $(document).ready(function () {
             placeholder: dept ? 'Search actors…' : 'Search directors, writers…',
             maxOptions: null,
             create: false,
+            render: {
+                option: function (data, escape) {
+                    const img = data.profile
+                        ? `<img src="https://image.tmdb.org/t/p/w45${escape(data.profile)}" class="w-7 h-7 rounded-full object-cover flex-shrink-0">`
+                        : `<div class="w-7 h-7 rounded-full bg-white/10 flex-shrink-0"></div>`;
+                    return `<div class="flex items-center gap-2 py-0.5">${img}<span>${escape(data.text)}</span></div>`;
+                },
+            },
         });
         let timer;
         ts.on('type', function (query) {
@@ -44,7 +52,9 @@ $(document).ready(function () {
                 if (dept) params.dept = dept;
                 $.getJSON('/tmdb/search/people', params)
                     .done(function (data) {
-                        data.forEach(function (p) { ts.addOption({ value: String(p.id), text: p.name }); });
+                        data.forEach(function (p) {
+                            ts.addOption({ value: String(p.id), text: p.name, profile: p.profile_path || '' });
+                        });
                     })
                     .always(function () {
                         ts.loading = Math.max(ts.loading - 1, 0);

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', $title ?? 'Batch — MoviePickr')
-@section('hide_footer', true)
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])
 @endsection

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', $title ?? 'Batch — MoviePickr')
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])
 @endsection

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -68,24 +68,21 @@
                 </div>
             </div>
 
+            {{-- Language --}}
+            <div class="card p-5">
+                <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Language</h3>
+                @include('includes.languages')
+            </div>
+
             {{-- Streaming --}}
             <div class="card p-5">
                 <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Streaming</h3>
-                <div class="flex flex-col gap-4">
-                    <div>
-                        <label class="block text-sm text-gray-400 mb-1.5">Language</label>
-                        @include('includes.languages')
-                    </div>
-                    <div>
-                        <label class="block text-sm text-gray-400 mb-1.5">Services</label>
-                        <select id="with_watch_providers" name="with_watch_providers[]" multiple>
-                            @foreach($providersArray as $value)
-                                <option value="{{ $value['id'] }}" data-logo="{{ $value['logo'] }}">{{ $value['name'] }}</option>
-                            @endforeach
-                        </select>
-                        <p class="text-xs text-gray-600 mt-1">Shows services available in your region</p>
-                    </div>
-                </div>
+                <select id="with_watch_providers" name="with_watch_providers[]" multiple>
+                    @foreach($providersArray as $value)
+                        <option value="{{ $value['id'] }}" data-logo="{{ $value['logo'] }}">{{ $value['name'] }}</option>
+                    @endforeach
+                </select>
+                <p class="text-xs text-gray-600 mt-1">Shows services available in your region</p>
             </div>
 
             {{-- People --}}

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', 'Criteria — MoviePickr')
-@section('footer_pb', 'pb-20 sm:pb-6')
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/criteriaForm.js'])
 @endsection

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -2,7 +2,8 @@
     if ($user_input === 'default') $user_input = [];
     $openYear     = !empty($user_input['primary_release_date_gte'] ?? '') || !empty($user_input['primary_release_date_lte'] ?? '');
     $openGenres   = !empty($user_input['with_genres'] ?? []) || !empty($user_input['without_genres'] ?? []);
-    $openStreaming = !empty($user_input['with_watch_providers'] ?? []);
+    $openLanguage  = !empty($user_input['with_original_language'] ?? '');
+    $openStreaming  = !empty($user_input['with_watch_providers'] ?? []);
     $openPeople   = !empty($user_input['with_cast'] ?? []) || !empty($user_input['with_crew'] ?? []);
     $openScores   = !empty($user_input['vote_average_gte'] ?? '') || !empty($user_input['vote_average_lte'] ?? '') || !empty($user_input['vote_count_gte'] ?? '');
 @endphp
@@ -75,6 +76,19 @@
                     </div>
                 </div>
 
+                {{-- Language --}}
+                <div class="accordion-section border-t border-white/5 {{ $openLanguage ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4">
+                            @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? ''])
+                        </div>
+                    </div>
+                </div>
+
                 {{-- Streaming --}}
                 <div class="accordion-section border-t border-white/5 {{ $openStreaming ? 'accordion-open' : '' }}">
                     <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
@@ -82,23 +96,16 @@
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
                     <div class="accordion-body">
-                        <div class="pb-4 flex flex-col gap-3">
-                            <div>
-                                <label class="block text-sm text-gray-400 mb-1">Language</label>
-                                @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? 'en'])
-                            </div>
-                            <div>
-                                <label class="block text-sm text-gray-400 mb-1">Services</label>
-                                <select id="modal-with_watch_providers" name="with_watch_providers[]" multiple>
-                                    @foreach($providersArray as $value)
-                                        <option value="{{ $value['id'] }}"
-                                            data-logo="{{ $value['logo'] }}"
-                                            {{ isset($user_input['with_watch_providers']) && in_array($value['id'], (array)$user_input['with_watch_providers']) ? 'selected' : '' }}>
-                                            {{ $value['name'] }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                            </div>
+                        <div class="pb-4">
+                            <select id="modal-with_watch_providers" name="with_watch_providers[]" multiple>
+                                @foreach($providersArray as $value)
+                                    <option value="{{ $value['id'] }}"
+                                        data-logo="{{ $value['logo'] }}"
+                                        {{ isset($user_input['with_watch_providers']) && in_array($value['id'], (array)$user_input['with_watch_providers']) ? 'selected' : '' }}>
+                                        {{ $value['name'] }}
+                                    </option>
+                                @endforeach
+                            </select>
                         </div>
                     </div>
                 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -178,6 +178,13 @@
     @unless(View::hasSection('hide_footer'))
     <footer class="border-t border-white/5 mt-8 pt-6 @yield('footer_pb', 'pb-6') text-center text-xs text-gray-600">
         © Martynas Jankauskas {{ date('Y') }}
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+            <a href="https://www.themoviedb.org" target="_blank" class="flex items-center gap-1.5 hover:opacity-80 transition-opacity">
+                <img src="https://www.themoviedb.org/assets/2/v4/logos/v2/blue_short-8e7b30f73a4020692ccca9c88bafe5dcb6f8a62a4c6bc55cd9ba82bb2cd95f6c.svg" alt="TMDB" class="h-3">
+            </a>
+            <span class="text-gray-700">This product uses the TMDB API but is not endorsed or certified by TMDB.</span>
+            <span class="text-gray-700">Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.</span>
+        </div>
     </footer>
     @endunless
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -93,7 +93,6 @@
                                 class="h-8 w-8 rounded-md border border-white/10 hover:border-white/30 transition-colors">
                         </a>
                     @endforeach
-                    <a href="{{ $jwUrl }}" target="_blank" class="text-xs text-gray-500 hover:text-white transition-colors ml-1">Find on JustWatch →</a>
                 </div>
             @endif
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
-@section('hide_footer', true)
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
@@ -85,13 +85,15 @@
 
             {{-- Streaming --}}
             @if ($watchProviders != null)
+                @php $jwUrl = 'https://www.justwatch.com/' . strtolower($country) . '/search?q=' . urlencode($tmdbInfo->title ?? $omdbInfo->Title); @endphp
                 <div class="flex items-center gap-2 flex-wrap">
                     @foreach($watchProviders->flatrate as $stream)
-                        <a href="{{ $watchProviders->link }}" target="_blank" title="Watch on streaming">
+                        <a href="{{ $jwUrl }}" target="_blank" title="Find on JustWatch">
                             <img src="https://image.tmdb.org/t/p/w45{{ $stream->logo_path }}"
                                 class="h-8 w-8 rounded-md border border-white/10 hover:border-white/30 transition-colors">
                         </a>
                     @endforeach
+                    <a href="{{ $jwUrl }}" target="_blank" class="text-xs text-gray-500 hover:text-white transition-colors ml-1">Find on JustWatch →</a>
                 </div>
             @endif
 
@@ -107,7 +109,7 @@
     </div>
 
     @if ($watchProviders != null)
-        <p class="text-xs text-gray-600 mb-6">Streaming info from TMDB & JustWatch. Logos link to TMDB which redirects to your streaming service.</p>
+        <p class="text-xs text-gray-600 mb-6">Streaming availability by JustWatch. Links open JustWatch search for your region.</p>
     @endif
 
     {{-- Info cards --}}

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', 'My Watchlist — MoviePickr')
-@section('hide_footer', true)
+@section('footer_pb', 'pb-24')
 @section('content')
 <div class="max-w-7xl mx-auto px-4 py-8 pb-24">
 

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', 'My Watchlist — MoviePickr')
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('content')
 <div class="max-w-7xl mx-auto px-4 py-8 pb-24">
 


### PR DESCRIPTION
## Summary
- Added TMDB logo + attribution text to the footer: "This product uses the TMDB API but is not endorsed or certified by TMDB."
- Added JustWatch credit for watch provider data in the footer
- Footer now shows on all pages — sticky-bar pages (movie, batch, watchlist, criteria) use extra bottom padding so the footer clears the bar
- Streaming provider logos on the movie page now link directly to JustWatch search for the user's region instead of the TMDB watch page

## Test plan
- [x] Footer with TMDB logo and attribution visible on homepage, roulettes, criteria
- [x] Footer also visible on movie, batch, watchlist pages when scrolled to bottom
- [x] Footer not hidden under the sticky bar on any page
- [x] Clicking a streaming logo opens JustWatch search in the correct country
- [x] iOS safe area inset doesn't cut off the footer on mobile