### PR TITLE
Criteria filters: origin country, exclude genre, session fixes, live poster preview

### DIFF
--- a/app/Http/Controllers/Admin/AdminRouletteController.php
+++ b/app/Http/Controllers/Admin/AdminRouletteController.php
@@ -106,10 +106,10 @@ class AdminRouletteController extends Controller
         $page   = max(1, min(10, (int) $request->input('page', 1)));
         $sort   = $request->input('sort', 'rating') === 'rating' ? 'rating' : 'popularity';
         $mapper = new RouletteTagMapper();
-        $isTv   = $roulette->media_type === 'tv';
-        $criteria = $isTv
-            ? $mapper->toCriteriaTv($roulette->tags ?? [])
-            : $mapper->toCriteria($roulette->tags ?? []);
+        $isTv   = ($request->input('media_type') ?? $roulette->media_type) === 'tv';
+        $rawTags  = $request->input('tags');
+        $tags     = $rawTags !== null ? $mapper->normalizeTags($rawTags) : ($roulette->tags ?? []);
+        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteria($tags);
         $criteria['sort_by'] = $sort === 'rating' ? 'vote_average.desc' : 'popularity.desc';
         $criteria['page']    = $page;
         if ($sort === 'rating') {

--- a/app/Http/Controllers/Admin/AdminRouletteController.php
+++ b/app/Http/Controllers/Admin/AdminRouletteController.php
@@ -238,8 +238,14 @@ class AdminRouletteController extends Controller
         if ($genres = $request->input('tags.genre', [])) {
             $tags['genre'] = array_values($genres);
         }
+        if ($withoutGenres = $request->input('tags.without_genre', [])) {
+            $tags['without_genre'] = array_values($withoutGenres);
+        }
         if ($era = $request->input('tags.era')) {
             $tags['era'] = [$era];
+        }
+        if ($country = $request->input('tags.country')) {
+            $tags['country'] = [$country];
         }
         if ($language = $request->input('tags.language')) {
             $tags['language'] = [$language];

--- a/app/Http/Controllers/CriteriaController.php
+++ b/app/Http/Controllers/CriteriaController.php
@@ -13,7 +13,7 @@ class CriteriaController extends Controller
         return view('criteria', [
             'genres'         => $ms->genres($tmdb),
             'providersArray' => $ms->buildProvidersArray($tmdb),
-            'userInput'      => session('userInput', []),
+            'userInput'      => [],
         ]);
     }
 }

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -17,7 +17,7 @@ class MoviePickController extends Controller
         }
 
         $country  = $movieService->getUserCountry();
-        $criteria = $movieService->resolveSessionCriteria($this->submitted($request));
+        $criteria = $movieService->resolveSessionCriteria($this->submitted($request), $request->isMethod('post'));
         $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
 
         $results = $tmdb->discover($criteria, $country);
@@ -41,7 +41,7 @@ class MoviePickController extends Controller
         }
 
         $country  = $movieService->getUserCountry();
-        $criteria = $movieService->resolveSessionCriteria($this->submitted($request));
+        $criteria = $movieService->resolveSessionCriteria($this->submitted($request), $request->isMethod('post'));
         $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
 
         $movies             = $tmdb->discover($criteria, $country);
@@ -68,11 +68,24 @@ class MoviePickController extends Controller
 
     private function submitted(CriteriaRequest $request): array
     {
-        return $request->except(['_token', 'i', 'total_pages', 'a']);
+        return array_filter(
+            $request->except(['_token', 'i', 'total_pages', 'a']),
+            fn($v) => $v !== '' && $v !== null && $v !== []
+        );
     }
 
     private function handleSessionReset(CriteriaRequest $request, string $redirectTo): ?RedirectResponse
     {
+        if ($request->query('i') === 'new') {
+            session(['userInput' => [
+                'with_original_language'   => 'en',
+                'primary_release_date_gte' => 1990,
+                'vote_average_gte'         => 7,
+                'vote_count_gte'           => 100,
+            ]]);
+            return null;
+        }
+
         if ($request->query('i') !== null && session('userInput') !== null) {
             session()->forget('userInput');
             return redirect(url($redirectTo));

--- a/app/Http/Controllers/TvCriteriaController.php
+++ b/app/Http/Controllers/TvCriteriaController.php
@@ -13,7 +13,7 @@ class TvCriteriaController extends Controller
         return view('tv.criteria', [
             'genres'         => $ms->tvGenres($tmdb),
             'providersArray' => $ms->buildProvidersArray($tmdb),
-            'userInput'      => session('tvInput', []),
+            'userInput'      => [],
         ]);
     }
 }

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -17,7 +17,7 @@ class TvPickController extends Controller
         }
 
         $country  = $movieService->getUserCountry();
-        $criteria = $this->resolveSessionCriteria($this->submitted($request));
+        $criteria = $this->resolveSessionCriteria($this->submitted($request), $request->isMethod('post'));
         $criteria['page'] = $movieService->resolveTvPage($tmdb, $criteria, $country);
 
         $results = $tmdb->discoverTv($criteria, $country);
@@ -41,7 +41,7 @@ class TvPickController extends Controller
         }
 
         $country  = $movieService->getUserCountry();
-        $criteria = $this->resolveSessionCriteria($this->submitted($request));
+        $criteria = $this->resolveSessionCriteria($this->submitted($request), $request->isMethod('post'));
         $criteria['page'] = $movieService->resolveTvPage($tmdb, $criteria, $country);
 
         $shows            = $tmdb->discoverTv($criteria, $country);
@@ -74,22 +74,39 @@ class TvPickController extends Controller
         ]);
     }
 
-    private function resolveSessionCriteria(array $submitted): array
+    private function resolveSessionCriteria(array $submitted, bool $overwrite = false): array
     {
-        if (session('tvInput') === null || !empty($submitted['with_people'])) {
+        if ($overwrite || !empty($submitted)) {
+            session()->put('tvInput', $submitted);
+            session()->forget('tvPersonRollIds');
+        } elseif (session('tvInput') === null) {
             session()->put('tvInput', $submitted);
         }
 
-        return session('tvInput');
+        return session('tvInput') ?? [];
     }
 
     private function submitted(TvCriteriaRequest $request): array
     {
-        return $request->except(['_token', 'i', 'total_pages', 'a']);
+        return array_filter(
+            $request->except(['_token', 'i', 'total_pages', 'a']),
+            fn($v) => $v !== '' && $v !== null && $v !== []
+        );
     }
 
     private function handleSessionReset(TvCriteriaRequest $request, string $redirectTo): ?RedirectResponse
     {
+        if ($request->query('i') === 'new') {
+            session()->forget('tvPersonRollIds');
+            session(['tvInput' => [
+                'with_original_language' => 'en',
+                'first_air_date_gte'     => 1990,
+                'vote_average_gte'       => 7,
+                'vote_count_gte'         => 100,
+            ]]);
+            return null;
+        }
+
         if ($request->query('i') !== null && session('tvInput') !== null) {
             session()->forget(['tvInput', 'tvPersonRollIds']);
             return redirect(url($redirectTo));

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -76,8 +76,9 @@ class TvPickController extends Controller
 
     private function resolveSessionCriteria(array $submitted): array
     {
-        session()->put('tvInput', $submitted);
-        session()->forget('tvPersonRollIds');
+        if (session('tvInput') === null || !empty($submitted['with_people'])) {
+            session()->put('tvInput', $submitted);
+        }
 
         return session('tvInput');
     }

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -189,7 +189,9 @@ class UserRouletteController extends Controller
         $sort   = $request->input('sort', 'rating') === 'rating' ? 'rating' : 'popularity';
         $mapper = new RouletteTagMapper();
         $isTv   = $roulette->media_type === 'tv';
-        $criteria = $isTv ? $mapper->toCriteriaTv($roulette->tags ?? []) : $mapper->toCriteria($roulette->tags ?? []);
+        $rawTags  = $request->input('tags');
+        $tags     = $rawTags !== null ? $mapper->normalizeTags($rawTags) : ($roulette->tags ?? []);
+        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteria($tags);
         $criteria['sort_by'] = $sort === 'rating' ? 'vote_average.desc' : 'popularity.desc';
         $criteria['page']    = $page;
         if ($sort === 'rating') {

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -277,8 +277,14 @@ class UserRouletteController extends Controller
         if ($genres = $request->input('tags.genre', [])) {
             $tags['genre'] = array_values($genres);
         }
+        if ($withoutGenres = $request->input('tags.without_genre', [])) {
+            $tags['without_genre'] = array_values($withoutGenres);
+        }
         if ($era = $request->input('tags.era')) {
             $tags['era'] = [$era];
+        }
+        if ($country = $request->input('tags.country')) {
+            $tags['country'] = [$country];
         }
         if ($language = $request->input('tags.language')) {
             $tags['language'] = [$language];

--- a/app/Models/Roulette.php
+++ b/app/Models/Roulette.php
@@ -31,11 +31,12 @@ class Roulette extends Model
             return $platforms[$tags['platform'][0]] ?? 'Other';
         }
         if (!empty($tags['era'])) return 'By Decade';
-        if (!empty($tags['language']) && in_array('ja', (array) $tags['language'])
-            && !empty($tags['genre']) && in_array('animation', (array) $tags['genre'])) {
+        $hasJapan = (!empty($tags['country']) && in_array('JP', (array) $tags['country']))
+                 || (!empty($tags['language']) && in_array('ja', (array) $tags['language']));
+        if ($hasJapan && !empty($tags['genre']) && in_array('animation', (array) $tags['genre'])) {
             return 'Anime';
         }
-        if (!empty($tags['language'])) return 'World Cinema';
+        if (!empty($tags['country']) || !empty($tags['language'])) return 'World Cinema';
         return 'By Genre';
     }
 

--- a/app/Services/MovieService.php
+++ b/app/Services/MovieService.php
@@ -39,9 +39,9 @@ class MovieService
      * On first visit stores submitted criteria in session; subsequent visits
      * always return the session copy so "pick another" keeps the same filters.
      */
-    public function resolveSessionCriteria(array $submitted): array
+    public function resolveSessionCriteria(array $submitted, bool $overwrite = false): array
     {
-        if (session('userInput') === null) {
+        if ($overwrite || session('userInput') === null) {
             session()->put('userInput', $submitted);
         }
 

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -66,6 +66,17 @@ class RouletteTagMapper
         '2020s'    => ['gte' => 2020],
     ];
 
+    public function normalizeTags(array $raw): array
+    {
+        $tags = [];
+        if (!empty($raw['platform'])) $tags['platform'] = [$raw['platform']];
+        if (!empty($raw['genre']))    $tags['genre']    = array_values((array) $raw['genre']);
+        if (!empty($raw['without_genre'])) $tags['without_genre'] = array_values((array) $raw['without_genre']);
+        if (!empty($raw['era']))      $tags['era']      = [$raw['era']];
+        if (!empty($raw['country']))  $tags['country']  = [$raw['country']];
+        return $tags;
+    }
+
     public function toCriteria(array $tags): array
     {
         $criteria = [];

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -88,8 +88,22 @@ class RouletteTagMapper
             }
         }
 
-        if (!empty($tags['language'])) {
-            $criteria['with_original_language'] = $tags['language'][0];
+        if (!empty($tags['without_genre'])) {
+            $ids = array_values(array_filter(
+                array_map(fn($g) => self::GENRE_IDS[$g] ?? null, (array) $tags['without_genre'])
+            ));
+            if ($ids) {
+                $criteria['without_genres'] = $ids;
+            }
+        }
+
+        if (!empty($tags['country'])) {
+            $criteria['with_origin_country'] = $tags['country'][0];
+        } elseif (!empty($tags['language'])) {
+            // legacy: old roulettes stored ISO 639-1 language codes; map to ISO 3166-1 country codes
+            $legacyMap = ['ja'=>'JP','ko'=>'KR','fr'=>'FR','es'=>'ES','it'=>'IT','zh'=>'CN','hi'=>'IN','de'=>'DE','tr'=>'TR','pt'=>'PT','lt'=>'LT'];
+            $code = $legacyMap[$tags['language'][0]] ?? null;
+            if ($code) $criteria['with_origin_country'] = $code;
         }
 
         if (!empty($tags['era'])) {
@@ -133,8 +147,21 @@ class RouletteTagMapper
             }
         }
 
-        if (!empty($tags['language'])) {
-            $criteria['with_original_language'] = $tags['language'][0];
+        if (!empty($tags['without_genre'])) {
+            $ids = array_values(array_unique(array_filter(
+                array_map(fn($g) => self::TV_GENRE_IDS[$g] ?? null, (array) $tags['without_genre'])
+            )));
+            if ($ids) {
+                $criteria['without_genres'] = $ids;
+            }
+        }
+
+        if (!empty($tags['country'])) {
+            $criteria['with_origin_country'] = $tags['country'][0];
+        } elseif (!empty($tags['language'])) {
+            $legacyMap = ['ja'=>'JP','ko'=>'KR','fr'=>'FR','es'=>'ES','it'=>'IT','zh'=>'CN','hi'=>'IN','de'=>'DE','tr'=>'TR','pt'=>'PT','lt'=>'LT'];
+            $code = $legacyMap[$tags['language'][0]] ?? null;
+            if ($code) $criteria['with_origin_country'] = $code;
         }
 
         if (!empty($tags['era'])) {

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -99,6 +99,10 @@ $(document).ready(function () {
     initTs('with_original_language',       { maxOptions: null, create: false });
     initTs('modal-with_original_language', { maxOptions: null, create: false });
 
+    /* ── Origin Country ─────────────────────────────────────────── */
+    initTs('with_origin_country',       { maxOptions: null, create: false });
+    initTs('modal-with_origin_country', { maxOptions: null, create: false });
+
     /* ── Streaming providers ─────────────────────────────────────── */
     const logoRender = {
         option: function (data, escape) {
@@ -143,7 +147,9 @@ $(document).ready(function () {
             if (ts) ts.clear(true);
         });
         const langTs = window['_ts_' + prefix + 'with_original_language'];
-        if (langTs) langTs.setValue('en', true);
+        if (langTs) langTs.setValue('', true);
+        const countryTs = window['_ts_' + prefix + 'with_origin_country'];
+        if (countryTs) countryTs.setValue('', true);
     }
 
     $('#btn-reset, #btn-reset-mobile').on('click', function () { resetForm('#criteria', ''); });

--- a/resources/views/admin/roulettes/form.blade.php
+++ b/resources/views/admin/roulettes/form.blade.php
@@ -271,17 +271,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function getTags() {
+        const tags = {};
+        const genres = Array.from(document.querySelectorAll('input[name="tags[genre][]"]:checked')).map(el => el.value);
+        if (genres.length) tags.genre = genres;
+        const withoutGenres = Array.from(document.querySelectorAll('input[name="tags[without_genre][]"]:checked')).map(el => el.value);
+        if (withoutGenres.length) tags.without_genre = withoutGenres;
+        const platform = document.querySelector('select[name="tags[platform]"]')?.value;
+        if (platform) tags.platform = platform;
+        const era = document.querySelector('select[name="tags[era]"]')?.value;
+        if (era) tags.era = era;
+        const country = document.querySelector('select[name="tags[country]"]')?.value;
+        if (country) tags.country = country;
+        return tags;
+    }
+
     function fetchPage(page) {
         if (loading) return;
         loading = true;
         prevBtn.disabled = true;
         nextBtn.disabled = true;
         indicator.textContent = '…';
+        const mediaType = document.querySelector('input[name="media_type"]:checked')?.value ?? 'movie';
 
         fetch(URL, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': CSRF },
-            body: JSON.stringify({ page, sort: currentSort }),
+            body: JSON.stringify({ page, sort: currentSort, tags: getTags(), media_type: mediaType }),
         })
         .then(r => r.json())
         .then(data => {

--- a/resources/views/admin/roulettes/form.blade.php
+++ b/resources/views/admin/roulettes/form.blade.php
@@ -26,6 +26,11 @@
         <div class="flex items-center justify-between mb-1.5">
             <label class="text-xs font-semibold uppercase tracking-widest text-gray-500">Poster</label>
             <div class="flex items-center gap-1">
+                <button type="button" id="refresh-posters-btn"
+                        class="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 rounded transition-colors"
+                        title="Refresh posters">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                </button>
                 <button type="button" id="prev-page-btn" disabled
                         class="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 rounded disabled:opacity-30 disabled:pointer-events-none transition-colors">
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7"/></svg>
@@ -334,6 +339,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     prevBtn.addEventListener('click', () => fetchPage(currentPage - 1));
     nextBtn.addEventListener('click', () => fetchPage(currentPage + 1));
+    document.getElementById('refresh-posters-btn').addEventListener('click', () => fetchPage(1));
 
     document.querySelectorAll('.sort-btn').forEach(btn => {
         btn.addEventListener('click', () => {

--- a/resources/views/admin/roulettes/form.blade.php
+++ b/resources/views/admin/roulettes/form.blade.php
@@ -20,7 +20,7 @@
         $allPosters = $roulette->poster_paths ?? [];
         $poster     = $allPosters[0] ?? null;
     @endphp
-    <div id="poster-section" class="sm:w-32 lg:w-44 flex-shrink-0">
+    <div id="poster-section" class="sm:w-52 lg:w-80 flex-shrink-0">
 
         {{-- Label + page navigation --}}
         <div class="flex items-center justify-between mb-1.5">
@@ -64,7 +64,7 @@
 
         {{-- Thumbnail grid (desktop 4-col) / scroll strip (mobile) --}}
         @if(count($allPosters) > 1)
-        <div id="poster-grid" class="grid grid-cols-4 gap-1">
+        <div id="poster-grid" class="grid grid-cols-3 gap-1">
             @foreach($allPosters as $i => $path)
                 <button type="button"
                         class="poster-thumb relative rounded overflow-hidden {{ $i === 0 ? 'ring-2 ring-accent' : 'opacity-50 hover:opacity-100' }} transition-opacity"
@@ -75,7 +75,7 @@
             @endforeach
         </div>
         @else
-            <div id="poster-grid" class="grid grid-cols-4 gap-1"></div>
+            <div id="poster-grid" class="grid grid-cols-3 gap-1"></div>
         @endif
     </div>
     @endif
@@ -262,7 +262,7 @@ document.addEventListener('DOMContentLoaded', () => {
         paths.forEach(path => {
             const btn = document.createElement('button');
             btn.type = 'button';
-            btn.className = 'poster-thumb relative rounded overflow-hidden transition-opacity ' +
+            btn.className = 'poster-thumb relative rounded overflow-hidden transition-opacity col-span-1 ' +
                 (path === activePath ? 'ring-2 ring-accent' : 'opacity-50 hover:opacity-100');
             btn.style.aspectRatio = '2/3';
             btn.dataset.path = path;

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -73,7 +73,13 @@
             {{-- Language --}}
             <div class="card p-5">
                 <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Language</h3>
-                @include('includes.languages', ['selectedLang' => old('with_original_language', $ui['with_original_language'] ?? 'en')])
+                @include('includes.languages', ['selectedLang' => old('with_original_language', $ui['with_original_language'] ?? '')])
+            </div>
+
+            {{-- Origin Country --}}
+            <div class="card p-5">
+                <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Origin Country</h3>
+                @include('includes.origin-country', ['selectedCountry' => old('with_origin_country', $ui['with_origin_country'] ?? '')])
             </div>
 
             {{-- Streaming --}}

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -2,7 +2,7 @@
     if ($user_input === 'default') $user_input = [];
     $openYear     = !empty($user_input['primary_release_date_gte'] ?? '') || !empty($user_input['primary_release_date_lte'] ?? '');
     $openGenres   = !empty($user_input['with_genres'] ?? []) || !empty($user_input['without_genres'] ?? []);
-    $openLanguage  = !empty($user_input['with_original_language'] ?? '');
+    $openLanguage  = !empty($user_input['with_original_language'] ?? '') || !empty($user_input['with_origin_country'] ?? '');
     $openStreaming  = !empty($user_input['with_watch_providers'] ?? []);
     $openPeople   = !empty($user_input['with_cast'] ?? []) || !empty($user_input['with_crew'] ?? []);
     $openScores   = !empty($user_input['vote_average_gte'] ?? '') || !empty($user_input['vote_average_lte'] ?? '') || !empty($user_input['vote_count_gte'] ?? '');
@@ -76,15 +76,22 @@
                     </div>
                 </div>
 
-                {{-- Language --}}
+                {{-- Language & Country --}}
                 <div class="accordion-section border-t border-white/5 {{ $openLanguage ? 'accordion-open' : '' }}">
                     <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
-                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language</h3>
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language & Country</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
                     <div class="accordion-body">
-                        <div class="pb-4">
-                            @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? ''])
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Language</label>
+                                @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? ''])
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Origin Country</label>
+                                @include('includes.origin-country', ['modalMode' => true, 'selectedCountry' => $user_input['with_origin_country'] ?? ''])
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/includes/languages.blade.php
+++ b/resources/views/includes/languages.blade.php
@@ -1,6 +1,6 @@
 @php
     $langId   = isset($modalMode) && $modalMode ? 'modal-with_original_language' : 'with_original_language';
-    $selLang  = $selectedLang ?? old('with_original_language', 'en');
+    $selLang  = $selectedLang ?? old('with_original_language', '');
     $langOpts = [
         'en'=>'English','de'=>'German','fr'=>'French','es'=>'Spanish','ja'=>'Japanese',
         'pt'=>'Portuguese','it'=>'Italian','ru'=>'Russian','zh'=>'Chinese','ko'=>'Korean',
@@ -27,4 +27,3 @@
         <option value="{{ $val }}" {{ $selLang === $val ? 'selected' : '' }}>{{ $label }}</option>
     @endforeach
 </select>
-<p class="text-xs text-gray-600 mt-1">Default: English</p>

--- a/resources/views/includes/origin-country.blade.php
+++ b/resources/views/includes/origin-country.blade.php
@@ -1,0 +1,19 @@
+@php
+    $countryId   = isset($modalMode) && $modalMode ? 'modal-with_origin_country' : 'with_origin_country';
+    $selCountry  = $selectedCountry ?? '';
+    $countryOpts = [
+        'US'=>'United States','GB'=>'United Kingdom','FR'=>'France','DE'=>'Germany',
+        'IT'=>'Italy','ES'=>'Spain','JP'=>'Japan','KR'=>'South Korea','CN'=>'China',
+        'IN'=>'India','AU'=>'Australia','CA'=>'Canada','MX'=>'Mexico','BR'=>'Brazil',
+        'DK'=>'Denmark','SE'=>'Sweden','NO'=>'Norway','NL'=>'Netherlands','PL'=>'Poland',
+        'RU'=>'Russia','TR'=>'Turkey','TH'=>'Thailand','TW'=>'Taiwan','HK'=>'Hong Kong',
+        'IE'=>'Ireland','IS'=>'Iceland','BE'=>'Belgium','PT'=>'Portugal','AR'=>'Argentina',
+        'IR'=>'Iran','IL'=>'Israel','GR'=>'Greece','LT'=>'Lithuania',
+    ];
+@endphp
+<select id="{{ $countryId }}" name="with_origin_country">
+    <option value="">Any Country</option>
+    @foreach($countryOpts as $val => $label)
+        <option value="{{ $val }}" {{ $selCountry === $val ? 'selected' : '' }}>{{ $label }}</option>
+    @endforeach
+</select>

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -28,6 +28,11 @@
         <div class="flex items-center justify-between mb-1.5">
             <label class="text-xs font-semibold uppercase tracking-widest text-gray-500">Poster</label>
             <div class="flex items-center gap-1">
+                <button type="button" id="refresh-posters-btn"
+                        class="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 rounded transition-colors"
+                        title="Refresh posters">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                </button>
                 <button type="button" id="prev-page-btn" disabled
                         class="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 rounded disabled:opacity-30 disabled:pointer-events-none transition-colors">
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M15 19l-7-7 7-7"/></svg>
@@ -301,6 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     prevBtn.addEventListener('click', () => fetchPage(currentPage - 1));
     nextBtn.addEventListener('click', () => fetchPage(currentPage + 1));
+    document.getElementById('refresh-posters-btn').addEventListener('click', () => fetchPage(1));
 
     document.querySelectorAll('.sort-btn').forEach(btn => {
         btn.addEventListener('click', () => {

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -22,7 +22,7 @@
         $allPosters = $roulette->poster_paths ?? [];
         $poster     = $allPosters[0] ?? null;
     @endphp
-    <div id="poster-section" class="sm:w-32 lg:w-40 flex-shrink-0">
+    <div id="poster-section" class="sm:w-52 lg:w-80 flex-shrink-0">
 
         {{-- Label + page navigation --}}
         <div class="flex items-center justify-between mb-1.5">
@@ -66,7 +66,7 @@
 
         {{-- Thumbnail grid (desktop 4-col) / scroll strip (mobile) --}}
         @if(count($allPosters) > 1)
-        <div id="poster-grid" class="grid grid-cols-4 gap-1">
+        <div id="poster-grid" class="grid grid-cols-3 gap-1">
             @foreach($allPosters as $i => $path)
                 <button type="button"
                         class="poster-thumb relative rounded overflow-hidden {{ $i === 0 ? 'ring-2 ring-accent' : 'opacity-50 hover:opacity-100' }} transition-opacity"
@@ -77,7 +77,7 @@
             @endforeach
         </div>
         @else
-            <div id="poster-grid" class="grid grid-cols-4 gap-1"></div>
+            <div id="poster-grid" class="grid grid-cols-3 gap-1"></div>
         @endif
     </div>
     @endif

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -238,6 +238,21 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function getTags() {
+        const tags = {};
+        const genres = Array.from(document.querySelectorAll('input[name="tags[genre][]"]:checked')).map(el => el.value);
+        if (genres.length) tags.genre = genres;
+        const withoutGenres = Array.from(document.querySelectorAll('input[name="tags[without_genre][]"]:checked')).map(el => el.value);
+        if (withoutGenres.length) tags.without_genre = withoutGenres;
+        const platform = document.querySelector('select[name="tags[platform]"]')?.value;
+        if (platform) tags.platform = platform;
+        const era = document.querySelector('select[name="tags[era]"]')?.value;
+        if (era) tags.era = era;
+        const country = document.querySelector('select[name="tags[country]"]')?.value;
+        if (country) tags.country = country;
+        return tags;
+    }
+
     function fetchPage(page) {
         if (loading) return;
         loading = true;
@@ -248,7 +263,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(URL, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': CSRF },
-            body: JSON.stringify({ page, sort: currentSort }),
+            body: JSON.stringify({ page, sort: currentSort, tags: getTags() }),
         })
         .then(r => r.json())
         .then(data => {

--- a/resources/views/roulettes/_tag_form.blade.php
+++ b/resources/views/roulettes/_tag_form.blade.php
@@ -12,21 +12,23 @@
         '1990s'=>'The Nineties','1980s'=>'The Eighties','1970s'=>'The Seventies',
         '1960s'=>'The Sixties','1950s'=>'The Fifties','pre-1950'=>'Classic Hollywood',
     ];
-    $languages = [
-        'ja'=>'Japanese','ko'=>'Korean','fr'=>'French','es'=>'Spanish','it'=>'Italian',
-        'zh'=>'Chinese','hi'=>'Hindi','de'=>'German','tr'=>'Turkish','pt'=>'Portuguese','lt'=>'Lithuanian',
+    $countries = [
+        'JP'=>'Japanese','KR'=>'Korean','FR'=>'French','ES'=>'Spanish','IT'=>'Italian',
+        'CN'=>'Chinese','IN'=>'Indian','DE'=>'German','TR'=>'Turkish','PT'=>'Portuguese',
+        'MX'=>'Mexican','SE'=>'Swedish','DK'=>'Danish','LT'=>'Lithuanian',
     ];
-    $selectedPlatform  = $currentTags['platform'][0]  ?? null;
-    $selectedGenres    = $currentTags['genre']         ?? [];
-    $selectedEra       = $currentTags['era'][0]        ?? null;
-    $selectedLanguage  = $currentTags['language'][0]   ?? null;
+    $selectedPlatform      = $currentTags['platform'][0]      ?? null;
+    $selectedGenres        = $currentTags['genre']             ?? [];
+    $selectedWithoutGenres = $currentTags['without_genre']     ?? [];
+    $selectedEra           = $currentTags['era'][0]            ?? null;
+    $selectedCountry       = $currentTags['country'][0]        ?? null;
 @endphp
 
 <div class="space-y-6">
 
-    {{-- Genre --}}
+    {{-- Include Genre --}}
     <div>
-        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Genre</label>
+        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Include Genre</label>
         <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
             @foreach($genres as $value => $label)
                 <label class="flex items-center gap-2 cursor-pointer group">
@@ -38,6 +40,21 @@
             @endforeach
         </div>
         @error('tags.genre') <p class="text-red-400 text-xs mt-1">{{ $message }}</p> @enderror
+    </div>
+
+    {{-- Exclude Genre --}}
+    <div>
+        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Exclude Genre</label>
+        <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
+            @foreach($genres as $value => $label)
+                <label class="flex items-center gap-2 cursor-pointer group">
+                    <input type="checkbox" name="tags[without_genre][]" value="{{ $value }}"
+                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-red-400 focus:ring-red-400/50"
+                           {{ in_array($value, $selectedWithoutGenres) ? 'checked' : '' }}>
+                    <span class="text-sm text-gray-300 group-hover:text-white transition-colors">{{ $label }}</span>
+                </label>
+            @endforeach
+        </div>
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -64,13 +81,13 @@
             </select>
         </div>
 
-        {{-- Language --}}
+        {{-- Country --}}
         <div>
-            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Language</label>
-            <select name="tags[language]" class="input-dark w-full">
+            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Country</label>
+            <select name="tags[country]" class="input-dark w-full">
                 <option value="">None</option>
-                @foreach($languages as $value => $label)
-                    <option value="{{ $value }}" {{ $selectedLanguage === $value ? 'selected' : '' }}>{{ $label }}</option>
+                @foreach($countries as $value => $label)
+                    <option value="{{ $value }}" {{ $selectedCountry === $value ? 'selected' : '' }}>{{ $label }}</option>
                 @endforeach
             </select>
         </div>

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -2,7 +2,7 @@
     if ($user_input === 'default') $user_input = [];
     $openYear      = !empty($user_input['first_air_date_gte'] ?? '') || !empty($user_input['first_air_date_lte'] ?? '');
     $openGenres    = !empty($user_input['with_genres'] ?? []) || !empty($user_input['without_genres'] ?? []);
-    $openLanguage  = !empty($user_input['with_original_language'] ?? '');
+    $openLanguage  = !empty($user_input['with_original_language'] ?? '') || !empty($user_input['with_origin_country'] ?? '');
     $openStreaming  = !empty($user_input['with_watch_providers'] ?? []);
     $openScores    = !empty($user_input['vote_average_gte'] ?? '') || !empty($user_input['vote_average_lte'] ?? '') || !empty($user_input['vote_count_gte'] ?? '');
     $openPeople    = !empty($user_input['with_cast'] ?? []) || !empty($user_input['with_crew'] ?? []);
@@ -76,15 +76,22 @@
                     </div>
                 </div>
 
-                {{-- Language --}}
+                {{-- Language & Country --}}
                 <div class="accordion-section border-t border-white/5 {{ $openLanguage ? 'accordion-open' : '' }}">
                     <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
-                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language</h3>
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language & Country</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
                     <div class="accordion-body">
-                        <div class="pb-4">
-                            @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? ''])
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Language</label>
+                                @include('includes.languages', ['modalMode' => true, 'selectedLang' => $user_input['with_original_language'] ?? ''])
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Origin Country</label>
+                                @include('includes.origin-country', ['modalMode' => true, 'selectedCountry' => $user_input['with_origin_country'] ?? ''])
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -106,32 +113,6 @@
                                     </option>
                                 @endforeach
                             </select>
-                        </div>
-                    </div>
-                </div>
-
-                {{-- Scores --}}
-                <div class="accordion-section border-t border-white/5 {{ $openScores ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
-                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Scores</h3>
-                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
-                    </button>
-                    <div class="accordion-body">
-                        <div class="pb-4 flex flex-col gap-3">
-                            <div class="grid grid-cols-2 gap-3">
-                                <div>
-                                    <label class="block text-sm text-gray-400 mb-1">Min Score</label>
-                                    <input type="text" class="input-dark" name="vote_average_gte" placeholder="0" value="{{ $user_input['vote_average_gte'] ?? '' }}">
-                                </div>
-                                <div>
-                                    <label class="block text-sm text-gray-400 mb-1">Max Score</label>
-                                    <input type="text" class="input-dark" name="vote_average_lte" placeholder="10" value="{{ $user_input['vote_average_lte'] ?? '' }}">
-                                </div>
-                            </div>
-                            <div>
-                                <label class="block text-sm text-gray-400 mb-1">Min Vote Count</label>
-                                <input type="text" class="input-dark" name="vote_count_gte" placeholder="10" value="{{ $user_input['vote_count_gte'] ?? '' }}">
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -159,6 +140,32 @@
                                         <option value="{{ $crewId }}" selected>{{ ($user_input['with_crew_names'] ?? [])[$i] ?? '' }}</option>
                                     @endforeach
                                 </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Scores --}}
+                <div class="accordion-section border-t border-white/5 {{ $openScores ? 'accordion-open' : '' }}">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Scores</h3>
+                        <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div class="accordion-body">
+                        <div class="pb-4 flex flex-col gap-3">
+                            <div class="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label class="block text-sm text-gray-400 mb-1">Min Score</label>
+                                    <input type="text" class="input-dark" name="vote_average_gte" placeholder="0" value="{{ $user_input['vote_average_gte'] ?? '' }}">
+                                </div>
+                                <div>
+                                    <label class="block text-sm text-gray-400 mb-1">Max Score</label>
+                                    <input type="text" class="input-dark" name="vote_average_lte" placeholder="10" value="{{ $user_input['vote_average_lte'] ?? '' }}">
+                                </div>
+                            </div>
+                            <div>
+                                <label class="block text-sm text-gray-400 mb-1">Min Vote Count</label>
+                                <input type="text" class="input-dark" name="vote_count_gte" placeholder="10" value="{{ $user_input['vote_count_gte'] ?? '' }}">
                             </div>
                         </div>
                     </div>

--- a/resources/views/tv/criteria.blade.php
+++ b/resources/views/tv/criteria.blade.php
@@ -73,7 +73,13 @@
             {{-- Language --}}
             <div class="card p-5">
                 <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Language</h3>
-                @include('includes.languages', ['selectedLang' => old('with_original_language', $ui['with_original_language'] ?? 'en')])
+                @include('includes.languages', ['selectedLang' => old('with_original_language', $ui['with_original_language'] ?? '')])
+            </div>
+
+            {{-- Origin Country --}}
+            <div class="card p-5">
+                <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Origin Country</h3>
+                @include('includes.origin-country', ['selectedCountry' => old('with_origin_country', $ui['with_origin_country'] ?? '')])
             </div>
 
             {{-- Streaming --}}
@@ -88,6 +94,31 @@
                     @endforeach
                 </select>
                 <p class="text-xs text-gray-600 mt-1">Shows services available in your region</p>
+            </div>
+
+            {{-- People --}}
+            <div class="card p-5">
+                <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">People</h3>
+                <div class="flex flex-col gap-4">
+                    <div>
+                        <label class="block text-sm text-gray-400 mb-1.5">Actors</label>
+                        <select id="with_cast" name="with_cast[]" multiple>
+                        @foreach((array)($ui['with_cast'] ?? []) as $i => $castId)
+                            <option value="{{ $castId }}" selected>{{ ($ui['with_cast_names'] ?? [])[$i] ?? '' }}</option>
+                        @endforeach
+                    </select>
+                        <p class="text-xs text-gray-600 mt-1">Type to search, you can add multiple</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm text-gray-400 mb-1.5">Crew</label>
+                        <select id="with_crew" name="with_crew[]" multiple>
+                        @foreach((array)($ui['with_crew'] ?? []) as $i => $crewId)
+                            <option value="{{ $crewId }}" selected>{{ ($ui['with_crew_names'] ?? [])[$i] ?? '' }}</option>
+                        @endforeach
+                    </select>
+                        <p class="text-xs text-gray-600 mt-1">Directors, writers, producers — you can add multiple</p>
+                    </div>
+                </div>
             </div>
 
             {{-- Scores --}}
@@ -114,31 +145,6 @@
                             class="input-dark bg-input {{ $errors->has('vote_count_gte') ? 'border-danger' : '' }}"
                             name="vote_count_gte" placeholder="10" value="{{ old('vote_count_gte', $ui['vote_count_gte'] ?? '') }}">
                         <p class="text-xs text-gray-600 mt-1">Filters out obscure shows</p>
-                    </div>
-                </div>
-            </div>
-
-            {{-- People --}}
-            <div class="card p-5">
-                <h3 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">People</h3>
-                <div class="flex flex-col gap-4">
-                    <div>
-                        <label class="block text-sm text-gray-400 mb-1.5">Actors</label>
-                        <select id="with_cast" name="with_cast[]" multiple>
-                        @foreach((array)($ui['with_cast'] ?? []) as $i => $castId)
-                            <option value="{{ $castId }}" selected>{{ ($ui['with_cast_names'] ?? [])[$i] ?? '' }}</option>
-                        @endforeach
-                    </select>
-                        <p class="text-xs text-gray-600 mt-1">Type to search, you can add multiple</p>
-                    </div>
-                    <div>
-                        <label class="block text-sm text-gray-400 mb-1.5">Crew</label>
-                        <select id="with_crew" name="with_crew[]" multiple>
-                        @foreach((array)($ui['with_crew'] ?? []) as $i => $crewId)
-                            <option value="{{ $crewId }}" selected>{{ ($ui['with_crew_names'] ?? [])[$i] ?? '' }}</option>
-                        @endforeach
-                    </select>
-                        <p class="text-xs text-gray-600 mt-1">Directors, writers, producers — you can add multiple</p>
                     </div>
                 </div>
             </div>

--- a/tests/Feature/MoviePickSessionTest.php
+++ b/tests/Feature/MoviePickSessionTest.php
@@ -29,12 +29,19 @@ it('saves submitted criteria in userInput on first submit', function () {
     expect(session('userInput'))->toMatchArray(['vote_count_gte' => '20']);
 });
 
-it('keeps the original userInput when criteria already exists', function () {
+it('overwrites userInput when new criteria is submitted via POST', function () {
     session(['userInput' => ['vote_count_gte' => '99']]);
 
     $this->post('/movie', ['vote_count_gte' => '5']);
 
-    // resolveSessionCriteria does not overwrite an existing session
+    expect(session('userInput.vote_count_gte'))->toBe('5');
+});
+
+it('keeps existing userInput on GET re-roll', function () {
+    session(['userInput' => ['vote_count_gte' => '99']]);
+
+    $this->get('/movie');
+
     expect(session('userInput.vote_count_gte'))->toBe('99');
 });
 
@@ -52,4 +59,31 @@ it('does not redirect on ?i when no session exists', function () {
 
     // Should reach the discover step, not loop back
     expect(session('userInput'))->not->toBeNull();
+});
+
+it('sets default criteria when ?i=new is used with no prior session', function () {
+    $this->get('/movie?i=new')->assertRedirect();
+
+    expect(session('userInput'))->toMatchArray([
+        'with_original_language'   => 'en',
+        'primary_release_date_gte' => 1990,
+        'vote_average_gte'         => 7,
+        'vote_count_gte'           => 100,
+    ]);
+});
+
+it('replaces existing session with defaults when ?i=new is used', function () {
+    session(['userInput' => ['vote_count_gte' => '50', 'with_original_language' => 'fr']]);
+
+    $this->get('/movie?i=new')->assertRedirect();
+
+    expect(session('userInput.vote_count_gte'))->toBe(100);
+    expect(session('userInput.with_original_language'))->toBe('en');
+});
+
+it('strips empty string values from submitted criteria', function () {
+    $this->post('/movie', ['with_original_language' => '', 'vote_count_gte' => '5']);
+
+    expect(session('userInput'))->not->toHaveKey('with_original_language');
+    expect(session('userInput.vote_count_gte'))->toBe('5');
 });

--- a/tests/Feature/TvPickSessionTest.php
+++ b/tests/Feature/TvPickSessionTest.php
@@ -75,3 +75,34 @@ it('clears tvPersonRollIds on modal submit with ?a', function () {
 
     expect(session('tvPersonRollIds'))->toBeNull();
 });
+
+it('sets default tv criteria when ?i=new is used with no prior session', function () {
+    $this->get('/tv/pick?i=new')->assertRedirect();
+
+    expect(session('tvInput'))->toMatchArray([
+        'with_original_language' => 'en',
+        'first_air_date_gte'     => 1990,
+        'vote_average_gte'       => 7,
+        'vote_count_gte'         => 100,
+    ]);
+});
+
+it('replaces existing session with defaults and clears tvPersonRollIds when ?i=new is used', function () {
+    session([
+        'tvInput'         => ['vote_count_gte' => '50', 'with_original_language' => 'fr'],
+        'tvPersonRollIds' => [101, 202],
+    ]);
+
+    $this->get('/tv/pick?i=new')->assertRedirect();
+
+    expect(session('tvInput.vote_count_gte'))->toBe(100);
+    expect(session('tvInput.with_original_language'))->toBe('en');
+    expect(session('tvPersonRollIds'))->toBeNull();
+});
+
+it('strips empty string values from submitted tv criteria', function () {
+    $this->post('/tv/pick', ['with_original_language' => '', 'vote_count_gte' => '5']);
+
+    expect(session('tvInput'))->not->toHaveKey('with_original_language');
+    expect(session('tvInput.vote_count_gte'))->toBe('5');
+});


### PR DESCRIPTION
## Summary

- Add origin country filter to movie and TV criteria pages and modals (Language & Country combined accordion)
- Add exclude genre and origin country filters to roulettes (tag form, mapper, model grouping)
- Fix roulette `buildTags` not saving `without_genre` and `country` tags — they were silently dropped on save
- Poster picker now uses the current form tag selections live, so posters update to match new filters without saving first
- Criteria page always shows a blank form regardless of session state
- Homepage / mobile nav rolls (`?i=new`) set sensible defaults (English, 1990+, score ≥ 7, 100+ votes); submitting the criteria form via POST always overwrites the session, so a blank submission correctly finds anything
- Move People section above Scores on TV criteria page and modal for consistency with movie forms
- Increase poster size on roulette edit pages (`sm:w-52 lg:w-80`, 3-column thumbnail grid)

## Test plan

- [x] Roll from homepage → gets movie with English/1990+/score ≥ 7 defaults
- [x] Go to criteria page → form is blank, not pre-filled with session
- [x] Submit blank criteria form → finds any movie (not filtered by previous session)
- [x] Add origin country on criteria page → rolls correctly filter by country
- [x] Add origin country in adjust criteria modal → same
- [x] Reset button clears country and language dropdowns
- [x] Edit a roulette, change genres/country before saving → poster grid refreshes with new filters immediately
- [x] Save a roulette with exclude genre + country → tags persisted, poster fetch respects them
- [x] TV criteria page: section order is Year → Genres → Language/Country → Streaming → People → Scores