### PR TITLE
Add seasons row to TV show detail page

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -15,7 +15,13 @@ class MovieController extends Controller
     {
         $movieId  = $request->route('id');
         $country  = $movieService->getUserCountry();
-        $tmdbInfo = $tmdb->movie($movieId);
+
+        try {
+            $tmdbInfo = $tmdb->movie($movieId);
+            if (empty($tmdbInfo->id)) abort(404);
+        } catch (\Throwable) {
+            abort(404);
+        }
         $omdbInfo = $omdb->movie($tmdbInfo->imdb_id);
 
         $watchProviders = isset($tmdbInfo->{'watch/providers'}->results->$country->flatrate)

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\TmdbClient;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class PersonController extends Controller
+{
+    public function __invoke(Request $request, TmdbClient $tmdb): View
+    {
+        $id = (int) $request->route('id');
+
+        try {
+            $person = $tmdb->personDetail($id);
+            if (empty($person->id)) abort(404);
+        } catch (\Throwable) {
+            abort(404);
+        }
+
+        $credits = collect($person->combined_credits->cast ?? [])
+            ->merge(collect($person->combined_credits->crew ?? []))
+            ->unique(fn($c) => ($c->media_type ?? '') . ($c->id ?? ''))
+            ->sortByDesc('vote_count')
+            ->values();
+
+        // Known for: top 8 by popularity, deduplicated by title ID
+        $knownFor = collect($person->combined_credits->cast ?? [])
+            ->sortByDesc('popularity')
+            ->unique('id')
+            ->take(8)
+            ->values();
+
+        // Full filmography split by type, sorted by date desc
+        $movies = $credits->filter(fn($c) => ($c->media_type ?? '') === 'movie')
+            ->sortByDesc(fn($c) => $c->release_date ?? '')
+            ->values();
+
+        $tvShows = $credits->filter(fn($c) => ($c->media_type ?? '') === 'tv')
+            ->sortByDesc(fn($c) => $c->first_air_date ?? '')
+            ->values();
+
+        return view('person', compact('person', 'knownFor', 'movies', 'tvShows'));
+    }
+}

--- a/app/Http/Controllers/TvEpisodeController.php
+++ b/app/Http/Controllers/TvEpisodeController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\TmdbClient;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class TvEpisodeController extends Controller
+{
+    public function __invoke(Request $request, TmdbClient $tmdb): View
+    {
+        $showId        = (int) $request->route('id');
+        $seasonNumber  = (int) $request->route('season');
+        $episodeNumber = (int) $request->route('episode');
+
+        try {
+            $show    = $tmdb->tvShow($showId);
+            $season  = $tmdb->tvSeason($showId, $seasonNumber);
+            $episode = $tmdb->tvEpisode($showId, $seasonNumber, $episodeNumber);
+            if (empty($show->id) || empty($episode->id)) abort(404);
+        } catch (\Throwable) {
+            abort(404);
+        }
+
+        $episodes = collect($season->episodes ?? []);
+        $prevEpisode = $episodes->firstWhere('episode_number', $episodeNumber - 1);
+        $nextEpisode = $episodes->firstWhere('episode_number', $episodeNumber + 1);
+
+        return view('tv.episode', compact(
+            'show', 'season', 'episode',
+            'showId', 'seasonNumber', 'episodeNumber',
+            'prevEpisode', 'nextEpisode'
+        ));
+    }
+}

--- a/app/Http/Controllers/TvSeasonController.php
+++ b/app/Http/Controllers/TvSeasonController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\TmdbClient;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class TvSeasonController extends Controller
+{
+    public function __invoke(Request $request, TmdbClient $tmdb): View
+    {
+        $showId       = (int) $request->route('id');
+        $seasonNumber = (int) $request->route('season');
+
+        try {
+            $show   = $tmdb->tvShow($showId);
+            $season = $tmdb->tvSeason($showId, $seasonNumber);
+            if (empty($show->id) || empty($season->id)) abort(404);
+        } catch (\Throwable) {
+            abort(404);
+        }
+
+        return view('tv.season', compact('show', 'season', 'showId', 'seasonNumber'));
+    }
+}

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -13,7 +13,13 @@ class TvShowController extends Controller
     {
         $showId  = $request->route('id');
         $country = $movieService->getUserCountry();
-        $tmdbInfo = $tmdb->tvShow($showId);
+
+        try {
+            $tmdbInfo = $tmdb->tvShow($showId);
+            if (empty($tmdbInfo->id)) abort(404);
+        } catch (\Throwable) {
+            abort(404);
+        }
 
         $watchProviders = isset($tmdbInfo->{'watch/providers'}->results->$country->flatrate)
             ? $tmdbInfo->{'watch/providers'}->results->$country

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -183,6 +183,18 @@ class TmdbClient implements ApiMovie
         });
     }
 
+    /**
+     * Full person detail with combined_credits. Cached 6 hours.
+     */
+    public function personDetail(int $id): object
+    {
+        return Cache::remember('tmdb_person_detail_' . $id, now()->addHours(6), function () use ($id) {
+            $url = 'https://api.themoviedb.org/3/person/' . $id . '?'
+                . http_build_query(['language' => 'en-US', 'append_to_response' => 'combined_credits,images']);
+            return json_decode($this->client->get($url)->getBody()->getContents());
+        });
+    }
+
     public function collection(int $id): object
     {
         return Cache::remember('tmdb_collection_' . $id, now()->addWeek(), function () use ($id) {
@@ -261,6 +273,30 @@ class TmdbClient implements ApiMovie
                 'status'        => $data['status'] ?? null,
                 'last_air_date' => $data['last_air_date'] ?? null,
             ];
+        });
+    }
+
+    /**
+     * Episode detail — guest stars, crew, images. Cached 6 hours.
+     */
+    public function tvEpisode(int $showId, int $seasonNumber, int $episodeNumber): object
+    {
+        return Cache::remember("tmdb_tv_{$showId}_s{$seasonNumber}_e{$episodeNumber}", now()->addHours(6), function () use ($showId, $seasonNumber, $episodeNumber) {
+            $url = "https://api.themoviedb.org/3/tv/{$showId}/season/{$seasonNumber}/episode/{$episodeNumber}?"
+                . http_build_query(['language' => 'en-US', 'append_to_response' => 'credits,images']);
+            return json_decode($this->client->get($url)->getBody()->getContents());
+        });
+    }
+
+    /**
+     * Season detail — all episodes, cast, and crew. Cached 6 hours.
+     */
+    public function tvSeason(int $showId, int $seasonNumber): object
+    {
+        return Cache::remember("tmdb_tv_{$showId}_season_{$seasonNumber}", now()->addHours(6), function () use ($showId, $seasonNumber) {
+            $url = "https://api.themoviedb.org/3/tv/{$showId}/season/{$seasonNumber}?"
+                . http_build_query(['language' => 'en-US', 'append_to_response' => 'credits']);
+            return json_decode($this->client->get($url)->getBody()->getContents());
         });
     }
 

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -37,6 +37,25 @@ $(document).ready(function () {
                 </div>${rows}`;
     }
 
+    function buildPeopleSection(people) {
+        if (!people.length) return '';
+        const rows = people.map(function (p) {
+            const photo = p.profile_path
+                ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(p.profile_path)}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" loading="lazy">`
+                : `<div class="w-8 h-8 rounded-full bg-white/5 flex-shrink-0 flex items-center justify-center text-gray-600 text-xs font-bold">${escHtml(p.name.charAt(0).toUpperCase())}</div>`;
+            return `<a href="/person/${p.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
+                ${photo}
+                <div class="min-w-0">
+                    <div class="text-sm text-white truncate">${escHtml(p.name)}</div>
+                    ${p.known_for_department ? `<div class="text-xs text-gray-500">${escHtml(p.known_for_department)}</div>` : ''}
+                </div>
+            </a>`;
+        }).join('');
+        return `<div class="px-3 pt-2 pb-1">
+                    <span class="text-xs font-semibold uppercase tracking-widest text-gray-600">People</span>
+                </div>${rows}`;
+    }
+
     function initSearch(inputSel, resultsSel) {
         const $input   = $(inputSel);
         const $results = $(resultsSel);
@@ -52,12 +71,15 @@ $(document).ready(function () {
             timer = setTimeout(function () {
                 $.when(
                     $.getJSON('/tmdb/search/movies', { q: q }),
-                    $.getJSON('/tmdb/search/tv',     { q: q })
-                ).done(function (movieResp, tvResp) {
-                    const movies = (movieResp[0] || []).slice(0, 4);
-                    const shows  = (tvResp[0]   || []).slice(0, 4);
+                    $.getJSON('/tmdb/search/tv',     { q: q }),
+                    $.getJSON('/tmdb/search/people', { q: q })
+                ).done(function (movieResp, tvResp, peopleResp) {
+                    const movies = (movieResp[0]  || []).slice(0, 3);
+                    const shows  = (tvResp[0]     || []).slice(0, 3);
+                    const people = (peopleResp[0] || []).slice(0, 3);
                     const html   = buildSection('Movies', movies, 'movie', false) +
-                                   buildSection('TV Shows', shows, 'tv', true);
+                                   buildSection('TV Shows', shows, 'tv', true) +
+                                   buildPeopleSection(people);
                     if (!html) { $results.addClass('hidden').empty(); return; }
                     $results.html(html).removeClass('hidden');
                 });

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -2,13 +2,18 @@
 @section('page_title', '404 — MoviePickr')
 @section('content')
 <div class="min-h-[70vh] flex items-center justify-center px-4">
-    <div class="text-center">
+    <div class="text-center max-w-md">
         <p class="text-8xl font-bold text-accent mb-4">404</p>
         <h1 class="text-2xl font-bold text-white mb-2">Page not found</h1>
-        <p class="text-gray-500 mb-8">We couldn't find what you were looking for.</p>
-        <div class="flex flex-wrap gap-3 justify-center">
+        <p class="text-gray-500 mb-8">That movie, show, or person doesn't seem to exist — or the link is broken.</p>
+        <div class="flex flex-wrap gap-3 justify-center mb-4">
             <a href="/movie?i=new" class="btn-accent">Random Movie</a>
-            <a href="/criteria" class="btn-secondary">Set Criteria</a>
+            <a href="/tv/pick?i=new" class="btn-accent">Random TV Show</a>
+        </div>
+        <div class="flex flex-wrap gap-3 justify-center">
+            <a href="/criteria" class="btn-secondary">Movie Criteria</a>
+            <a href="/tv/criteria" class="btn-secondary">TV Criteria</a>
+            <a href="/" class="btn-secondary">Home</a>
         </div>
     </div>
 </div>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -106,6 +106,23 @@
                 </p>
             </div>
 
+            {{-- Director --}}
+            @php
+                $directors = collect($tmdbInfo->credits->crew ?? [])->where('job', 'Director')->values();
+            @endphp
+            @if($directors->isNotEmpty())
+            <div class="flex flex-wrap gap-x-6 gap-y-2">
+                <div>
+                    <p class="text-xs text-gray-600 uppercase tracking-widest mb-1">Director</p>
+                    <div class="flex flex-wrap gap-x-3">
+                        @foreach($directors as $d)
+                            <a href="{{ route('person', $d->id) }}" class="text-sm text-white font-medium hover:text-accent transition-colors">{{ $d->name }}</a>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+            @endif
+
         </div>
     </div>
 
@@ -123,7 +140,7 @@
                 <ul class="cast-list flex flex-col gap-1.5">
                     @foreach ($tmdbInfo->credits->cast as $member)
                         <li class="text-sm text-gray-300">
-                            {{ $member->name }}
+                            <a href="{{ route('person', $member->id) }}" class="hover:text-white transition-colors">{{ $member->name }}</a>
                             @if($member->character)
                                 <span class="text-gray-500"> as {{ $member->character }}</span>
                             @endif
@@ -142,7 +159,7 @@
                 <ul class="crew-list flex flex-col gap-1.5">
                     @foreach ($tmdbInfo->credits->crew as $member)
                         <li class="text-sm text-gray-300">
-                            <span class="text-gray-500">{{ $member->job }}:</span> {{ $member->name }}
+                            <span class="text-gray-500">{{ $member->job }}:</span> <a href="{{ route('person', $member->id) }}" class="hover:text-white transition-colors">{{ $member->name }}</a>
                         </li>
                     @endforeach
                 </ul>

--- a/resources/views/person.blade.php
+++ b/resources/views/person.blade.php
@@ -1,0 +1,231 @@
+@extends('layouts.app')
+@section('page_title', ($person->name ?? 'Person').' — MoviePickr')
+@section('content')
+<div class="max-w-4xl mx-auto px-4 py-8">
+
+    {{-- Header --}}
+    <div class="flex gap-6 mb-8">
+        <div class="flex-shrink-0 w-32 sm:w-44">
+            @if(!empty($person->profile_path))
+                <img src="https://image.tmdb.org/t/p/w300{{ $person->profile_path }}"
+                     alt="{{ $person->name }}"
+                     class="w-full rounded-xl border border-white/10 object-cover">
+            @else
+                <div class="w-full aspect-[2/3] rounded-xl bg-white/[0.03] border border-white/5 flex items-center justify-center text-gray-600 text-3xl font-bold">
+                    {{ strtoupper(substr($person->name ?? '?', 0, 1)) }}
+                </div>
+            @endif
+        </div>
+        <div class="min-w-0 flex flex-col justify-center">
+            @if(!empty($person->known_for_department))
+                <span class="inline-block text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20 mb-2 w-fit">{{ $person->known_for_department }}</span>
+            @endif
+            <h1 class="text-2xl sm:text-3xl font-bold text-white leading-tight">{{ $person->name }}</h1>
+            <div class="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-sm text-gray-500">
+                @if(!empty($person->birthday))
+                    <span>Born {{ \Carbon\Carbon::parse($person->birthday)->format('M j, Y') }}
+                        @if(empty($person->deathday))
+                            ({{ \Carbon\Carbon::parse($person->birthday)->age }} years old)
+                        @endif
+                    </span>
+                @endif
+                @if(!empty($person->deathday))
+                    <span>Died {{ \Carbon\Carbon::parse($person->deathday)->format('M j, Y') }}</span>
+                @endif
+                @if(!empty($person->place_of_birth))
+                    <span>{{ $person->place_of_birth }}</span>
+                @endif
+            </div>
+            {{-- External links --}}
+            @if(!empty($person->imdb_id) || !empty($person->homepage))
+            <div class="flex flex-wrap gap-2 mt-3">
+                @if(!empty($person->imdb_id))
+                    <a href="https://www.imdb.com/name/{{ $person->imdb_id }}" target="_blank"
+                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 hover:bg-yellow-500/20 transition-colors">
+                        IMDb
+                    </a>
+                @endif
+                @if(!empty($person->homepage))
+                    <a href="{{ $person->homepage }}" target="_blank"
+                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 transition-colors">
+                        Website
+                    </a>
+                @endif
+            </div>
+            @endif
+
+            {{-- Discover buttons --}}
+            <div class="flex flex-wrap gap-2 mt-3">
+                @if($movies->isNotEmpty())
+                <form method="POST" action="/movie">
+                    @csrf
+                    <input type="hidden" name="with_cast[]" value="{{ $person->id }}">
+                    <button type="submit" class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll a movie with {{ $person->name }}
+                    </button>
+                </form>
+                @endif
+                @if($tvShows->isNotEmpty())
+                <form method="POST" action="/tv/pick">
+                    @csrf
+                    <input type="hidden" name="with_people[]" value="{{ $person->id }}">
+                    <button type="submit" class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll a TV show with {{ $person->name }}
+                    </button>
+                </form>
+                @endif
+            </div>
+
+            @if(!empty($person->biography))
+                <p class="text-gray-400 text-sm mt-3 leading-relaxed line-clamp-4">{{ $person->biography }}</p>
+                @if(strlen($person->biography) > 300)
+                    <button onclick="this.previousElementSibling.classList.toggle('line-clamp-4'); this.textContent = this.textContent === 'Show more' ? 'Show less' : 'Show more'"
+                            class="text-xs text-accent mt-1 hover:underline">Show more</button>
+                @endif
+            @endif
+        </div>
+    </div>
+
+    {{-- Photo strip --}}
+    @php $photos = collect($person->images->profiles ?? [])->sortByDesc('vote_average')->skip(1)->take(6)->values(); @endphp
+    @if($photos->isNotEmpty())
+    <div class="flex gap-2 overflow-x-auto pb-2 scrollbar-hide mb-8">
+        @foreach($photos as $photo)
+        <div class="flex-shrink-0 w-20 aspect-[2/3] rounded-lg overflow-hidden border border-white/5">
+            <img src="https://image.tmdb.org/t/p/w185{{ $photo->file_path }}"
+                 alt="{{ $person->name }}"
+                 class="w-full h-full object-cover" loading="lazy">
+        </div>
+        @endforeach
+    </div>
+    @endif
+
+    {{-- Known for --}}
+    @if($knownFor->isNotEmpty())
+    <div class="mb-10">
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Known For</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
+            @foreach($knownFor as $item)
+            @php
+                $link  = ($item->media_type ?? '') === 'tv' ? '/tv/'.$item->id : '/movie/'.$item->id;
+                $title = $item->title ?? $item->name ?? '';
+                $year  = substr($item->release_date ?? $item->first_air_date ?? '', 0, 4);
+            @endphp
+            <a href="{{ $link }}" class="flex-shrink-0 w-28 group">
+                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] group-hover:ring-1 group-hover:ring-accent/50 transition-all">
+                    @if(!empty($item->poster_path))
+                        <img src="https://image.tmdb.org/t/p/w185{{ $item->poster_path }}"
+                             alt="{{ $title }}"
+                             class="w-full h-full object-cover" loading="lazy">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">{{ $title }}</div>
+                    @endif
+                </div>
+                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug group-hover:text-white transition-colors truncate">{{ $title }}</p>
+                @if($year)<p class="text-xs text-gray-600">{{ $year }}</p>@endif
+            </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- Filmography --}}
+    @php $showMovies = $movies->isNotEmpty(); $showTv = $tvShows->isNotEmpty(); @endphp
+    @if($showMovies || $showTv)
+    <div>
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Filmography</h2>
+            <div class="section-divider"></div>
+        </div>
+
+        {{-- Tabs --}}
+        @if($showMovies && $showTv)
+        <div class="flex gap-1 mb-4">
+            <button id="tab-movies" onclick="switchTab('movies')"
+                class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors bg-white/10 text-white">Movies ({{ $movies->count() }})</button>
+            <button id="tab-tv" onclick="switchTab('tv')"
+                class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors text-gray-400 hover:text-white">TV Shows ({{ $tvShows->count() }})</button>
+        </div>
+        @endif
+
+        {{-- Movies list --}}
+        @if($showMovies)
+        <div id="list-movies">
+            <div class="flex flex-col divide-y divide-white/5">
+                @foreach($movies as $item)
+                @php $year = substr($item->release_date ?? '', 0, 4); @endphp
+                <a href="/movie/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
+                    <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
+                    <div class="w-8 h-12 flex-shrink-0 rounded overflow-hidden bg-white/[0.03]">
+                        @if(!empty($item->poster_path))
+                            <img src="https://image.tmdb.org/t/p/w92{{ $item->poster_path }}" class="w-full h-full object-cover" loading="lazy">
+                        @endif
+                    </div>
+                    <div class="min-w-0">
+                        <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->title ?? '' }}</p>
+                        @if(!empty($item->character))
+                            <p class="text-xs text-gray-600 truncate">as {{ $item->character }}</p>
+                        @elseif(!empty($item->job))
+                            <p class="text-xs text-gray-600 truncate">{{ $item->job }}</p>
+                        @endif
+                    </div>
+                    @if(!empty($item->vote_average) && $item->vote_average > 0)
+                        <span class="ml-auto text-xs text-gray-600 flex-shrink-0">★ {{ number_format($item->vote_average, 1) }}</span>
+                    @endif
+                </a>
+                @endforeach
+            </div>
+        </div>
+        @endif
+
+        {{-- TV list --}}
+        @if($showTv)
+        <div id="list-tv" @if($showMovies && $showTv) style="display:none" @endif>
+            <div class="flex flex-col divide-y divide-white/5">
+                @foreach($tvShows as $item)
+                @php $year = substr($item->first_air_date ?? '', 0, 4); @endphp
+                <a href="/tv/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
+                    <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
+                    <div class="w-8 h-12 flex-shrink-0 rounded overflow-hidden bg-white/[0.03]">
+                        @if(!empty($item->poster_path))
+                            <img src="https://image.tmdb.org/t/p/w92{{ $item->poster_path }}" class="w-full h-full object-cover" loading="lazy">
+                        @endif
+                    </div>
+                    <div class="min-w-0">
+                        <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->name ?? '' }}</p>
+                        @if(!empty($item->character))
+                            <p class="text-xs text-gray-600 truncate">as {{ $item->character }}</p>
+                        @elseif(!empty($item->job))
+                            <p class="text-xs text-gray-600 truncate">{{ $item->job }}</p>
+                        @endif
+                    </div>
+                    @if(!empty($item->vote_average) && $item->vote_average > 0)
+                        <span class="ml-auto text-xs text-gray-600 flex-shrink-0">★ {{ number_format($item->vote_average, 1) }}</span>
+                    @endif
+                </a>
+                @endforeach
+            </div>
+        </div>
+        @endif
+    </div>
+    @endif
+
+</div>
+
+@if($showMovies && $showTv)
+<script>
+function switchTab(tab) {
+    document.getElementById('list-movies').style.display = tab === 'movies' ? '' : 'none';
+    document.getElementById('list-tv').style.display     = tab === 'tv'     ? '' : 'none';
+    document.getElementById('tab-movies').className = 'px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ' +
+        (tab === 'movies' ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white');
+    document.getElementById('tab-tv').className = 'px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ' +
+        (tab === 'tv' ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white');
+}
+</script>
+@endif
+
+@endsection

--- a/resources/views/person.blade.php
+++ b/resources/views/person.blade.php
@@ -57,7 +57,7 @@
             {{-- Discover buttons --}}
             <div class="flex flex-wrap gap-2 mt-3">
                 @if($movies->isNotEmpty())
-                <form method="POST" action="/movie">
+                <form method="POST" action="/movie?a=1">
                     @csrf
                     <input type="hidden" name="with_cast[]" value="{{ $person->id }}">
                     <button type="submit" class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
@@ -66,7 +66,7 @@
                 </form>
                 @endif
                 @if($tvShows->isNotEmpty())
-                <form method="POST" action="/tv/pick">
+                <form method="POST" action="/tv/pick?a=1">
                     @csrf
                     <input type="hidden" name="with_people[]" value="{{ $person->id }}">
                     <button type="submit" class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">

--- a/resources/views/roulettes.blade.php
+++ b/resources/views/roulettes.blade.php
@@ -76,6 +76,15 @@
             t.addEventListener('click', function () { activate(t.dataset.tab); });
         });
     })();
+
+    document.querySelectorAll('.roulette-row').forEach(function (el) {
+        el.addEventListener('wheel', function (e) {
+            if (e.deltaY !== 0) {
+                e.preventDefault();
+                window.scrollBy(0, e.deltaY);
+            }
+        }, { passive: false });
+    });
 </script>
 
 @endsection

--- a/resources/views/tv/episode.blade.php
+++ b/resources/views/tv/episode.blade.php
@@ -1,0 +1,158 @@
+@extends('layouts.app')
+@section('page_title', ($show->name ?? 'TV Show').' — S'.str_pad($seasonNumber,2,'0',STR_PAD_LEFT).'E'.str_pad($episodeNumber,2,'0',STR_PAD_LEFT).' — MoviePickr')
+@section('content')
+<div class="max-w-4xl mx-auto px-4 py-8">
+
+    {{-- Breadcrumb --}}
+    <div class="flex items-center gap-2 text-sm text-gray-500 mb-6 flex-wrap">
+        <a href="/tv/{{ $showId }}" class="hover:text-white transition-colors">{{ $show->name ?? 'Show' }}</a>
+        <span class="text-gray-700">›</span>
+        <a href="{{ route('tv.season', ['id' => $showId, 'season' => $seasonNumber]) }}" class="hover:text-white transition-colors">{{ $season->name ?? 'Season '.$seasonNumber }}</a>
+        <span class="text-gray-700">›</span>
+        <span class="text-gray-300">Episode {{ $episodeNumber }}</span>
+    </div>
+
+    {{-- Still image --}}
+    @if(!empty($episode->still_path))
+    <div class="rounded-xl overflow-hidden border border-white/10 mb-6 aspect-video">
+        <img src="https://image.tmdb.org/t/p/original{{ $episode->still_path }}"
+             alt="{{ $episode->name }}"
+             class="w-full h-full object-cover">
+    </div>
+    @endif
+
+    {{-- Title + meta --}}
+    <div class="mb-6">
+        <div class="flex items-center gap-2 mb-2 flex-wrap">
+            <span class="text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20">
+                S{{ str_pad($seasonNumber,2,'0',STR_PAD_LEFT) }}E{{ str_pad($episodeNumber,2,'0',STR_PAD_LEFT) }}
+            </span>
+            @if(!empty($episode->vote_average) && $episode->vote_average > 0)
+                <span class="text-xs text-gray-500">★ {{ number_format($episode->vote_average, 1) }}</span>
+            @endif
+        </div>
+        <h1 class="text-2xl sm:text-3xl font-bold text-white leading-tight">{{ $episode->name ?? 'Episode '.$episodeNumber }}</h1>
+        <div class="flex items-center gap-3 mt-1.5 text-sm text-gray-500 flex-wrap">
+            @if(!empty($episode->air_date))
+                <span>{{ \Carbon\Carbon::parse($episode->air_date)->format('M j, Y') }}</span>
+            @endif
+            @if(!empty($episode->runtime))
+                <span>· {{ $episode->runtime }} min</span>
+            @endif
+        </div>
+        @if(!empty($episode->overview))
+            <p class="text-gray-400 mt-4 leading-relaxed">{{ $episode->overview }}</p>
+        @endif
+    </div>
+
+    {{-- Crew highlights (Director, Writer) --}}
+    @php
+        $crew = collect($episode->credits->crew ?? []);
+        $directors = $crew->where('job', 'Director')->values();
+        $writers   = $crew->whereIn('job', ['Writer', 'Teleplay', 'Story', 'Screenplay'])->values();
+    @endphp
+    @if($directors->isNotEmpty() || $writers->isNotEmpty())
+    <div class="flex flex-wrap gap-6 mb-8 text-sm">
+        @if($directors->isNotEmpty())
+        <div>
+            <p class="text-xs text-gray-600 uppercase tracking-widest mb-1">Director</p>
+            @foreach($directors as $d)
+                <a href="{{ route('person', $d->id) }}" class="text-white font-medium hover:text-accent transition-colors">{{ $d->name }}</a>
+            @endforeach
+        </div>
+        @endif
+        @if($writers->isNotEmpty())
+        <div>
+            <p class="text-xs text-gray-600 uppercase tracking-widest mb-1">Writer</p>
+            @foreach($writers as $w)
+                <a href="{{ route('person', $w->id) }}" class="text-white font-medium hover:text-accent transition-colors">{{ $w->name }}</a>
+            @endforeach
+        </div>
+        @endif
+    </div>
+    @endif
+
+    {{-- Guest stars --}}
+    @if(!empty($episode->credits->guest_stars) && count((array)$episode->credits->guest_stars) > 0)
+    @php $guests = array_slice((array) $episode->credits->guest_stars, 0, 12); @endphp
+    <div class="mb-8">
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Guest Stars</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            @foreach($guests as $guest)
+            <a href="{{ route('person', $guest->id) }}" class="flex items-center gap-3 rounded-xl bg-white/[0.03] border border-white/5 p-2.5 hover:bg-white/[0.07] transition-colors">
+                <div class="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden bg-white/[0.05]">
+                    @if(!empty($guest->profile_path))
+                        <img src="https://image.tmdb.org/t/p/w92{{ $guest->profile_path }}"
+                             alt="{{ $guest->name }}" class="w-full h-full object-cover">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-sm font-bold">
+                            {{ strtoupper(substr($guest->name, 0, 1)) }}
+                        </div>
+                    @endif
+                </div>
+                <div class="min-w-0">
+                    <p class="text-xs text-white font-medium truncate">{{ $guest->name }}</p>
+                    @if(!empty($guest->character))
+                        <p class="text-xs text-gray-600 truncate">{{ $guest->character }}</p>
+                    @endif
+                </div>
+            </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- Cast --}}
+    @if(!empty($episode->credits->cast) && count((array)$episode->credits->cast) > 0)
+    @php $cast = array_slice((array) $episode->credits->cast, 0, 8); @endphp
+    <div class="mb-8">
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Cast</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            @foreach($cast as $member)
+            <a href="{{ route('person', $member->id) }}" class="flex items-center gap-3 rounded-xl bg-white/[0.03] border border-white/5 p-2.5 hover:bg-white/[0.07] transition-colors">
+                <div class="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden bg-white/[0.05]">
+                    @if(!empty($member->profile_path))
+                        <img src="https://image.tmdb.org/t/p/w92{{ $member->profile_path }}"
+                             alt="{{ $member->name }}" class="w-full h-full object-cover">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-sm font-bold">
+                            {{ strtoupper(substr($member->name, 0, 1)) }}
+                        </div>
+                    @endif
+                </div>
+                <div class="min-w-0">
+                    <p class="text-xs text-white font-medium truncate">{{ $member->name }}</p>
+                    @if(!empty($member->character))
+                        <p class="text-xs text-gray-600 truncate">{{ $member->character }}</p>
+                    @endif
+                </div>
+            </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- Prev / Next episode navigation --}}
+    <div class="flex items-center justify-between gap-4 border-t border-white/5 pt-6">
+        <div>
+            @if($prevEpisode)
+                <a href="{{ route('tv.episode', ['id' => $showId, 'season' => $seasonNumber, 'episode' => $prevEpisode->episode_number]) }}"
+                   class="btn-secondary text-sm">← E{{ $prevEpisode->episode_number }} {{ $prevEpisode->name }}</a>
+            @endif
+        </div>
+        <div>
+            @if($nextEpisode)
+                <a href="{{ route('tv.episode', ['id' => $showId, 'season' => $seasonNumber, 'episode' => $nextEpisode->episode_number]) }}"
+                   class="btn-secondary text-sm">E{{ $nextEpisode->episode_number }} {{ $nextEpisode->name }} →</a>
+        @endif
+        </div>
+    </div>
+
+</div>
+@endsection

--- a/resources/views/tv/season.blade.php
+++ b/resources/views/tv/season.blade.php
@@ -1,0 +1,149 @@
+@extends('layouts.app')
+@section('page_title', ($show->name ?? 'TV Show').' — Season '.($season->season_number ?? '').' — MoviePickr')
+@section('content')
+<div class="max-w-4xl mx-auto px-4 py-8">
+
+    {{-- Breadcrumb --}}
+    <div class="flex items-center gap-2 text-sm text-gray-500 mb-6">
+        <a href="/tv/{{ $showId }}" class="hover:text-white transition-colors">{{ $show->name ?? 'Show' }}</a>
+        <span class="text-gray-700">›</span>
+        <span class="text-gray-300">{{ $season->name ?? 'Season '.$seasonNumber }}</span>
+    </div>
+
+    {{-- Season header --}}
+    <div class="flex gap-5 mb-8">
+        <div class="flex-shrink-0 w-32 sm:w-40">
+            @if(!empty($season->poster_path))
+                <img src="https://image.tmdb.org/t/p/w300{{ $season->poster_path }}"
+                     alt="{{ $season->name }}"
+                     class="w-full rounded-xl border border-white/10 object-cover">
+            @else
+                <div class="w-full aspect-[2/3] rounded-xl bg-white/[0.03] border border-white/5 flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
+            @endif
+        </div>
+        <div class="min-w-0">
+            <span class="inline-block text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20 mb-2">TV Series</span>
+            <h1 class="text-2xl sm:text-3xl font-bold text-white leading-tight">{{ $season->name ?? 'Season '.$seasonNumber }}</h1>
+            <p class="text-gray-500 text-sm mt-1">
+                {{ $show->name ?? '' }}
+                @if(!empty($season->air_date))
+                    · {{ substr($season->air_date, 0, 4) }}
+                @endif
+                @if(!empty($season->episodes))
+                    · {{ count($season->episodes) }} episodes
+                @endif
+            </p>
+            @if(!empty($season->overview))
+                <p class="text-gray-400 text-sm mt-3 leading-relaxed">{{ $season->overview }}</p>
+            @endif
+        </div>
+    </div>
+
+    {{-- Episode list --}}
+    @if(!empty($season->episodes))
+    <div class="mb-10">
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Episodes</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="flex flex-col gap-3">
+            @foreach($season->episodes as $episode)
+            <a href="{{ route('tv.episode', ['id' => $showId, 'season' => $seasonNumber, 'episode' => $episode->episode_number]) }}"
+               class="flex gap-4 rounded-xl bg-white/[0.03] border border-white/5 p-3 hover:bg-white/[0.06] transition-colors">
+                {{-- Still --}}
+                <div class="flex-shrink-0 w-32 sm:w-40 aspect-video rounded-lg overflow-hidden bg-white/[0.03]">
+                    @if(!empty($episode->still_path))
+                        <img src="https://image.tmdb.org/t/p/w300{{ $episode->still_path }}"
+                             alt="{{ $episode->name }}"
+                             class="w-full h-full object-cover" loading="lazy">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-700 text-xs">No image</div>
+                    @endif
+                </div>
+                {{-- Info --}}
+                <div class="min-w-0 flex flex-col justify-center">
+                    <div class="flex items-baseline gap-2 flex-wrap">
+                        <span class="text-xs text-gray-600 font-medium flex-shrink-0">E{{ $episode->episode_number }}</span>
+                        <span class="text-sm font-semibold text-white leading-snug">{{ $episode->name }}</span>
+                    </div>
+                    <div class="flex items-center gap-2 mt-0.5 text-xs text-gray-600">
+                        @if(!empty($episode->air_date))
+                            <span>{{ \Carbon\Carbon::parse($episode->air_date)->format('M j, Y') }}</span>
+                        @endif
+                        @if(!empty($episode->runtime))
+                            <span>· {{ $episode->runtime }} min</span>
+                        @endif
+                        @if(!empty($episode->vote_average) && $episode->vote_average > 0)
+                            <span>· ★ {{ number_format($episode->vote_average, 1) }}</span>
+                        @endif
+                    </div>
+                    @if(!empty($episode->overview))
+                        <p class="text-xs text-gray-500 mt-1.5 leading-relaxed line-clamp-2">{{ $episode->overview }}</p>
+                    @endif
+                </div>
+            </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- Cast --}}
+    @if(!empty($season->credits->cast))
+    @php $cast = array_slice((array) $season->credits->cast, 0, 12); @endphp
+    <div class="mb-10">
+        <div class="section-header mb-4">
+            <h2 class="text-xl font-bold text-white mb-3">Cast</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            @foreach($cast as $member)
+            <a href="{{ route('person', $member->id) }}" class="flex items-center gap-3 rounded-xl bg-white/[0.03] border border-white/5 p-2.5 hover:bg-white/[0.07] transition-colors">
+                <div class="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden bg-white/[0.05]">
+                    @if(!empty($member->profile_path))
+                        <img src="https://image.tmdb.org/t/p/w92{{ $member->profile_path }}"
+                             alt="{{ $member->name }}" class="w-full h-full object-cover">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-sm">?</div>
+                    @endif
+                </div>
+                <div class="min-w-0">
+                    <p class="text-xs text-white font-medium truncate">{{ $member->name }}</p>
+                    @if(!empty($member->character))
+                        <p class="text-xs text-gray-600 truncate">{{ $member->character }}</p>
+                    @endif
+                </div>
+            </a>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- Season navigation --}}
+    @php
+        $allSeasons = collect($show->seasons ?? [])
+            ->where('season_number', '>', 0)
+            ->sortBy('season_number')
+            ->values();
+        $currentIndex = $allSeasons->search(fn($s) => $s->season_number == $seasonNumber);
+        $prevSeason   = $currentIndex > 0 ? $allSeasons[$currentIndex - 1] : null;
+        $nextSeason   = $currentIndex !== false && $currentIndex < $allSeasons->count() - 1 ? $allSeasons[$currentIndex + 1] : null;
+    @endphp
+    @if($prevSeason || $nextSeason)
+    <div class="flex items-center justify-between gap-4 border-t border-white/5 pt-6">
+        <div>
+            @if($prevSeason)
+                <a href="{{ route('tv.season', ['id' => $showId, 'season' => $prevSeason->season_number]) }}"
+                   class="btn-secondary text-sm">← {{ $prevSeason->name }}</a>
+            @endif
+        </div>
+        <div>
+            @if($nextSeason)
+                <a href="{{ route('tv.season', ['id' => $showId, 'season' => $nextSeason->season_number]) }}"
+                   class="btn-secondary text-sm">{{ $nextSeason->name }} →</a>
+            @endif
+        </div>
+    </div>
+    @endif
+
+</div>
+@endsection

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -91,6 +91,18 @@
                 </p>
             </div>
 
+            {{-- Created by --}}
+            @if(!empty($tmdbInfo->created_by) && count((array)$tmdbInfo->created_by) > 0)
+            <div>
+                <p class="text-xs text-gray-600 uppercase tracking-widest mb-1">Created by</p>
+                <div class="flex flex-wrap gap-x-3">
+                    @foreach($tmdbInfo->created_by as $creator)
+                        <a href="{{ route('person', $creator->id) }}" class="text-sm text-white font-medium hover:text-accent transition-colors">{{ $creator->name }}</a>
+                    @endforeach
+                </div>
+            </div>
+            @endif
+
         </div>
     </div>
 
@@ -98,19 +110,38 @@
         <p class="text-xs text-gray-600 mb-6">Streaming availability by JustWatch. Links open JustWatch search for your region.</p>
     @endif
 
+    {{-- Last aired episode --}}
+    @if(!empty($tmdbInfo->last_episode_to_air))
+        @php $last = $tmdbInfo->last_episode_to_air; @endphp
+        <a href="{{ route('tv.episode', ['id' => $tmdbInfo->id, 'season' => $last->season_number, 'episode' => $last->episode_number]) }}"
+           class="flex items-center gap-3 bg-white/[0.03] border border-white/5 rounded-xl px-4 py-3 mb-3 hover:bg-white/[0.06] transition-colors">
+            <span class="text-gray-500 text-sm">🎬</span>
+            <div class="flex-1">
+                <p class="text-gray-300 text-sm font-medium">
+                    Last episode: S{{ str_pad($last->season_number, 2, '0', STR_PAD_LEFT) }}E{{ str_pad($last->episode_number, 2, '0', STR_PAD_LEFT) }}
+                    @if(!empty($last->name)) — {{ $last->name }}@endif
+                </p>
+                <p class="text-gray-600 text-xs">Aired {{ \Carbon\Carbon::parse($last->air_date)->format('M j, Y') }}</p>
+            </div>
+            <span class="text-gray-700 text-sm">›</span>
+        </a>
+    @endif
+
     {{-- Next episode callout --}}
     @if(!empty($tmdbInfo->next_episode_to_air))
         @php $next = $tmdbInfo->next_episode_to_air; @endphp
-        <div class="flex items-center gap-3 bg-blue-500/10 border border-blue-500/20 rounded-xl px-4 py-3 mb-6">
+        <a href="{{ route('tv.episode', ['id' => $tmdbInfo->id, 'season' => $next->season_number, 'episode' => $next->episode_number]) }}"
+           class="flex items-center gap-3 bg-blue-500/10 border border-blue-500/20 rounded-xl px-4 py-3 mb-6 hover:bg-blue-500/15 transition-colors">
             <span class="text-blue-400 text-sm">📅</span>
-            <div>
+            <div class="flex-1">
                 <p class="text-blue-300 text-sm font-medium">
                     Next episode: S{{ str_pad($next->season_number, 2, '0', STR_PAD_LEFT) }}E{{ str_pad($next->episode_number, 2, '0', STR_PAD_LEFT) }}
                     @if(!empty($next->name)) — {{ $next->name }}@endif
                 </p>
                 <p class="text-blue-400/60 text-xs">Airs {{ \Carbon\Carbon::parse($next->air_date)->format('M j, Y') }}</p>
             </div>
-        </div>
+            <span class="text-blue-400/40 text-sm">›</span>
+        </a>
     @endif
 
     {{-- Info cards --}}
@@ -123,7 +154,7 @@
                 <ul class="cast-list flex flex-col gap-1.5">
                     @foreach ($tmdbInfo->credits->cast as $member)
                         <li class="text-sm text-gray-300">
-                            {{ $member->name }}
+                            <a href="{{ route('person', $member->id) }}" class="hover:text-white transition-colors">{{ $member->name }}</a>
                             @if($member->character)
                                 <span class="text-gray-500"> as {{ $member->character }}</span>
                             @endif
@@ -142,7 +173,7 @@
                 <ul class="crew-list flex flex-col gap-1.5">
                     @foreach ($tmdbInfo->credits->crew as $member)
                         <li class="text-sm text-gray-300">
-                            <span class="text-gray-500">{{ $member->job }}:</span> {{ $member->name }}
+                            <span class="text-gray-500">{{ $member->job }}:</span> <a href="{{ route('person', $member->id) }}" class="hover:text-white transition-colors">{{ $member->name }}</a>
                         </li>
                     @endforeach
                 </ul>
@@ -275,8 +306,8 @@
         </div>
         <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide mt-4">
             @foreach($regularSeasons as $season)
-            <div class="flex-shrink-0 w-28">
-                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03]">
+            <a href="{{ route('tv.season', ['id' => $tmdbInfo->id, 'season' => $season->season_number]) }}" class="flex-shrink-0 w-28 group">
+                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] group-hover:ring-1 group-hover:ring-accent/50 transition-all">
                     @if(!empty($season->poster_path))
                         <img src="https://image.tmdb.org/t/p/w185{{ $season->poster_path }}"
                              alt="{{ $season->name }}"
@@ -285,15 +316,15 @@
                         <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
                     @endif
                 </div>
-                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug">{{ $season->name }}</p>
+                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug group-hover:text-white transition-colors">{{ $season->name }}</p>
                 <p class="text-xs text-gray-600">
                     @if(!empty($season->air_date)){{ substr($season->air_date, 0, 4) }} · @endif{{ $season->episode_count ?? '?' }} ep
                 </p>
-            </div>
+            </a>
             @endforeach
             @if($specialsSeason)
-            <div class="flex-shrink-0 w-28">
-                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03]">
+            <a href="{{ route('tv.season', ['id' => $tmdbInfo->id, 'season' => 0]) }}" class="flex-shrink-0 w-28 group">
+                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] group-hover:ring-1 group-hover:ring-accent/50 transition-all">
                     @if(!empty($specialsSeason->poster_path))
                         <img src="https://image.tmdb.org/t/p/w185{{ $specialsSeason->poster_path }}"
                              alt="{{ $specialsSeason->name }}"
@@ -302,11 +333,11 @@
                         <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
                     @endif
                 </div>
-                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug">{{ $specialsSeason->name }}</p>
+                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug group-hover:text-white transition-colors">{{ $specialsSeason->name }}</p>
                 <p class="text-xs text-gray-600">
                     @if(!empty($specialsSeason->air_date)){{ substr($specialsSeason->air_date, 0, 4) }} · @endif{{ $specialsSeason->episode_count ?? '?' }} ep
                 </p>
-            </div>
+            </a>
             @endif
         </div>
     </div>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -259,6 +259,59 @@
         </div>
     </div>
 
+    {{-- Seasons --}}
+    @php
+        $seasons = collect($tmdbInfo->seasons ?? [])
+            ->sortBy('season_number')
+            ->values();
+        $regularSeasons = $seasons->where('season_number', '>', 0)->values();
+        $specialsSeason = $seasons->firstWhere('season_number', 0);
+    @endphp
+    @if($regularSeasons->isNotEmpty())
+    <div class="mb-10">
+        <div class="section-header">
+            <h2 class="text-xl font-bold text-white mb-3">Seasons</h2>
+            <div class="section-divider"></div>
+        </div>
+        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide mt-4">
+            @foreach($regularSeasons as $season)
+            <div class="flex-shrink-0 w-28">
+                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03]">
+                    @if(!empty($season->poster_path))
+                        <img src="https://image.tmdb.org/t/p/w185{{ $season->poster_path }}"
+                             alt="{{ $season->name }}"
+                             class="w-full h-full object-cover" loading="lazy">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
+                    @endif
+                </div>
+                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug">{{ $season->name }}</p>
+                <p class="text-xs text-gray-600">
+                    @if(!empty($season->air_date)){{ substr($season->air_date, 0, 4) }} · @endif{{ $season->episode_count ?? '?' }} ep
+                </p>
+            </div>
+            @endforeach
+            @if($specialsSeason)
+            <div class="flex-shrink-0 w-28">
+                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03]">
+                    @if(!empty($specialsSeason->poster_path))
+                        <img src="https://image.tmdb.org/t/p/w185{{ $specialsSeason->poster_path }}"
+                             alt="{{ $specialsSeason->name }}"
+                             class="w-full h-full object-cover" loading="lazy">
+                    @else
+                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">No poster</div>
+                    @endif
+                </div>
+                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug">{{ $specialsSeason->name }}</p>
+                <p class="text-xs text-gray-600">
+                    @if(!empty($specialsSeason->air_date)){{ substr($specialsSeason->air_date, 0, 4) }} · @endif{{ $specialsSeason->episode_count ?? '?' }} ep
+                </p>
+            </div>
+            @endif
+        </div>
+    </div>
+    @endif
+
     {{-- Similar shows --}}
     @if ($similarShows != null)
     <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,9 @@ use App\Http\Controllers\Admin\RowOrderController;
 use App\Http\Controllers\TvCriteriaController;
 use App\Http\Controllers\TvPickController;
 use App\Http\Controllers\TvShowController;
+use App\Http\Controllers\TvSeasonController;
+use App\Http\Controllers\TvEpisodeController;
+use App\Http\Controllers\PersonController;
 
 Route::get('/',  HomeController::class);
 Route::post('/', ContactController::class);
@@ -57,6 +60,10 @@ Route::get('/tv/criteria',                     TvCriteriaController::class);
 Route::match(['get', 'post'], '/tv/pick',      [TvPickController::class, 'single']);
 Route::match(['get', 'post'], '/tv/multiple',  [TvPickController::class, 'batch']);
 Route::get('/tv/{id}', TvShowController::class)->name('tv.show');
+Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
+Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
+
+Route::get('/person/{id}', PersonController::class)->name('person');
 
 // My Roulettes (auth required — must be before /roulettes/{slug} wildcard)
 Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(function () {


### PR DESCRIPTION
## Summary
- Adds a horizontal scrollable seasons row to the TV show detail page, placed just above the Similar Shows section
- Shows regular seasons (Season 1, 2, 3…) sorted by season number, with Specials appended at the end if present
- Each card displays the season poster (w185), season name, year, and episode count
- Uses data already included in the `$tmdbInfo->seasons` payload — no extra API calls

## Test plan
- [x] Visit any TV show page (e.g. `/tv/1396` for Breaking Bad) and verify the seasons row appears
- [x] Check a show with specials (e.g. Doctor Who) to confirm Specials appear at the end
- [x] Check a show with missing posters renders the fallback placeholder
- [x] Verify the row scrolls horizontally on mobile without layout breaks