### PR TITLE
Add movie search bar to nav

### DIFF
--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -8,6 +8,21 @@ use Illuminate\Http\Request;
 
 class TmdbProxyController extends Controller
 {
+    public function searchMovies(Request $request, TmdbClient $tmdb): JsonResponse
+    {
+        $query = trim($request->string('q'));
+        if (!$query) {
+            return response()->json([]);
+        }
+
+        $results = collect($tmdb->searchMovies($query)['results'] ?? [])
+            ->take(6)
+            ->values()
+            ->all();
+
+        return response()->json($results);
+    }
+
     public function searchPeople(Request $request, TmdbClient $tmdb): JsonResponse
     {
         $query = trim($request->string('q'));

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -140,6 +140,17 @@ class TmdbClient implements ApiMovie
         });
     }
 
+    public function searchMovies(string $query): array
+    {
+        $url = 'https://api.themoviedb.org/3/search/movie?' . http_build_query([
+            'language'      => 'en-US',
+            'query'         => $query,
+            'page'          => 1,
+            'include_adult' => 'false',
+        ]);
+        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+    }
+
     public function searchPeople(string $query): array
     {
         $url = 'https://api.themoviedb.org/3/search/person?' . http_build_query([

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -1,0 +1,67 @@
+$(document).ready(function () {
+
+    function escHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function buildResults(data) {
+        if (!data.length) return '';
+        return data.map(function (m) {
+            const year   = m.release_date ? m.release_date.substring(0, 4) : '';
+            const poster = m.poster_path
+                ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(m.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
+                : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
+            return `<a href="/movie/${m.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
+                ${poster}
+                <div class="min-w-0">
+                    <div class="text-sm text-white truncate">${escHtml(m.title)}</div>
+                    ${year ? `<div class="text-xs text-gray-500">${year}</div>` : ''}
+                </div>
+            </a>`;
+        }).join('');
+    }
+
+    function initSearch(inputSel, resultsSel) {
+        const $input   = $(inputSel);
+        const $results = $(resultsSel);
+        if (!$input.length) return;
+
+        let timer;
+
+        $input.on('input', function () {
+            clearTimeout(timer);
+            const q = $(this).val().trim();
+            if (!q) { $results.addClass('hidden').empty(); return; }
+
+            timer = setTimeout(function () {
+                $.getJSON('/tmdb/search/movies', { q: q })
+                    .done(function (data) {
+                        const html = buildResults(data);
+                        if (!html) { $results.addClass('hidden').empty(); return; }
+                        $results.html(html).removeClass('hidden');
+                    });
+            }, 300);
+        });
+
+        $input.on('keydown', function (e) {
+            if (e.key === 'Escape') {
+                $results.addClass('hidden').empty();
+                $input.val('').blur();
+            }
+        });
+    }
+
+    initSearch('#desktop-search-input', '#desktop-search-results');
+    initSearch('#mobile-search-input',  '#mobile-search-results');
+
+    // Close desktop results when clicking outside
+    $(document).on('click', function (e) {
+        if (!$(e.target).closest('#desktop-search-wrap').length) {
+            $('#desktop-search-results').addClass('hidden').empty();
+        }
+    });
+});

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,7 +8,7 @@
     <meta name="description" content="Random Movie Picker — find the perfect film for tonight.">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script>!function(){var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);if(m)document.documentElement.dataset.theme=m[1]}()</script>
-    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js'])
+    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js', 'resources/js/custom/search.js'])
     @yield('scripts', '')
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-204204564-1"></script>
     <script>
@@ -68,6 +68,13 @@
                     <a href="{{ route('auth.google') }}" class="text-sm px-3 py-1.5 rounded-lg border border-white/10 text-gray-300 hover:text-white hover:border-white/25 transition-all">Sign in</a>
                 @endauth
 
+                {{-- Search --}}
+                <div id="desktop-search-wrap" class="relative">
+                    <input id="desktop-search-input" type="text" placeholder="Search movies…" autocomplete="off"
+                        class="w-40 focus:w-56 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 transition-all duration-200">
+                    <div id="desktop-search-results" class="hidden absolute right-0 top-full mt-1 w-72 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden shadow-2xl z-50 divide-y divide-white/5"></div>
+                </div>
+
                 {{-- Theme toggle --}}
                 <button id="theme-toggle"
                     class="theme-toggle p-1.5 rounded-lg text-gray-500 hover:text-white hover:bg-white/5 transition-all"
@@ -89,6 +96,13 @@
     {{-- Mobile menu overlay --}}
     <div id="mobile-menu" class="hidden fixed inset-x-0 top-16 bottom-0 bg-[#0f0f0f] z-40 overflow-y-auto md:hidden">
         <div class="px-4 py-4 flex flex-col gap-1 min-h-full">
+
+            {{-- Search --}}
+            <div class="relative mb-2">
+                <input id="mobile-search-input" type="text" placeholder="Search movies…" autocomplete="off"
+                    class="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 transition-colors">
+                <div id="mobile-search-results" class="hidden mt-1 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden divide-y divide-white/5"></div>
+            </div>
 
             {{-- Primary actions --}}
             <a href="/movie?i=new" class="long-single flex items-center justify-between px-4 py-3.5 rounded-xl bg-white/5 hover:bg-white/8 text-white font-medium text-sm transition-colors">

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware('auth')->group(function () {
 Route::get('/userinput', UserInputController::class);
 
 Route::prefix('tmdb')->group(function () {
+    Route::get('/search/movies', [TmdbProxyController::class, 'searchMovies']);
     Route::get('/search/people', [TmdbProxyController::class, 'searchPeople']);
     Route::get('/people/{id}',   [TmdbProxyController::class, 'person']);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
                 'resources/js/custom/criteriaForm.js',
                 'resources/js/custom/trailerModal.js',
                 'resources/js/custom/watchlist.js',
+                'resources/js/custom/search.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Summary
- Search input added to desktop navbar (right side, expands on focus) and top of mobile menu
- Live autocomplete powered by TMDB search — debounced at 300ms, shows top 6 results
- Each result shows poster thumbnail, title, and year
- Clicking a result navigates directly to the movie detail page
- Escape key clears and closes results; clicking outside closes on desktop

## Test plan
- [x] Type a movie name in the desktop nav search — results appear as a dropdown
- [x] Type in the mobile menu search — results appear below the input
- [x] Clicking a result navigates to `/movie/{id}`
- [x] Escape clears the input and closes results
- [x] Clicking outside the search on desktop closes results