### PR TITLE
Watchlist roll animation with tier-based reveal

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -359,6 +359,14 @@ html[data-theme="light"] {
     }
     .modal-close:hover { background: var(--bg-surface-hover); color: var(--text-primary); }
 
+    /* Watchlist case opening */
+    #case-rays-inner {
+        animation: case-rays-spin 10s linear infinite;
+    }
+    @keyframes case-rays-spin {
+        to { transform: rotate(360deg); }
+    }
+
     /* Progress bar */
     #progress-bar {
         position: fixed;

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -159,6 +159,180 @@ $(document).ready(function () {
 
     $('#sort-select').on('change', applySort);
 
+    /* ── Auto-roll when returning from movie page ──────────────────── */
+    if (sessionStorage.getItem('wl_autoroll') === '1') {
+        sessionStorage.removeItem('wl_autoroll');
+        setTimeout(() => $('#watchlist-roll').trigger('click'), 120);
+    }
+
+    /* ── Animation toggle ──────────────────────────────────────────── */
+    function getAnimEnabled() {
+        return localStorage.getItem('wl_animation') !== '0';
+    }
+
+    function syncToggle() {
+        const on = getAnimEnabled();
+        document.getElementById('anim-toggle').checked = on;
+        document.getElementById('anim-track').style.backgroundColor = on ? '#c0393a' : 'rgba(255,255,255,0.1)';
+        document.getElementById('anim-thumb').style.transform = on ? 'translateX(16px)' : 'translateX(0)';
+    }
+
+    syncToggle();
+
+    $('#anim-toggle').on('change', function () {
+        localStorage.setItem('wl_animation', this.checked ? '1' : '0');
+        syncToggle();
+    });
+
+    /* ── Case opening animation ────────────────────────────────────── */
+    const CARD_W   = 140;
+    const CARD_H   = 200;
+    const CARD_GAP = 8;
+    const STEP     = CARD_W + CARD_GAP;
+    const STRIP_LEN  = 65;
+    const WINNER_POS = 52;
+    const START_POS  = 4;
+
+    const TIERS = [
+        { min: 8.5, color: '#f59e0b', label: 'Masterpiece' },
+        { min: 7.5, color: '#c0393a', label: 'Excellent'   },
+        { min: 6.5, color: '#8b5cf6', label: 'Great'       },
+        { min: 5.5, color: '#3b82f6', label: 'Good'        },
+        { min: 0,   color: '#6b7280', label: 'Mixed'       },
+    ];
+
+    function getTier(rating) {
+        return TIERS.find(t => (rating || 0) >= t.min) || TIERS[TIERS.length - 1];
+    }
+
+    function buildCards() {
+        const cards = [];
+        $('.watchlist-card:visible').each(function () {
+            const link   = $(this).find('a[href]').first();
+            const img    = $(this).find('img').first();
+            const title  = $(this).data('title') || '';
+            const rating = parseFloat($(this).data('rating')) || 0;
+            if (link.length && img.length) {
+                cards.push({
+                    url:    link.attr('href'),
+                    poster: (img.attr('src') || '').replace('w500', 'w342'),
+                    title,
+                    rating,
+                });
+            }
+        });
+        return cards;
+    }
+
+    function runCaseOpening(cards, winnerIdx, fullUrl) {
+        const strip = Array.from({ length: STRIP_LEN }, (_, i) => cards[i % cards.length]);
+        strip[WINNER_POS] = cards[winnerIdx];
+
+        const overlay    = document.getElementById('case-overlay');
+        const stripEl    = document.getElementById('case-strip');
+        const titleEl    = document.getElementById('case-winner-title');
+        const tierEl     = document.getElementById('case-winner-tier');
+        const raysEl     = document.getElementById('case-rays');
+        const raysInner  = document.getElementById('case-rays-inner');
+        const glowEl     = document.getElementById('case-glow');
+        const viewport   = document.getElementById('case-viewport');
+
+        // Populate strip — each card gets a subtle tier-colored border
+        stripEl.innerHTML = '';
+        strip.forEach((card, i) => {
+            const tier = getTier(card.rating);
+            const el = document.createElement('div');
+            el.className = 'case-card flex-shrink-0 rounded-lg overflow-hidden relative';
+            el.style.cssText = `width:${CARD_W}px;height:${CARD_H}px;box-shadow:0 0 10px 2px ${tier.color}44;outline:1px solid ${tier.color}55`;
+            if (i === WINNER_POS) el.id = 'case-winner-card';
+            el.innerHTML = `
+                <img src="${card.poster}" alt="" class="w-full h-full object-cover" loading="eager">
+                <div style="position:absolute;inset:0;background:linear-gradient(to top, ${tier.color}cc 0%, ${tier.color}33 35%, transparent 65%);pointer-events:none"></div>
+                <div style="position:absolute;bottom:0;left:0;right:0;padding:5px 6px;text-align:center">
+                    <span style="font-size:9px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#fff;text-shadow:0 1px 4px rgba(0,0,0,0.8)">${tier.label}</span>
+                </div>
+            `;
+            stripEl.appendChild(el);
+        });
+
+        overlay.classList.remove('hidden');
+        titleEl.classList.add('opacity-0');
+        tierEl.classList.add('opacity-0');
+        titleEl.textContent    = '';
+        tierEl.textContent     = '';
+        raysEl.style.opacity   = '0';
+        glowEl.style.opacity   = '0';
+
+        const cw     = viewport.clientWidth;
+        const center = cw / 2;
+        const startX = center - (START_POS  * STEP + CARD_W / 2);
+        const endX   = center - (WINNER_POS * STEP + CARD_W / 2);
+
+        // Prefetch winner page so it loads instantly after animation
+        const prefetchLink = document.createElement('link');
+        prefetchLink.rel  = 'prefetch';
+        prefetchLink.href = fullUrl;
+        document.head.appendChild(prefetchLink);
+
+        stripEl.style.transition = 'none';
+        stripEl.style.transform  = `translateX(${startX}px)`;
+
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            stripEl.style.transition = 'transform 7s cubic-bezier(0.12, 0.9, 0.1, 1)';
+            stripEl.style.transform  = `translateX(${endX}px)`;
+        }));
+
+        // Reveal winner with tier color
+        setTimeout(() => {
+            const winner = cards[winnerIdx];
+            const tier   = getTier(winner.rating);
+            const winnerEl = document.getElementById('case-winner-card');
+
+            // Winner card glow
+            if (winnerEl) {
+                winnerEl.style.outline    = `2px solid ${tier.color}`;
+                winnerEl.style.boxShadow  = `0 0 32px 10px ${tier.color}66`;
+                winnerEl.style.transform  = 'scale(1.06)';
+                winnerEl.style.transition = 'transform 0.25s ease, box-shadow 0.25s ease';
+            }
+
+            // Sunburst rays
+            raysInner.style.background = `repeating-conic-gradient(
+                from 0deg at 50% 50%,
+                ${tier.color}55 0deg 7deg,
+                transparent 7deg 20deg
+            )`;
+            raysInner.style.maskImage        = 'radial-gradient(circle, white 15%, transparent 68%)';
+            raysInner.style.webkitMaskImage  = 'radial-gradient(circle, white 15%, transparent 68%)';
+            raysEl.style.transition  = 'opacity 0.9s ease';
+            raysEl.style.opacity     = '1';
+
+            // Central glow
+            glowEl.style.background = `radial-gradient(circle, ${tier.color}50 0%, transparent 70%)`;
+            glowEl.style.transition = 'opacity 0.9s ease';
+            glowEl.style.opacity    = '1';
+
+            // Tier badge + title
+            tierEl.textContent = tier.label;
+            tierEl.style.color = tier.color;
+            tierEl.classList.remove('opacity-0');
+            titleEl.textContent = winner.title;
+            titleEl.classList.remove('opacity-0');
+        }, 7050);
+
+        // Navigate
+        setTimeout(() => { window.location.href = fullUrl; }, 8500);
+
+        // Escape to cancel
+        document.addEventListener('keydown', function onEsc(e) {
+            if (e.key === 'Escape') {
+                overlay.classList.add('hidden');
+                document.removeEventListener('keydown', onEsc);
+            }
+        });
+    }
+
+    /* ── Roll button ───────────────────────────────────────────────── */
     $('#watchlist-roll').on('click', function () {
         const visible = $('.watchlist-card:visible');
         if (!visible.length) {
@@ -168,13 +342,23 @@ $(document).ready(function () {
             setTimeout(() => btn.text(orig).prop('disabled', false), 1500);
             return;
         }
-        const status = $('.watchlist-filter.active').data('filter') || 'all';
-        const genres = genreSelect ? genreSelect.getValue().join(',') : '';
-        const picked = visible.eq(Math.floor(Math.random() * visible.length));
+
+        const status    = $('.watchlist-filter.active').data('filter') || 'all';
+        const genres    = genreSelect ? genreSelect.getValue().join(',') : '';
+        const pickedIdx = Math.floor(Math.random() * visible.length);
+        const picked    = visible.eq(pickedIdx);
         let url = picked.find('a').first().attr('href') + '?wl_status=' + status;
         if (genres) url += '&wl_genres=' + encodeURIComponent(genres);
-        window.showProgress?.();
-        window.location.href = url;
+
+        if (getAnimEnabled()) {
+            const cards      = buildCards();
+            const winnerHref = picked.find('a').first().attr('href');
+            const winnerIdx  = cards.findIndex(c => c.url === winnerHref);
+            runCaseOpening(cards, winnerIdx >= 0 ? winnerIdx : 0, url);
+        } else {
+            window.showProgress?.();
+            window.location.href = url;
+        }
     });
 
 });

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -281,27 +281,58 @@
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
-        {{-- Back button: far left --}}
+        {{-- Left --}}
         <div class="flex-shrink-0">
-            @if(!empty($batchUrl))
-                @php $backLabel = str_contains($batchUrl, 'watchlist') ? '← Watchlist' : '← Batch'; @endphp
-                <a href="{{ $batchUrl }}" class="btn-secondary text-center">{{ $backLabel }}</a>
+            @if(request()->query('wl_status'))
+                <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
+            @elseif(!empty($batchUrl))
+                <a href="{{ $batchUrl }}" class="btn-secondary text-center">← Batch</a>
             @endif
         </div>
-        {{-- Right actions --}}
-        <div class="flex gap-3">
-            <button type="button" class="btn-secondary" data-modal-open="modal-form">Criteria</button>
+        {{-- Right --}}
+        <div class="flex items-center gap-3">
             @if(request()->query('wl_status'))
-                @php
-                    $wlParams = ['status' => request()->query('wl_status')];
-                    if (request()->query('wl_genres')) $wlParams['genres'] = request()->query('wl_genres');
-                @endphp
-                <a href="{{ route('watchlist.roll', $wlParams) }}" class="btn-accent long-single text-center">Roll</a>
+                {{-- Animation toggle (shared with watchlist page) --}}
+                <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+                    <span class="relative inline-block w-9 h-5">
+                        <input type="checkbox" id="anim-toggle" class="sr-only">
+                        <span id="anim-track" class="block w-9 h-5 rounded-full transition-colors duration-200"></span>
+                        <span id="anim-thumb" class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200 shadow"></span>
+                    </span>
+                    Animation
+                </label>
+                <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
+                <button type="button" class="btn-secondary" data-modal-open="modal-form">Criteria</button>
                 <a href="/movie" class="btn-accent long-single text-center">Roll</a>
             @endif
         </div>
     </div>
 </div>
+
+@if(request()->query('wl_status'))
+<script>
+(function () {
+    const track = document.getElementById('anim-track');
+    const thumb = document.getElementById('anim-thumb');
+    const toggle = document.getElementById('anim-toggle');
+    function sync() {
+        const on = localStorage.getItem('wl_animation') !== '0';
+        toggle.checked = on;
+        track.style.backgroundColor = on ? '#c0393a' : 'rgba(255,255,255,0.1)';
+        thumb.style.transform = on ? 'translateX(16px)' : 'translateX(0)';
+    }
+    sync();
+    toggle.addEventListener('change', function () {
+        localStorage.setItem('wl_animation', this.checked ? '1' : '0');
+        sync();
+    });
+    document.getElementById('wl-roll-btn').addEventListener('click', function () {
+        sessionStorage.setItem('wl_autoroll', '1');
+        window.location.href = '{{ route('watchlist') }}';
+    });
+})();
+</script>
+@endif
 
 @endsection

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -137,10 +137,46 @@
 {{-- Sticky bar --}}
 @if($items->isNotEmpty())
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex justify-end">
+    <div class="max-w-7xl mx-auto flex items-center justify-between py-1">
+        <label class="flex items-center gap-2.5 text-xs text-gray-400 cursor-pointer select-none">
+            <span class="relative inline-block w-9 h-5">
+                <input type="checkbox" id="anim-toggle" class="sr-only">
+                <span id="anim-track" class="block w-9 h-5 rounded-full transition-colors duration-200"></span>
+                <span id="anim-thumb" class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200 shadow"></span>
+            </span>
+            Animation
+        </label>
         <button id="watchlist-roll" class="btn-accent px-8">Roll</button>
     </div>
 </div>
 @endif
+
+{{-- Case opening overlay --}}
+<div id="case-overlay" class="hidden fixed inset-0 z-50 flex flex-col items-center justify-center" style="background:rgba(0,0,0,0.88);backdrop-filter:blur(8px)">
+
+    {{-- Sunburst rays (behind everything) --}}
+    <div id="case-rays" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0" style="width:900px;height:900px;z-index:1">
+        <div id="case-rays-inner" style="width:100%;height:100%;border-radius:50%"></div>
+    </div>
+    {{-- Central radial glow --}}
+    <div id="case-glow" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full opacity-0" style="width:320px;height:320px;z-index:2"></div>
+
+    <p class="text-gray-500 text-xs uppercase tracking-widest mb-8" style="position:relative;z-index:20">Good luck...</p>
+
+    <div id="case-viewport" class="relative w-full overflow-hidden" style="height:220px;z-index:20">
+        {{-- Fade edges --}}
+        <div class="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-black to-transparent z-10 pointer-events-none"></div>
+        <div class="absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-black to-transparent z-10 pointer-events-none"></div>
+        {{-- Center indicator --}}
+        <div class="absolute inset-y-0 left-1/2 -translate-x-px w-0.5 bg-accent z-10" style="box-shadow:0 0 14px 3px rgba(192,57,58,0.75)"></div>
+        {{-- Card strip --}}
+        <div id="case-strip" class="absolute top-1 flex" style="gap:8px"></div>
+    </div>
+
+    <div class="mt-8 text-center" style="position:relative;z-index:20">
+        <p id="case-winner-tier" class="text-xs font-bold uppercase tracking-widest mb-2 transition-opacity duration-300 opacity-0"></p>
+        <p id="case-winner-title" class="text-white font-bold text-2xl px-6 transition-opacity duration-500 opacity-0 max-w-lg"></p>
+    </div>
+</div>
 
 @endsection


### PR DESCRIPTION
## Summary

- Full-screen overlay animation plays when rolling from watchlist — scrolling strip of movie posters with the winner landing at center
- Each card shows its tier (Masterpiece/Excellent/Great/Good/Mixed) based on rating, with matching color glow and gradient overlay
- After strip settles: sunburst rays + radial glow reveal, then auto-navigates to the movie
- Winner page is prefetched during animation so it loads instantly
- Animation toggle in watchlist sticky bar, persisted in localStorage
- On the movie page (when arriving from watchlist): sticky bar swaps Criteria for ← Watchlist + toggle + Roll; clicking Roll sets a sessionStorage flag and returns to watchlist which auto-triggers the animation

## Test plan

- [ ] Roll from watchlist with animation on — strip scrolls, winner highlights, rays appear, navigates to movie
- [ ] Roll from watchlist with animation off — navigates directly, no overlay
- [ ] On movie page from watchlist — sticky bar shows ← Watchlist, toggle, Roll
- [ ] Roll from movie page — returns to watchlist and auto-rolls
- [ ] Escape key cancels the overlay
- [ ] Toggle state persists across page loads