### PR TITLE
Add TV shows support to personal roulettes

### DIFF
--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -39,14 +39,16 @@ class UserRouletteController extends Controller
             }
 
             try {
-                $criteria         = $mapper->toCriteria(array_diff_key($roulette->tags, ['platform' => true]));
+                $tagsForPosters   = array_diff_key($roulette->tags, ['platform' => true]);
+                $isTv             = $roulette->media_type === 'tv';
+                $criteria         = $isTv ? $mapper->toCriteriaTv($tagsForPosters) : $mapper->toCriteria($tagsForPosters);
                 $criteria['page'] = 1;
-                $results          = $tmdb->discover($criteria, 'US');
+                $results          = $isTv ? $tmdb->discoverTv($criteria, 'US') : $tmdb->discover($criteria, 'US');
                 $paths            = [];
-                foreach ($results['results'] ?? [] as $movie) {
-                    if (!empty($movie['poster_path'])) {
-                        $paths[] = $movie['poster_path'];
-                        break;
+                foreach ($results['results'] ?? [] as $item) {
+                    if (!empty($item['poster_path'])) {
+                        $paths[] = $item['poster_path'];
+                        if (count($paths) >= 8) break;
                     }
                 }
                 $roulette->update(['poster_paths' => $paths ?: null]);
@@ -189,14 +191,18 @@ class UserRouletteController extends Controller
             return back()->withErrors(['tags' => 'At least one tag must be set.'])->withInput();
         }
 
+        $mediaType   = $request->input('media_type') === 'tv' ? 'tv' : 'movie';
+        $fingerprint = ($mediaType === 'tv' ? 'tv:' : '') . Roulette::fingerprintFromTags($tags);
+
         return [
             'name'            => $request->input('name'),
             'slug'            => Roulette::generateSlug($request->input('name'), $excludeId),
             'description'     => $request->input('description'),
             'tags'            => $tags,
-            'tag_fingerprint' => Roulette::fingerprintFromTags($tags),
+            'tag_fingerprint' => $fingerprint,
             'is_public'       => $request->boolean('is_public'),
             'row'             => $request->input('row') ?: null,
+            'media_type'      => $mediaType,
         ];
     }
 

--- a/resources/views/admin/roulettes/_table.blade.php
+++ b/resources/views/admin/roulettes/_table.blade.php
@@ -48,7 +48,7 @@
                         <div class="flex items-center gap-2">
                             <span class="text-white font-medium">{{ $roulette->name }}</span>
                             @if(($roulette->media_type ?? 'movie') === 'tv')
-                                <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20">TV</span>
+                                <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20">TV</span>
                             @else
                                 <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/5 text-gray-500 border border-white/10">Film</span>
                             @endif

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -47,10 +47,10 @@
                     </div>
                 </div>
                 {{-- TV Shows card --}}
-                <div class="bg-white/5 border border-white/8 rounded-2xl p-6 flex flex-col gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(96,165,250,0.1)]">
+                <div class="bg-white/5 border border-white/8 rounded-2xl p-6 flex flex-col gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
                     <div class="flex items-center gap-2.5">
-                        <div class="w-8 h-8 rounded-lg bg-blue-500/15 flex items-center justify-center flex-shrink-0">
-                            <svg class="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <div class="w-8 h-8 rounded-lg bg-accent/15 flex items-center justify-center flex-shrink-0">
+                            <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                                 <rect x="2" y="3" width="20" height="14" rx="2"/>
                                 <path d="M8 21h8M12 17v4"/>
                             </svg>

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -20,6 +20,23 @@
         @csrf
         @if($roulette) @method('PUT') @endif
 
+        {{-- Type --}}
+        <div>
+            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Type</label>
+            <div class="flex gap-4">
+                <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="media_type" value="movie" class="text-accent"
+                           {{ old('media_type', $roulette?->media_type ?? 'movie') === 'movie' ? 'checked' : '' }}>
+                    <span class="text-sm text-gray-300">Movie</span>
+                </label>
+                <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="media_type" value="tv" class="text-accent"
+                           {{ old('media_type', $roulette?->media_type) === 'tv' ? 'checked' : '' }}>
+                    <span class="text-sm text-gray-300">TV Show</span>
+                </label>
+            </div>
+        </div>
+
         {{-- Name --}}
         <div>
             <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>

--- a/resources/views/my-roulettes/index.blade.php
+++ b/resources/views/my-roulettes/index.blade.php
@@ -85,7 +85,7 @@
                                     <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-black/60 text-gray-400 border border-white/10">Private</span>
                                 @endif
                                 @if(($roulette->media_type ?? 'movie') === 'tv')
-                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/70 text-white">TV</span>
+                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/80 text-white">TV</span>
                                 @endif
                             </div>
 

--- a/resources/views/my-roulettes/index.blade.php
+++ b/resources/views/my-roulettes/index.blade.php
@@ -80,9 +80,14 @@
                                 <img src="{{ $logo }}" class="absolute top-2 right-2 h-5 drop-shadow-lg" loading="lazy">
                             @endif
 
-                            @if(!$roulette->is_public)
-                                <span class="absolute top-2 left-2 text-[10px] px-1.5 py-0.5 rounded-full bg-black/60 text-gray-400 border border-white/10">Private</span>
-                            @endif
+                            <div class="absolute top-2 left-2 flex gap-1">
+                                @if(!$roulette->is_public)
+                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-black/60 text-gray-400 border border-white/10">Private</span>
+                                @endif
+                                @if(($roulette->media_type ?? 'movie') === 'tv')
+                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/70 text-white">TV</span>
+                                @endif
+                            </div>
 
                             <div class="absolute bottom-0 left-0 right-0 p-3">
                                 @if($allTags->isNotEmpty())

--- a/resources/views/my-roulettes/manage.blade.php
+++ b/resources/views/my-roulettes/manage.blade.php
@@ -92,7 +92,14 @@
                             <tbody>
                                 @foreach($roulettes as $roulette)
                                     <tr class="border-b border-white/5 last:border-0 hover:bg-white/2 transition-colors">
-                                        <td class="py-3 px-4 text-white font-medium">{{ $roulette->name }}</td>
+                                        <td class="py-3 px-4">
+                                            <div class="flex items-center gap-2">
+                                                <span class="text-white font-medium">{{ $roulette->name }}</span>
+                                                @if(($roulette->media_type ?? 'movie') === 'tv')
+                                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20">TV</span>
+                                                @endif
+                                            </div>
+                                        </td>
                                         <td class="py-3 px-4 hidden sm:table-cell">
                                             <div class="flex flex-wrap gap-1">
                                                 @foreach(collect($roulette->tags)->flatten() as $tag)

--- a/resources/views/my-roulettes/manage.blade.php
+++ b/resources/views/my-roulettes/manage.blade.php
@@ -96,7 +96,7 @@
                                             <div class="flex items-center gap-2">
                                                 <span class="text-white font-medium">{{ $roulette->name }}</span>
                                                 @if(($roulette->media_type ?? 'movie') === 'tv')
-                                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20">TV</span>
+                                                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20">TV</span>
                                                 @endif
                                             </div>
                                         </td>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -15,7 +15,7 @@
     {{-- Title row --}}
     <div class="flex items-start justify-between gap-4 mb-4 flex-wrap">
         <div>
-            <span class="inline-block text-xs font-medium px-2.5 py-0.5 rounded-full bg-blue-500/15 text-blue-400 border border-blue-500/20 mb-2">TV Series</span>
+            <span class="inline-block text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20 mb-2">TV Series</span>
             <h1 class="text-3xl md:text-4xl font-bold text-white leading-tight">
                 {{ $tmdbInfo->name }}
             </h1>

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -99,7 +99,7 @@
 
                             {{-- Type badge --}}
                             @if(($item->type ?? 'movie') === 'tv')
-                                <div class="absolute top-2 right-2 bg-blue-600/80 text-white text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">TV</div>
+                                <div class="absolute top-2 right-2 bg-accent/80 text-white text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">TV</div>
                             @else
                                 <div class="absolute top-2 right-2 bg-black/50 text-white/50 text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none">Film</div>
                             @endif


### PR DESCRIPTION
## Summary

- Movie/TV type radio on the create/edit roulette form
- `media_type` saved on store and update; TV roulette fingerprints prefixed with `tv:` to avoid cross-contamination with movie poster reuse
- Poster fetching in `index()` uses `toCriteriaTv()` + `discoverTv()` for TV roulettes
- Blue TV badge on roulette cards (index page) and manage table rows

## Test plan

- [x] Create a personal roulette, select TV Show — verify it saves and rolls TV results
- [x] Edit an existing movie roulette, switch to TV — verify type updates correctly
- [x] TV roulette card shows blue TV badge on `/my-roulettes`
- [x] Manage page shows TV badge next to roulette name