### PR TITLE
Watchlist sorting by date, title, year, and rating

### DIFF
--- a/app/Console/Commands/BackfillWatchlistRatings.php
+++ b/app/Console/Commands/BackfillWatchlistRatings.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Watchlist;
+use App\Services\TmdbClient;
+use Illuminate\Console\Command;
+
+class BackfillWatchlistRatings extends Command
+{
+    protected $signature = 'watchlist:backfill-ratings';
+    protected $description = 'Fill in missing vote_average for watchlist items from TMDB';
+
+    public function handle(TmdbClient $tmdb): void
+    {
+        $items = Watchlist::whereNull('vote_average')->get();
+
+        if ($items->isEmpty()) {
+            $this->info('All watchlist items already have ratings.');
+            return;
+        }
+
+        $this->info("Backfilling ratings for {$items->count()} items...");
+        $bar = $this->output->createProgressBar($items->count());
+        $bar->start();
+
+        $updated = 0;
+        foreach ($items as $item) {
+            try {
+                $movie = $tmdb->movie($item->tmdb_id);
+                $rating = $movie->vote_average ?? null;
+                if ($rating) {
+                    $item->update(['vote_average' => $rating]);
+                    $updated++;
+                }
+            } catch (\Throwable) {
+                // skip on API error
+            }
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Done. Updated {$updated} of {$items->count()} items.");
+    }
+}

--- a/app/Http/Controllers/WatchlistController.php
+++ b/app/Http/Controllers/WatchlistController.php
@@ -30,11 +30,12 @@ class WatchlistController extends Controller
     public function toggle(Request $request)
     {
         $request->validate([
-            'tmdb_id'     => 'required|integer',
-            'title'       => 'required|string|max:255',
-            'poster_path' => 'nullable|string',
-            'year'        => 'nullable|integer',
-            'genres'      => 'nullable|string',
+            'tmdb_id'      => 'required|integer',
+            'title'        => 'required|string|max:255',
+            'poster_path'  => 'nullable|string',
+            'year'         => 'nullable|integer',
+            'genres'       => 'nullable|string',
+            'vote_average' => 'nullable|numeric|min:0|max:10',
         ]);
 
         $user = Auth::user();
@@ -46,12 +47,13 @@ class WatchlistController extends Controller
         }
 
         $user->watchlist()->create([
-            'tmdb_id'     => $request->tmdb_id,
-            'title'       => $request->title,
-            'poster_path' => $request->poster_path,
-            'year'        => $request->year,
-            'genres'      => $request->genres,
-            'status'      => 'saved',
+            'tmdb_id'      => $request->tmdb_id,
+            'title'        => $request->title,
+            'poster_path'  => $request->poster_path,
+            'year'         => $request->year,
+            'genres'       => $request->genres,
+            'vote_average' => $request->vote_average ?: null,
+            'status'       => 'saved',
         ]);
 
         return response()->json(['saved' => true]);

--- a/app/Models/Watchlist.php
+++ b/app/Models/Watchlist.php
@@ -15,6 +15,7 @@ class Watchlist extends Model
         'poster_path',
         'year',
         'genres',
+        'vote_average',
         'status',
     ];
 

--- a/database/migrations/2026_05_22_000001_add_vote_average_to_watchlist_table.php
+++ b/database/migrations/2026_05_22_000001_add_vote_average_to_watchlist_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('watchlist', function (Blueprint $table) {
+            $table->decimal('vote_average', 4, 1)->nullable()->after('genres');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('watchlist', function (Blueprint $table) {
+            $table->dropColumn('vote_average');
+        });
+    }
+};

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -22,12 +22,13 @@ $(document).ready(function () {
         btn.prop('disabled', true);
 
         $.post('/watchlist/toggle', {
-            _token:      csrf(),
-            tmdb_id:     btn.data('tmdb-id'),
-            title:       btn.data('title'),
-            poster_path: btn.data('poster') || null,
-            year:        btn.data('year') || null,
-            genres:      btn.data('genres') || null,
+            _token:       csrf(),
+            tmdb_id:      btn.data('tmdb-id'),
+            title:        btn.data('title'),
+            poster_path:  btn.data('poster') || null,
+            year:         btn.data('year') || null,
+            genres:       btn.data('genres') || null,
+            vote_average: btn.data('rating') || null,
         })
         .done(function (res) {
             btn.data('saved', res.saved ? '1' : '0');
@@ -115,6 +116,38 @@ $(document).ready(function () {
         $(this).addClass('active');
         applyFilters();
     });
+
+    function applySort() {
+        const val = $('#sort-select').val();
+        if (!val) return;
+        const [key, dir] = val.split('-');
+        const grid = $('.watchlist-card').parent();
+        const cards = $('.watchlist-card').get();
+
+        cards.sort(function (a, b) {
+            let av, bv;
+            if (key === 'date') {
+                av = parseInt($(a).data('date')) || 0;
+                bv = parseInt($(b).data('date')) || 0;
+            } else if (key === 'title') {
+                av = ($(a).data('title') || '').toLowerCase();
+                bv = ($(b).data('title') || '').toLowerCase();
+            } else if (key === 'year') {
+                av = parseInt($(a).data('year')) || 0;
+                bv = parseInt($(b).data('year')) || 0;
+            } else if (key === 'rating') {
+                av = parseFloat($(a).data('rating')) || 0;
+                bv = parseFloat($(b).data('rating')) || 0;
+            }
+            if (av < bv) return dir === 'asc' ? -1 : 1;
+            if (av > bv) return dir === 'asc' ? 1 : -1;
+            return 0;
+        });
+
+        grid.append(cards);
+    }
+
+    $('#sort-select').on('change', applySort);
 
     $('#watchlist-roll').on('click', function () {
         const visible = $('.watchlist-card:visible');

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -57,6 +57,7 @@
                                 data-poster="{{ $result['poster_path'] }}"
                                 data-year="{{ date('Y', strtotime($result['release_date'])) }}"
                                 data-genres="{{ $genres[$result['id']] ?? '' }}"
+                                data-rating="{{ $result['vote_average'] ?? '' }}"
                                 data-saved="{{ $isSaved ? '1' : '0' }}">
                                 {{ $isSaved ? '★ Saved' : '☆' }}
                             </button>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -36,6 +36,7 @@
                 data-poster="{{ $tmdbInfo->poster_path ?? '' }}"
                 data-year="{{ $omdbInfo->Year ?? date('Y', strtotime($tmdbInfo->release_date ?? '')) }}"
                 data-genres="{{ $genres ?? '' }}"
+                data-rating="{{ $tmdbInfo->vote_average ?? '' }}"
                 data-saved="{{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '1' : '0' }}">
                 {{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '★ Saved' : '☆ Save' }}
             </button>

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -6,12 +6,28 @@
 
     <div class="mb-6">
         <h1 class="text-2xl font-bold text-white mb-4">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
-        @if($items->isNotEmpty() && $genres->isNotEmpty())
-            <select id="genre-select" multiple placeholder="Filter by genre...">
-                @foreach($genres as $genre)
-                    <option value="{{ $genre }}">{{ $genre }}</option>
-                @endforeach
-            </select>
+        @if($items->isNotEmpty())
+            <div class="flex flex-col sm:flex-row gap-2">
+                @if($genres->isNotEmpty())
+                    <div class="flex-1">
+                        <select id="genre-select" multiple placeholder="Filter by genre...">
+                            @foreach($genres as $genre)
+                                <option value="{{ $genre }}">{{ $genre }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                @endif
+                <select id="sort-select" class="input-dark text-sm flex-shrink-0 sm:w-44">
+                    <option value="date-desc">Newest Added</option>
+                    <option value="date-asc">Oldest Added</option>
+                    <option value="title-asc">Title A–Z</option>
+                    <option value="title-desc">Title Z–A</option>
+                    <option value="year-desc">Year (Newest)</option>
+                    <option value="year-asc">Year (Oldest)</option>
+                    <option value="rating-desc">Rating (High–Low)</option>
+                    <option value="rating-asc">Rating (Low–High)</option>
+                </select>
+            </div>
         @endif
     </div>
 
@@ -24,7 +40,13 @@
     @else
         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
             @foreach($items as $item)
-                <div class="watchlist-card" data-status="{{ $item->status }}" data-genres="{{ $item->genres }}">
+                <div class="watchlist-card"
+                     data-status="{{ $item->status }}"
+                     data-genres="{{ $item->genres }}"
+                     data-date="{{ $item->created_at->timestamp }}"
+                     data-title="{{ $item->title }}"
+                     data-year="{{ $item->year ?? 0 }}"
+                     data-rating="{{ $item->vote_average ?? 0 }}">
 
                     {{-- Poster --}}
                     <a href="{{ url('movie/'.$item->tmdb_id) }}" class="block group">

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -70,6 +70,13 @@
                                 </div>
                             </div>
 
+                            {{-- Score badge --}}
+                            @if($item->vote_average)
+                                <div class="absolute top-2 left-2 bg-black/70 text-accent text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">
+                                    ★ {{ number_format($item->vote_average, 1) }}
+                                </div>
+                            @endif
+
                             {{-- Watched badge --}}
                             <div class="watched-overlay absolute inset-0 bg-black/50 flex items-center justify-center {{ $item->status === 'watched' ? '' : 'hidden' }} pointer-events-none">
                                 <span class="bg-black/60 text-white text-xs font-medium px-3 py-1.5 rounded-full border border-white/20">✓ Watched</span>


### PR DESCRIPTION
## Summary
- Added sort dropdown to watchlist page with 8 options: Newest/Oldest Added, Title A–Z/Z–A, Year Newest/Oldest, Rating High–Low/Low–High
- Sorting reorders cards client-side without a page reload, compatible with status and genre filters
- Added `vote_average` column to watchlist table — stored when saving a movie from any carousel or movie page
- Rating badge (★ 7.4) shown on each watchlist card when available
- Added `php artisan watchlist:backfill-ratings` command to populate ratings for existing watchlist items from TMDB

## Test plan
- [x] Run `php artisan migrate` on server
- [x] Run `php artisan watchlist:backfill-ratings` to populate existing items
- [x] Sort dropdown appears on watchlist page next to genre filter
- [x] Changing sort reorders cards correctly for each option
- [x] Rating badge appears on cards that have a rating
- [x] Saving a new movie from a carousel or movie page stores the rating
- [x] Sort + status filter + genre filter all work together