### PR TITLE
Sort roulette poster batch by popularity

### DIFF
--- a/app/Http/Controllers/Admin/AdminRouletteController.php
+++ b/app/Http/Controllers/Admin/AdminRouletteController.php
@@ -105,7 +105,8 @@ class AdminRouletteController extends Controller
         $criteria       = $roulette->media_type === 'tv'
             ? $mapper->toCriteriaTv($tagsForPosters)
             : $mapper->toCriteria($tagsForPosters);
-        $criteria['page'] = rand(1, 5);
+        $criteria['sort_by'] = 'popularity.desc';
+        $criteria['page']    = rand(1, 5);
 
         try {
             $results = $roulette->media_type === 'tv'

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -187,7 +187,8 @@ class UserRouletteController extends Controller
         $tagsForPosters = array_diff_key($roulette->tags ?? [], ['platform' => true]);
         $isTv           = $roulette->media_type === 'tv';
         $criteria       = $isTv ? $mapper->toCriteriaTv($tagsForPosters) : $mapper->toCriteria($tagsForPosters);
-        $criteria['page'] = rand(1, 5);
+        $criteria['sort_by'] = 'popularity.desc';
+        $criteria['page']    = rand(1, 5);
 
         try {
             $results = $isTv ? $tmdb->discoverTv($criteria, 'US') : $tmdb->discover($criteria, 'US');


### PR DESCRIPTION
## Summary
- Adds `sort_by=popularity.desc` to the TMDB discover call in `refreshPoster`, so the poster batch pulls from the most popular results rather than arbitrary ones
- Keeps the existing random page range (1–5) so there's still variety across refreshes

## Test plan
- [x] Open any roulette edit page in admin
- [x] Click "Refresh Poster" — verify posters come from well-known titles rather than obscure ones
- [x] Repeat a few times to confirm variety is maintained across refreshes