### PR TITLE
Add TV shows to nav search

### DIFF
--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -62,8 +62,16 @@ class TmdbProxyController extends Controller
                 $show['release_date'] = $show['first_air_date'] ?? '';
                 return $show;
             })
-            ->take(6)
+            ->take(4)
             ->values()
+            ->map(function ($show) use ($tmdb) {
+                try {
+                    $status = $tmdb->tvStatus($show['id']);
+                    $show['tv_status']     = $status['status'];
+                    $show['last_air_date'] = $status['last_air_date'];
+                } catch (\Throwable) {}
+                return $show;
+            })
             ->all();
 
         return response()->json($results);

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -250,6 +250,21 @@ class TmdbClient implements ApiMovie
     }
 
     /**
+     * Lightweight show status — only status + last_air_date. Cached 24 h.
+     */
+    public function tvStatus(int $id): array
+    {
+        return Cache::remember('tmdb_tv_status_' . $id, now()->addHours(24), function () use ($id) {
+            $url  = 'https://api.themoviedb.org/3/tv/' . $id . '?' . http_build_query(['language' => 'en-US']);
+            $data = json_decode($this->client->get($url)->getBody()->getContents(), true);
+            return [
+                'status'        => $data['status'] ?? null,
+                'last_air_date' => $data['last_air_date'] ?? null,
+            ];
+        });
+    }
+
+    /**
      * Full TV show details with videos, credits, similar, and watch/providers appended.
      * Cached per show ID for 6 hours.
      */

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -8,14 +8,14 @@ $(document).ready(function () {
             .replace(/"/g, '&quot;');
     }
 
-    function buildResults(data) {
-        if (!data.length) return '';
-        return data.map(function (m) {
+    function buildSection(label, items, linkBase) {
+        if (!items.length) return '';
+        const rows = items.map(function (m) {
             const year   = m.release_date ? m.release_date.substring(0, 4) : '';
             const poster = m.poster_path
                 ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(m.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
                 : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
-            return `<a href="/movie/${m.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
+            return `<a href="/${linkBase}/${m.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
                 ${poster}
                 <div class="min-w-0">
                     <div class="text-sm text-white truncate">${escHtml(m.title)}</div>
@@ -23,6 +23,9 @@ $(document).ready(function () {
                 </div>
             </a>`;
         }).join('');
+        return `<div class="px-3 pt-2 pb-1">
+                    <span class="text-xs font-semibold uppercase tracking-widest text-gray-600">${label}</span>
+                </div>${rows}`;
     }
 
     function initSearch(inputSel, resultsSel) {
@@ -38,12 +41,17 @@ $(document).ready(function () {
             if (!q) { $results.addClass('hidden').empty(); return; }
 
             timer = setTimeout(function () {
-                $.getJSON('/tmdb/search/movies', { q: q })
-                    .done(function (data) {
-                        const html = buildResults(data);
-                        if (!html) { $results.addClass('hidden').empty(); return; }
-                        $results.html(html).removeClass('hidden');
-                    });
+                $.when(
+                    $.getJSON('/tmdb/search/movies', { q: q }),
+                    $.getJSON('/tmdb/search/tv',     { q: q })
+                ).done(function (movieResp, tvResp) {
+                    const movies = (movieResp[0] || []).slice(0, 4);
+                    const shows  = (tvResp[0]   || []).slice(0, 4);
+                    const html   = buildSection('Movies', movies, 'movie') +
+                                   buildSection('TV Shows', shows, 'tv');
+                    if (!html) { $results.addClass('hidden').empty(); return; }
+                    $results.html(html).removeClass('hidden');
+                });
             }, 300);
         });
 

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -8,10 +8,19 @@ $(document).ready(function () {
             .replace(/"/g, '&quot;');
     }
 
-    function buildSection(label, items, linkBase) {
+    function buildSection(label, items, linkBase, isTv) {
         if (!items.length) return '';
         const rows = items.map(function (m) {
-            const year   = m.release_date ? m.release_date.substring(0, 4) : '';
+            const year    = m.release_date ? m.release_date.substring(0, 4) : '';
+            const endYear = m.last_air_date ? m.last_air_date.substring(0, 4) : '';
+            const active  = ['Returning Series', 'In Production', 'Planned', 'Pilot'].includes(m.tv_status);
+            const sub     = isTv
+                ? (year
+                    ? (active
+                        ? year + ' – present'
+                        : endYear && endYear !== year ? year + ' – ' + endYear : 'Since ' + year)
+                    : 'TV Series')
+                : year;
             const poster = m.poster_path
                 ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(m.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
                 : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
@@ -19,7 +28,7 @@ $(document).ready(function () {
                 ${poster}
                 <div class="min-w-0">
                     <div class="text-sm text-white truncate">${escHtml(m.title)}</div>
-                    ${year ? `<div class="text-xs text-gray-500">${year}</div>` : ''}
+                    ${sub ? `<div class="text-xs text-gray-500">${sub}</div>` : ''}
                 </div>
             </a>`;
         }).join('');
@@ -47,8 +56,8 @@ $(document).ready(function () {
                 ).done(function (movieResp, tvResp) {
                     const movies = (movieResp[0] || []).slice(0, 4);
                     const shows  = (tvResp[0]   || []).slice(0, 4);
-                    const html   = buildSection('Movies', movies, 'movie') +
-                                   buildSection('TV Shows', shows, 'tv');
+                    const html   = buildSection('Movies', movies, 'movie', false) +
+                                   buildSection('TV Shows', shows, 'tv', true);
                     if (!html) { $results.addClass('hidden').empty(); return; }
                     $results.html(html).removeClass('hidden');
                 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -74,7 +74,7 @@
 
                 {{-- Search --}}
                 <div id="desktop-search-wrap" class="relative">
-                    <input id="desktop-search-input" type="text" placeholder="Search movies…" autocomplete="off"
+                    <input id="desktop-search-input" type="text" placeholder="Search…" autocomplete="off"
                         class="w-40 focus:w-56 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 transition-all duration-200">
                     <div id="desktop-search-results" class="hidden absolute right-0 top-full mt-1 w-72 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden shadow-2xl z-50 divide-y divide-white/5"></div>
                 </div>
@@ -103,7 +103,7 @@
 
             {{-- Search --}}
             <div class="relative mb-2">
-                <input id="mobile-search-input" type="text" placeholder="Search movies…" autocomplete="off"
+                <input id="mobile-search-input" type="text" placeholder="Search…" autocomplete="off"
                     class="w-full bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 transition-colors">
                 <div id="mobile-search-results" class="hidden mt-1 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden divide-y divide-white/5"></div>
             </div>


### PR DESCRIPTION
## Summary
- Search bar now queries movies and TV shows simultaneously via two parallel TMDB requests
- Results shown in two labeled sections: **Movies** and **TV Shows** (up to 4 each)
- Movie results link to `/movie/{id}`, TV results link to `/tv/{id}`
- TV show results display date range instead of a misleading single year:
  - Active shows: `1947 – present`
  - Ended shows: `2011 – 2019`
  - Falls back to `Since YEAR` if status unavailable
- Status and last air date fetched via a lightweight cached TMDB call (24h cache) enriched server-side in the proxy
- Updated search placeholder from "Search movies…" to "Search…" on desktop and mobile

## Test plan
- [x] Typing in nav search shows both Movies and TV Shows sections
- [x] Active show (e.g. Meet the Press) shows `1947 – present`
- [x] Ended show (e.g. Breaking Bad) shows `2008 – 2013`
- [x] Movie result shows release year only (e.g. Inception → 2010)
- [x] Clicking a movie result navigates to `/movie/{id}`
- [x] Clicking a TV result navigates to `/tv/{id}`
- [x] Escape key clears and closes the dropdown
- [x] Works on mobile search input too