### PR TITLE
Show movie collection on movie page

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -85,6 +85,15 @@ class MovieController extends Controller
             $similarMovies = $tmdb->similarMovies($tmdbInfo);
         }
 
+        $collection = null;
+        if (!empty($tmdbInfo->belongs_to_collection->id)) {
+            $collectionData = $tmdb->collection($tmdbInfo->belongs_to_collection->id);
+            if (!empty($collectionData->parts) && count($collectionData->parts) > 1) {
+                usort($collectionData->parts, fn($a, $b) => strcmp($a->release_date ?? '', $b->release_date ?? ''));
+                $collection = $collectionData;
+            }
+        }
+
         $genres     = $movieService->genresString($tmdbInfo);
         $urls       = $link->linksArray($omdbInfo);
         $trailer    = $movieService->getTrailer($tmdbInfo->videos->results ?? []);
@@ -96,7 +105,8 @@ class MovieController extends Controller
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',
-            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country'
+            'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country',
+            'collection'
         ));
     }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -159,6 +159,14 @@ class TmdbClient implements ApiMovie
         });
     }
 
+    public function collection(int $id): object
+    {
+        return Cache::remember('tmdb_collection_' . $id, now()->addWeek(), function () use ($id) {
+            $url = 'https://api.themoviedb.org/3/collection/' . $id . '?' . http_build_query(['language' => 'en-US']);
+            return json_decode($this->client->get($url)->getBody()->getContents());
+        });
+    }
+
     /**
      * Genre list — callers should use MovieService::genres() which caches the result.
      */

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -139,6 +139,9 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
 
+    .scrollbar-hide { scrollbar-width: none; -ms-overflow-style: none; }
+    .scrollbar-hide::-webkit-scrollbar { display: none; }
+
     .roulette-row {
         scrollbar-width: none;
         -ms-overflow-style: none;

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -209,6 +209,43 @@
         </div>
     </div>
 
+    {{-- Collection --}}
+    @if ($collection)
+    <div class="mb-6">
+        <div class="section-header">
+            <h2 class="text-xl font-bold text-white mb-3">{{ $collection->name }}</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
+            @foreach ($collection->parts as $part)
+                @php $isCurrent = $part->id == $tmdbInfo->id; @endphp
+                <a href="{{ url('movie/' . $part->id) }}"
+                   class="flex-shrink-0 w-28 group {{ $isCurrent ? 'opacity-50 pointer-events-none' : '' }}">
+                    <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] relative">
+                        @if (!empty($part->poster_path))
+                            <img src="https://image.tmdb.org/t/p/w185{{ $part->poster_path }}"
+                                 alt="{{ $part->title }}"
+                                 class="w-full h-full object-cover {{ $isCurrent ? '' : 'group-hover:scale-105 transition-transform duration-300' }}"
+                                 loading="lazy">
+                        @else
+                            <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
+                        @endif
+                        @if ($isCurrent)
+                            <div class="absolute inset-0 flex items-end justify-center pb-2">
+                                <span class="text-xs text-white bg-black/60 px-2 py-0.5 rounded-full">This film</span>
+                            </div>
+                        @endif
+                    </div>
+                    <p class="text-xs text-gray-400 mt-1.5 line-clamp-2 leading-snug">{{ $part->title }}</p>
+                    @if (!empty($part->release_date))
+                        <p class="text-xs text-gray-600">{{ substr($part->release_date, 0, 4) }}</p>
+                    @endif
+                </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
     {{-- Similar movies --}}
     @if ($similarMovies != null)
     <div>


### PR DESCRIPTION
## Summary
- When a movie belongs to a TMDB collection (franchise/series), a horizontal poster strip is shown above the Similar Movies section
- Movies are sorted chronologically by release date
- The current film is dimmed with a "This film" label and is non-clickable
- Collection data is cached for one week
- Standalone movies (no collection) are unaffected

## Test plan
- [x] Open an MCU movie (e.g. Spider-Man: Homecoming) — collection strip appears above Similar Movies
- [x] Movies in the strip are in chronological order
- [x] Current movie is dimmed with "This film" label and not clickable
- [x] Other movies in the strip link to their movie pages correctly
- [x] A standalone movie (no collection) shows no collection section