### PR TITLE
Add TV trending and TV mood shortcuts to homepage

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -13,10 +13,17 @@ class HomeController extends Controller
             ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
             : [];
 
+        $normalize = fn(array $data) => array_merge($data, [
+            'results' => array_map(fn($s) => array_merge($s, [
+                'title'        => $s['name'] ?? $s['title'] ?? '',
+                'release_date' => $s['first_air_date'] ?? $s['release_date'] ?? '',
+            ]), $data['results'] ?? []),
+        ]);
+
         return view('home', [
-            'trendingDay'  => $tmdb->trending('day'),
-            'trendingWeek' => $tmdb->trending('week'),
-            'savedIds'     => $savedIds,
+            'trendingDay'   => $tmdb->trending('day'),
+            'tvTrendingDay' => $normalize($tmdb->trendingTv('day')),
+            'savedIds'      => $savedIds,
         ]);
     }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -140,6 +140,19 @@ class TmdbClient implements ApiMovie
         });
     }
 
+    public function trendingTv(string $period = 'day'): array
+    {
+        $period = $period === 'week' ? 'week' : 'day';
+        $ttl = $period === 'day'
+            ? now('UTC')->diffInSeconds(\Carbon\Carbon::tomorrow('UTC'))
+            : now('UTC')->diffInSeconds(\Carbon\Carbon::now('UTC')->startOfWeek(\Carbon\Carbon::MONDAY)->addWeek());
+
+        return Cache::remember("tmdb_trending_tv_{$period}", $ttl, function () use ($period) {
+            $response = $this->client->get("https://api.themoviedb.org/3/trending/tv/{$period}");
+            return json_decode($response->getBody()->getContents(), true);
+        });
+    }
+
     public function searchMovies(string $query): array
     {
         $url = 'https://api.themoviedb.org/3/search/movie?' . http_build_query([

--- a/resources/js/custom/carousel.js
+++ b/resources/js/custom/carousel.js
@@ -16,20 +16,18 @@ $(document).ready(function () {
         },
     };
 
-    if ($('.swiper-trending-day').length) {
-        new Swiper('.swiper-trending-day', sharedConfig);
-        let weekSwiper = null;
+    if ($('.swiper-trending-movies').length) {
+        new Swiper('.swiper-trending-movies', sharedConfig);
+        let tvSwiper = null;
 
-        $('#trend-day, #trend-week').on('click', function () {
-            const isWeek = this.id === 'trend-week';
-            $('#trend-day, #trend-week').toggleClass('active', false).addClass('text-gray-400');
+        $('#trend-movies, #trend-tv').on('click', function () {
+            const isTv = this.id === 'trend-tv';
+            $('#trend-movies, #trend-tv').toggleClass('active', false).addClass('text-gray-400');
             $(this).addClass('active').removeClass('text-gray-400');
-            $('#trend-label').text(isWeek ? 'This Week' : 'Today');
-            $('#trending-day').toggleClass('hidden', isWeek);
-            $('#trending-week').toggleClass('hidden', !isWeek);
-
-            if (isWeek && !weekSwiper) {
-                weekSwiper = new Swiper('.swiper-trending-week', sharedConfig);
+            $('#trending-movies').toggleClass('hidden', isTv);
+            $('#trending-tv').toggleClass('hidden', !isTv);
+            if (isTv && !tvSwiper) {
+                tvSwiper = new Swiper('.swiper-trending-tv', sharedConfig);
             }
         });
     }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -22,15 +22,15 @@
 
         <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(192,57,58,0.12)_0%,transparent_65%)]"></div>
         <div class="hero-fade absolute inset-0"></div>
-        <div class="relative z-10 text-center px-4 py-20 max-w-3xl mx-auto">
-            <h1 class="text-5xl md:text-7xl font-bold tracking-tight mb-5 leading-tight">
+        <div class="relative z-10 text-center px-4 py-12 sm:py-20 max-w-3xl mx-auto">
+            <h1 class="text-4xl sm:text-5xl md:text-7xl font-bold tracking-tight mb-4 sm:mb-5 leading-tight">
                 <span class="text-white">Random</span><br>
                 <span class="text-accent">Movie Picker</span>
             </h1>
-            <p class="text-gray-400 text-lg mb-10">For evenings when you can't decide what to watch.</p>
-            <div class="grid sm:grid-cols-2 gap-4 max-w-xl mx-auto w-full text-left">
+            <p class="text-gray-400 text-base sm:text-lg mb-7 sm:mb-10">For evenings when you can't decide what to watch.</p>
+            <div class="grid sm:grid-cols-2 gap-3 sm:gap-4 max-w-xl mx-auto w-full text-left">
                 {{-- Movies card --}}
-                <div class="bg-white/5 border border-white/8 rounded-2xl p-6 flex flex-col gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
+                <div class="bg-white/5 border border-white/8 rounded-2xl p-4 sm:p-6 flex flex-col gap-3 sm:gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
                     <div class="flex items-center gap-2.5">
                         <div class="w-8 h-8 rounded-lg bg-accent/15 flex items-center justify-center flex-shrink-0">
                             <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -47,7 +47,7 @@
                     </div>
                 </div>
                 {{-- TV Shows card --}}
-                <div class="bg-white/5 border border-white/8 rounded-2xl p-6 flex flex-col gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
+                <div class="bg-white/5 border border-white/8 rounded-2xl p-4 sm:p-6 flex flex-col gap-3 sm:gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
                     <div class="flex items-center gap-2.5">
                         <div class="w-8 h-8 rounded-lg bg-accent/15 flex items-center justify-center flex-shrink-0">
                             <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -68,14 +68,19 @@
     </section>
 
     {{-- Mood shortcuts --}}
-    <section class="max-w-7xl mx-auto px-4 py-12 border-b border-white/5">
-        <div class="section-header">
-            <h2 class="text-2xl font-bold text-white mb-3">I'm in the mood for…</h2>
-            <div class="section-divider"></div>
+    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12 border-b border-white/5">
+        <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+            <h2 class="text-xl sm:text-2xl font-bold text-white">I'm in the mood for…</h2>
+            <div class="flex gap-1 bg-white/5 p-1 rounded-lg shrink-0">
+                <button id="mood-movies-btn" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Movies</button>
+                <button id="mood-tv-btn" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">TV</button>
+            </div>
         </div>
-        <div class="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
+        <div class="section-divider"></div>
 
-            {{-- Funny --}}
+        {{-- Movie mood tiles --}}
+        <div id="mood-movies" class="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
+
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="35">
@@ -92,7 +97,6 @@
                 </button>
             </form>
 
-            {{-- Intense --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="53">
@@ -107,7 +111,6 @@
                 </button>
             </form>
 
-            {{-- Feel-good --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="18">
@@ -131,7 +134,6 @@
                 </button>
             </form>
 
-            {{-- Dark --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="27">
@@ -146,7 +148,6 @@
                 </button>
             </form>
 
-            {{-- Romantic --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="10749">
@@ -161,7 +162,6 @@
                 </button>
             </form>
 
-            {{-- Mindless --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="28">
@@ -177,29 +177,126 @@
             </form>
 
         </div>
+
+        {{-- TV mood tiles (genre IDs: Comedy 35, Crime 80, Drama 18, Mystery 9648, Action&Adventure 10759, Animation 16, Family 10751) --}}
+        <div id="mood-tv" class="hidden grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="35">
+                <input type="hidden" name="without_genres[]" value="16">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"/>
+                        <path d="M8 13s1.5 3 4 3 4-3 4-3"/>
+                        <line x1="9" y1="9" x2="9.01" y2="9"/>
+                        <line x1="15" y1="9" x2="15.01" y2="9"/>
+                    </svg>
+                    <span>Funny</span>
+                </button>
+            </form>
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="80">
+                <input type="hidden" name="with_genres[]" value="10759">
+                <input type="hidden" name="without_genres[]" value="35">
+                <input type="hidden" name="without_genres[]" value="16">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
+                    </svg>
+                    <span>Intense</span>
+                </button>
+            </form>
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="18">
+                <input type="hidden" name="vote_average_gte" value="7.5">
+                <input type="hidden" name="without_genres[]" value="80">
+                <input type="hidden" name="without_genres[]" value="9648">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"/>
+                        <line x1="12" y1="1" x2="12" y2="3"/>
+                        <line x1="12" y1="21" x2="12" y2="23"/>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                        <line x1="1" y1="12" x2="3" y2="12"/>
+                        <line x1="21" y1="12" x2="23" y2="12"/>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                    </svg>
+                    <span>Feel-good</span>
+                </button>
+            </form>
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="9648">
+                <input type="hidden" name="without_genres[]" value="35">
+                <input type="hidden" name="without_genres[]" value="16">
+                <input type="hidden" name="without_genres[]" value="10751">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+                    </svg>
+                    <span>Dark</span>
+                </button>
+            </form>
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="18">
+                <input type="hidden" name="without_genres[]" value="80">
+                <input type="hidden" name="without_genres[]" value="9648">
+                <input type="hidden" name="without_genres[]" value="10759">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
+                    </svg>
+                    <span>Romantic</span>
+                </button>
+            </form>
+
+            <form method="POST" action="/tv/pick?a=1">
+                @csrf
+                <input type="hidden" name="with_genres[]" value="10759">
+                <input type="hidden" name="without_genres[]" value="18">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10"/>
+                        <polygon points="10 8 16 12 10 16 10 8"/>
+                    </svg>
+                    <span>Mindless</span>
+                </button>
+            </form>
+
+        </div>
     </section>
 
     {{-- Trending --}}
-    <section class="max-w-7xl mx-auto px-4 py-12">
-        <div class="flex items-end justify-between mb-3">
-            <h2 class="text-2xl font-bold text-white">Trending <span id="trend-label">Today</span></h2>
-            <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                <button id="trend-day" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Today</button>
-                <button id="trend-week" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">This Week</button>
+    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12">
+        <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+            <h2 class="text-xl sm:text-2xl font-bold text-white">Trending Today</h2>
+            <div class="flex gap-1 bg-white/5 p-1 rounded-lg shrink-0">
+                <button id="trend-movies" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Movies</button>
+                <button id="trend-tv" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">TV</button>
             </div>
         </div>
         <div class="section-divider mb-4"></div>
 
-        <div id="trending-day">
-            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-day', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        <div id="trending-movies">
+            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-movies', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
         </div>
-        <div id="trending-week" class="hidden">
-            @include('includes.carousel', ['allMovies' => $trendingWeek, 'name' => 'swiper-trending-week', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        <div id="trending-tv" class="hidden">
+            @include('includes.carousel', ['allMovies' => $tvTrendingDay, 'name' => 'swiper-trending-tv', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds, 'linkBase' => 'tv'])
         </div>
     </section>
 
     {{-- About --}}
-    <section class="bg-white/[0.02] border-y border-white/5 py-16">
+    <section class="bg-white/[0.02] border-y border-white/5 py-10 sm:py-16">
         <div class="max-w-2xl mx-auto px-4 text-center">
             <h2 class="text-2xl font-bold text-white mb-3">About MoviePickr</h2>
             <div class="section-divider mb-6"></div>
@@ -248,5 +345,27 @@
             </div>
         </form>
     </section>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const moviesBtn   = document.getElementById('mood-movies-btn');
+        const tvBtn       = document.getElementById('mood-tv-btn');
+        const moviesTiles = document.getElementById('mood-movies');
+        const tvTiles     = document.getElementById('mood-tv');
+        if (!moviesBtn) return;
+        moviesBtn.addEventListener('click', function () {
+            moviesBtn.classList.add('active');    moviesBtn.classList.remove('text-gray-400');
+            tvBtn.classList.remove('active');     tvBtn.classList.add('text-gray-400');
+            moviesTiles.classList.remove('hidden');
+            tvTiles.classList.add('hidden');
+        });
+        tvBtn.addEventListener('click', function () {
+            tvBtn.classList.add('active');        tvBtn.classList.remove('text-gray-400');
+            moviesBtn.classList.remove('active'); moviesBtn.classList.add('text-gray-400');
+            tvTiles.classList.remove('hidden');
+            moviesTiles.classList.add('hidden');
+        });
+    });
+    </script>
 
 @endsection


### PR DESCRIPTION
## Summary
- Added Movies/TV toggle to the Trending Today carousel — switches between movie and TV trending without reloading
- Added Movies/TV toggle above mood shortcut tiles — TV tiles use TMDB TV genre IDs and post to `/tv/pick`
- Added `trendingTv()` to `TmdbClient` (hits `/trending/tv/{period}`, cached until midnight)
- Normalized TV trending data (name→title, first_air_date→release_date) in `HomeController` for the shared carousel component

## Mobile responsiveness
- Hero title scales down on small phones (`text-4xl` → `sm:text-5xl` → `md:text-7xl`)
- Hero inner padding reduced on mobile (`py-12 sm:py-20`)
- Hero cards tighter padding on mobile (`p-4 sm:p-6`)
- Section headers use `flex-wrap` so the title + toggle pill wrap instead of overflowing on narrow screens
- Section vertical padding reduced on mobile (`py-8 sm:py-12`)

## Test plan
- [x] Homepage loads without errors
- [x] Movies/TV trending toggle switches carousel correctly, lazy-inits TV swiper on first click
- [x] Movies/TV mood toggle shows correct set of tiles; TV tiles navigate to a TV show
- [x] Mobile layout looks clean at 375px and 320px viewports