### PR TITLE
Roll animation for batch pages, roulettes, and homepage

### DIFF
--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -103,9 +103,10 @@ class MoviePickController extends Controller
     {
         $country = $movieService->getUserCountry();
         $results = $tmdb->discover([
-            'sort_by'          => 'popularity.desc',
-            'page'             => rand(1, 20),
-            'vote_count.gte'   => 50,
+            'sort_by'            => 'popularity.desc',
+            'page'               => rand(1, 20),
+            'vote_count.gte'     => 50,
+            'vote_average.gte'   => 5,
         ], $country);
 
         $picked = $movieService->pickBatch($results['results'] ?? []);

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\TmdbClient;
 use App\Services\MovieService;
 use App\Http\Requests\CriteriaRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
@@ -96,5 +97,24 @@ class MoviePickController extends Controller
         }
 
         return null;
+    }
+
+    public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country = $movieService->getUserCountry();
+        $results = $tmdb->discover([
+            'sort_by'          => 'popularity.desc',
+            'page'             => rand(1, 20),
+            'vote_count.gte'   => 50,
+        ], $country);
+
+        $picked = $movieService->pickBatch($results['results'] ?? []);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('movie', $m['id']),
+        ], $picked));
     }
 }

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -7,6 +7,7 @@ use App\Models\Setting;
 use App\Services\TmdbClient;
 use App\Services\MovieService;
 use App\Services\RouletteTagMapper;
+use Illuminate\Http\JsonResponse;
 use Illuminate\View\View;
 
 class RouletteController extends Controller
@@ -84,6 +85,46 @@ class RouletteController extends Controller
             : collect();
 
         return view('roulettes', compact('movieGrouped', 'tvGrouped', 'communityRoulettes', 'myRoulettes'));
+    }
+
+    public function movies(string $slug, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $roulette = Roulette::where('slug', $slug)
+            ->where(function ($q) {
+                $q->where('is_public', true)
+                  ->orWhere('user_id', auth()->id());
+            })
+            ->firstOrFail();
+
+        $mapper  = new RouletteTagMapper();
+        $country = $movieService->getUserCountry();
+        $isTv    = $roulette->media_type === 'tv';
+
+        if ($isTv) {
+            $base     = $mapper->toCriteriaTv($roulette->tags);
+            $criteria = $movieService->resolveRoulettePageTv($tmdb, $base, $slug, $country);
+            $results  = $tmdb->discoverTv($criteria, $country)['results'] ?? [];
+            $picked   = $movieService->pickBatch($results);
+
+            return response()->json(array_map(fn($m) => [
+                'title'        => $m['name'] ?? $m['title'] ?? '',
+                'poster_path'  => $m['poster_path'] ?? null,
+                'vote_average' => $m['vote_average'] ?? 0,
+                'url'          => route('tv.show', $m['id']),
+            ], $picked));
+        }
+
+        $base    = $mapper->toCriteria($roulette->tags);
+        $criteria = $movieService->resolveRoulettePage($tmdb, $base, $slug, $country);
+        $results  = $tmdb->discover($criteria, $country)['results'] ?? [];
+        $picked   = $movieService->pickBatch($results);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('movie', $m['id']),
+        ], $picked));
     }
 
     public function pick(string $slug, MovieService $movieService, TmdbClient $tmdb): View

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -124,8 +124,9 @@ class TvPickController extends Controller
     {
         $country = $movieService->getUserCountry();
         $results = $tmdb->discoverTv([
-            'sort_by' => 'popularity.desc',
-            'page'    => rand(1, 20),
+            'sort_by'          => 'popularity.desc',
+            'page'             => rand(1, 20),
+            'vote_average.gte' => 5,
         ], $country);
 
         $picked = $movieService->pickBatch($results['results'] ?? []);

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\TmdbClient;
 use App\Services\MovieService;
 use App\Http\Requests\TvCriteriaRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
@@ -117,5 +118,23 @@ class TvPickController extends Controller
         }
 
         return null;
+    }
+
+    public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country = $movieService->getUserCountry();
+        $results = $tmdb->discoverTv([
+            'sort_by' => 'popularity.desc',
+            'page'    => rand(1, 20),
+        ], $country);
+
+        $picked = $movieService->pickBatch($results['results'] ?? []);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['name'] ?? $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('tv.show', $m['id']),
+        ], $picked));
     }
 }

--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -1,0 +1,119 @@
+const CARD_W    = 140;
+const CARD_H    = 200;
+const CARD_GAP  = 8;
+const STEP      = CARD_W + CARD_GAP;
+const STRIP_LEN  = 65;
+const WINNER_POS = 52;
+const START_POS  = 4;
+
+const TIERS = [
+    { min: 8.5, color: '#f59e0b', label: 'Masterpiece' },
+    { min: 7.5, color: '#c0393a', label: 'Excellent'   },
+    { min: 6.5, color: '#8b5cf6', label: 'Great'       },
+    { min: 5.5, color: '#3b82f6', label: 'Good'        },
+    { min: 0,   color: '#6b7280', label: 'Mixed'       },
+];
+
+export function getTier(rating) {
+    return TIERS.find(t => (rating || 0) >= t.min) || TIERS[TIERS.length - 1];
+}
+
+export function runCaseOpening(cards, winnerIdx, fullUrl) {
+    const winner = cards[winnerIdx];
+    const others = cards.filter((_, i) => i !== winnerIdx);
+    const pool = [];
+    while (pool.length < STRIP_LEN) {
+        pool.push(...[...others].sort(() => Math.random() - 0.5));
+    }
+    const strip = pool.slice(0, STRIP_LEN);
+    strip[WINNER_POS] = winner;
+
+    const overlay   = document.getElementById('case-overlay');
+    const stripEl   = document.getElementById('case-strip');
+    const titleEl   = document.getElementById('case-winner-title');
+    const tierEl    = document.getElementById('case-winner-tier');
+    const raysEl    = document.getElementById('case-rays');
+    const raysInner = document.getElementById('case-rays-inner');
+    const glowEl    = document.getElementById('case-glow');
+    const viewport  = document.getElementById('case-viewport');
+
+    stripEl.innerHTML = '';
+    strip.forEach((card, i) => {
+        const tier = getTier(card.rating);
+        const el = document.createElement('div');
+        el.className = 'case-card flex-shrink-0 rounded-lg overflow-hidden relative';
+        el.style.cssText = `width:${CARD_W}px;height:${CARD_H}px;box-shadow:0 0 10px 2px ${tier.color}44;outline:1px solid ${tier.color}55`;
+        if (i === WINNER_POS) el.id = 'case-winner-card';
+        el.innerHTML = `
+            <img src="${card.poster}" alt="" class="w-full h-full object-cover" loading="eager">
+            <div style="position:absolute;inset:0;background:linear-gradient(to top,${tier.color}cc 0%,${tier.color}33 35%,transparent 65%);pointer-events:none"></div>
+            <div style="position:absolute;bottom:0;left:0;right:0;padding:5px 6px;text-align:center">
+                <span style="font-size:9px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#fff;text-shadow:0 1px 4px rgba(0,0,0,0.8)">${tier.label}</span>
+            </div>
+        `;
+        stripEl.appendChild(el);
+    });
+
+    overlay.classList.remove('hidden');
+    titleEl.classList.add('opacity-0');
+    tierEl.classList.add('opacity-0');
+    titleEl.textContent  = '';
+    tierEl.textContent   = '';
+    raysEl.style.opacity = '0';
+    glowEl.style.opacity = '0';
+
+    const cw     = viewport.clientWidth;
+    const center = cw / 2;
+    const startX = center - (START_POS  * STEP + CARD_W / 2);
+    const endX   = center - (WINNER_POS * STEP + CARD_W / 2);
+
+    const prefetchLink = document.createElement('link');
+    prefetchLink.rel  = 'prefetch';
+    prefetchLink.href = fullUrl;
+    document.head.appendChild(prefetchLink);
+
+    stripEl.style.transition = 'none';
+    stripEl.style.transform  = `translateX(${startX}px)`;
+
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        stripEl.style.transition = 'transform 7s cubic-bezier(0.12, 0.9, 0.1, 1)';
+        stripEl.style.transform  = `translateX(${endX}px)`;
+    }));
+
+    setTimeout(() => {
+        const tier     = getTier(winner.rating);
+        const winnerEl = document.getElementById('case-winner-card');
+
+        if (winnerEl) {
+            winnerEl.style.outline    = `2px solid ${tier.color}`;
+            winnerEl.style.boxShadow  = `0 0 32px 10px ${tier.color}66`;
+            winnerEl.style.transform  = 'scale(1.06)';
+            winnerEl.style.transition = 'transform 0.25s ease, box-shadow 0.25s ease';
+        }
+
+        raysInner.style.background = `repeating-conic-gradient(from 0deg at 50% 50%,${tier.color}55 0deg 7deg,transparent 7deg 20deg)`;
+        raysInner.style.maskImage        = 'radial-gradient(circle, white 15%, transparent 68%)';
+        raysInner.style.webkitMaskImage  = 'radial-gradient(circle, white 15%, transparent 68%)';
+        raysEl.style.transition = 'opacity 0.9s ease';
+        raysEl.style.opacity    = '1';
+
+        glowEl.style.background = `radial-gradient(circle, ${tier.color}50 0%, transparent 70%)`;
+        glowEl.style.transition = 'opacity 0.9s ease';
+        glowEl.style.opacity    = '1';
+
+        tierEl.textContent = tier.label;
+        tierEl.style.color = tier.color;
+        tierEl.classList.remove('opacity-0');
+        titleEl.textContent = winner.title;
+        titleEl.classList.remove('opacity-0');
+    }, 7050);
+
+    setTimeout(() => { window.location.href = fullUrl; }, 8500);
+
+    document.addEventListener('keydown', function onEsc(e) {
+        if (e.key === 'Escape') {
+            overlay.classList.add('hidden');
+            document.removeEventListener('keydown', onEsc);
+        }
+    });
+}

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -1,0 +1,88 @@
+import { runCaseOpening } from './caseOpening.js';
+
+function getBatchCards(rowSelector) {
+    const cards = [];
+    document.querySelectorAll(`${rowSelector} [data-batch-card]`).forEach(el => {
+        if (!el.dataset.poster) return;
+        cards.push({
+            url:    el.dataset.url,
+            poster: `https://image.tmdb.org/t/p/w342${el.dataset.poster}`,
+            title:  el.dataset.title,
+            rating: parseFloat(el.dataset.rating) || 0,
+        });
+    });
+    return cards;
+}
+
+function rollCards(cards) {
+    if (!cards.length) return false;
+    const winnerIdx = Math.floor(Math.random() * cards.length);
+    runCaseOpening(cards, winnerIdx, cards[winnerIdx].url);
+    return true;
+}
+
+document.addEventListener('click', function (e) {
+
+    // ── Roulette card Roll button ─────────────────────────────────
+    const rouletteBtn = e.target.closest('[data-roulette-roll]');
+    if (rouletteBtn) {
+        e.preventDefault();
+        const slug = rouletteBtn.dataset.slug;
+        const orig = rouletteBtn.textContent;
+        rouletteBtn.textContent = 'Loading…';
+        rouletteBtn.disabled = true;
+
+        fetch(`/roulettes/${slug}/movies`)
+            .then(r => r.json())
+            .then(movies => {
+                const cards = movies
+                    .filter(m => m.poster_path)
+                    .map(m => ({
+                        url:    m.url,
+                        poster: `https://image.tmdb.org/t/p/w342${m.poster_path}`,
+                        title:  m.title,
+                        rating: m.vote_average,
+                    }));
+
+                rouletteBtn.textContent = orig;
+                rouletteBtn.disabled = false;
+
+                if (!rollCards(cards)) window.location.href = `/roulettes/${slug}`;
+            })
+            .catch(() => { window.location.href = `/roulettes/${slug}`; });
+        return;
+    }
+
+    // ── Batch page Roll button ────────────────────────────────────
+    if (e.target.closest('#batch-roll-btn')) {
+        e.preventDefault();
+        rollCards(getBatchCards('.swiper-multiple'));
+        return;
+    }
+
+    // ── Homepage single pick buttons ──────────────────────────────
+    const link = e.target.closest('a[href]');
+    if (!link) return;
+    const href = link.getAttribute('href');
+
+    if (href === '/movie?i=new' || href === '/tv/pick?i=new') {
+        e.preventDefault();
+        const endpoint = href === '/movie?i=new' ? '/movie/roll' : '/tv/roll';
+
+        fetch(endpoint)
+            .then(r => r.json())
+            .then(movies => {
+                const cards = movies
+                    .filter(m => m.poster_path)
+                    .map(m => ({
+                        url:    m.url,
+                        poster: `https://image.tmdb.org/t/p/w342${m.poster_path}`,
+                        title:  m.title,
+                        rating: m.vote_average,
+                    }));
+                if (!rollCards(cards)) window.location.href = href;
+            })
+            .catch(() => { window.location.href = href; });
+        return;
+    }
+});

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -1,4 +1,5 @@
 import TomSelect from 'tom-select';
+import { getTier, runCaseOpening } from './caseOpening.js';
 
 let genreSelect = null;
 
@@ -185,26 +186,6 @@ $(document).ready(function () {
     });
 
     /* ── Case opening animation ────────────────────────────────────── */
-    const CARD_W   = 140;
-    const CARD_H   = 200;
-    const CARD_GAP = 8;
-    const STEP     = CARD_W + CARD_GAP;
-    const STRIP_LEN  = 65;
-    const WINNER_POS = 52;
-    const START_POS  = 4;
-
-    const TIERS = [
-        { min: 8.5, color: '#f59e0b', label: 'Masterpiece' },
-        { min: 7.5, color: '#c0393a', label: 'Excellent'   },
-        { min: 6.5, color: '#8b5cf6', label: 'Great'       },
-        { min: 5.5, color: '#3b82f6', label: 'Good'        },
-        { min: 0,   color: '#6b7280', label: 'Mixed'       },
-    ];
-
-    function getTier(rating) {
-        return TIERS.find(t => (rating || 0) >= t.min) || TIERS[TIERS.length - 1];
-    }
-
     function buildCards() {
         const cards = [];
         $('.watchlist-card:visible').each(function () {
@@ -222,120 +203,6 @@ $(document).ready(function () {
             }
         });
         return cards;
-    }
-
-    function runCaseOpening(cards, winnerIdx, fullUrl) {
-        const winner = cards[winnerIdx];
-        const others = cards.filter((_, i) => i !== winnerIdx);
-        const pool = [];
-        while (pool.length < STRIP_LEN) {
-            pool.push(...[...others].sort(() => Math.random() - 0.5));
-        }
-        const strip = pool.slice(0, STRIP_LEN);
-        strip[WINNER_POS] = winner;
-
-        const overlay    = document.getElementById('case-overlay');
-        const stripEl    = document.getElementById('case-strip');
-        const titleEl    = document.getElementById('case-winner-title');
-        const tierEl     = document.getElementById('case-winner-tier');
-        const raysEl     = document.getElementById('case-rays');
-        const raysInner  = document.getElementById('case-rays-inner');
-        const glowEl     = document.getElementById('case-glow');
-        const viewport   = document.getElementById('case-viewport');
-
-        // Populate strip — each card gets a subtle tier-colored border
-        stripEl.innerHTML = '';
-        strip.forEach((card, i) => {
-            const tier = getTier(card.rating);
-            const el = document.createElement('div');
-            el.className = 'case-card flex-shrink-0 rounded-lg overflow-hidden relative';
-            el.style.cssText = `width:${CARD_W}px;height:${CARD_H}px;box-shadow:0 0 10px 2px ${tier.color}44;outline:1px solid ${tier.color}55`;
-            if (i === WINNER_POS) el.id = 'case-winner-card';
-            el.innerHTML = `
-                <img src="${card.poster}" alt="" class="w-full h-full object-cover" loading="eager">
-                <div style="position:absolute;inset:0;background:linear-gradient(to top, ${tier.color}cc 0%, ${tier.color}33 35%, transparent 65%);pointer-events:none"></div>
-                <div style="position:absolute;bottom:0;left:0;right:0;padding:5px 6px;text-align:center">
-                    <span style="font-size:9px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#fff;text-shadow:0 1px 4px rgba(0,0,0,0.8)">${tier.label}</span>
-                </div>
-            `;
-            stripEl.appendChild(el);
-        });
-
-        overlay.classList.remove('hidden');
-        titleEl.classList.add('opacity-0');
-        tierEl.classList.add('opacity-0');
-        titleEl.textContent    = '';
-        tierEl.textContent     = '';
-        raysEl.style.opacity   = '0';
-        glowEl.style.opacity   = '0';
-
-        const cw     = viewport.clientWidth;
-        const center = cw / 2;
-        const startX = center - (START_POS  * STEP + CARD_W / 2);
-        const endX   = center - (WINNER_POS * STEP + CARD_W / 2);
-
-        // Prefetch winner page so it loads instantly after animation
-        const prefetchLink = document.createElement('link');
-        prefetchLink.rel  = 'prefetch';
-        prefetchLink.href = fullUrl;
-        document.head.appendChild(prefetchLink);
-
-        stripEl.style.transition = 'none';
-        stripEl.style.transform  = `translateX(${startX}px)`;
-
-        requestAnimationFrame(() => requestAnimationFrame(() => {
-            stripEl.style.transition = 'transform 7s cubic-bezier(0.12, 0.9, 0.1, 1)';
-            stripEl.style.transform  = `translateX(${endX}px)`;
-        }));
-
-        // Reveal winner with tier color
-        setTimeout(() => {
-            const winner = cards[winnerIdx];
-            const tier   = getTier(winner.rating);
-            const winnerEl = document.getElementById('case-winner-card');
-
-            // Winner card glow
-            if (winnerEl) {
-                winnerEl.style.outline    = `2px solid ${tier.color}`;
-                winnerEl.style.boxShadow  = `0 0 32px 10px ${tier.color}66`;
-                winnerEl.style.transform  = 'scale(1.06)';
-                winnerEl.style.transition = 'transform 0.25s ease, box-shadow 0.25s ease';
-            }
-
-            // Sunburst rays
-            raysInner.style.background = `repeating-conic-gradient(
-                from 0deg at 50% 50%,
-                ${tier.color}55 0deg 7deg,
-                transparent 7deg 20deg
-            )`;
-            raysInner.style.maskImage        = 'radial-gradient(circle, white 15%, transparent 68%)';
-            raysInner.style.webkitMaskImage  = 'radial-gradient(circle, white 15%, transparent 68%)';
-            raysEl.style.transition  = 'opacity 0.9s ease';
-            raysEl.style.opacity     = '1';
-
-            // Central glow
-            glowEl.style.background = `radial-gradient(circle, ${tier.color}50 0%, transparent 70%)`;
-            glowEl.style.transition = 'opacity 0.9s ease';
-            glowEl.style.opacity    = '1';
-
-            // Tier badge + title
-            tierEl.textContent = tier.label;
-            tierEl.style.color = tier.color;
-            tierEl.classList.remove('opacity-0');
-            titleEl.textContent = winner.title;
-            titleEl.classList.remove('opacity-0');
-        }, 7050);
-
-        // Navigate
-        setTimeout(() => { window.location.href = fullUrl; }, 8500);
-
-        // Escape to cancel
-        document.addEventListener('keydown', function onEsc(e) {
-            if (e.key === 'Escape') {
-                overlay.classList.add('hidden');
-                document.removeEventListener('keydown', onEsc);
-            }
-        });
     }
 
     /* ── Roll button ───────────────────────────────────────────────── */

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -27,9 +27,10 @@
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex gap-3 sm:justify-end">
         @if(isset($providersArray) && isset($all_genres))
-            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Adjust Criteria</button>
+            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
         @endif
-        <a href="{{ Request::url() }}" class="btn-accent flex-1 sm:flex-none text-center">New Batch</a>
+        <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
+        <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
     </div>
 </div>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -365,6 +365,25 @@
             tvTiles.classList.remove('hidden');
             moviesTiles.classList.add('hidden');
         });
+
+        const trendMoviesBtn = document.getElementById('trend-movies');
+        const trendTvBtn     = document.getElementById('trend-tv');
+        const trendMovies    = document.getElementById('trending-movies');
+        const trendTv        = document.getElementById('trending-tv');
+        if (trendMoviesBtn) {
+            trendMoviesBtn.addEventListener('click', function () {
+                trendMoviesBtn.classList.add('active');    trendMoviesBtn.classList.remove('text-gray-400');
+                trendTvBtn.classList.remove('active');     trendTvBtn.classList.add('text-gray-400');
+                trendMovies.classList.remove('hidden');
+                trendTv.classList.add('hidden');
+            });
+            trendTvBtn.addEventListener('click', function () {
+                trendTvBtn.classList.add('active');        trendTvBtn.classList.remove('text-gray-400');
+                trendMoviesBtn.classList.remove('active'); trendMoviesBtn.classList.add('text-gray-400');
+                trendTv.classList.remove('hidden');
+                trendMovies.classList.add('hidden');
+            });
+        }
     });
     </script>
 

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -5,7 +5,12 @@
             $title = $result['title'] ?? $result['name'] ?? '';
         @endphp
         @if($date)
-        <div class="relative flex-shrink-0 w-44 sm:w-52 lg:w-56">
+        <div class="relative flex-shrink-0 w-44 sm:w-52 lg:w-56"
+             data-batch-card
+             data-title="{{ $title }}"
+             data-rating="{{ $result['vote_average'] ?? 0 }}"
+             data-poster="{{ $result['poster_path'] ?? '' }}"
+             data-url="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : ($linkSuffix ?? '') }}">
             <a href="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}"
                class="block h-full group long-movie" data-name="{{ $title }}">
                 <div class="card card-hover h-full flex flex-col overflow-hidden">

--- a/resources/views/includes/case-overlay.blade.php
+++ b/resources/views/includes/case-overlay.blade.php
@@ -1,0 +1,26 @@
+<div id="case-overlay" class="hidden fixed inset-0 z-50 flex flex-col items-center justify-center" style="background:rgba(0,0,0,0.88);backdrop-filter:blur(8px)">
+
+    {{-- Sunburst rays (behind everything) --}}
+    <div id="case-rays" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0" style="width:900px;height:900px;z-index:1">
+        <div id="case-rays-inner" style="width:100%;height:100%;border-radius:50%"></div>
+    </div>
+    {{-- Central radial glow --}}
+    <div id="case-glow" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full opacity-0" style="width:320px;height:320px;z-index:2"></div>
+
+    <p class="text-gray-500 text-xs uppercase tracking-widest mb-8" style="position:relative;z-index:20">Good luck...</p>
+
+    <div id="case-viewport" class="relative w-full overflow-hidden" style="height:220px;z-index:20">
+        {{-- Fade edges --}}
+        <div class="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-black to-transparent z-10 pointer-events-none"></div>
+        <div class="absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-black to-transparent z-10 pointer-events-none"></div>
+        {{-- Center indicator --}}
+        <div class="absolute inset-y-0 left-1/2 -translate-x-px w-0.5 bg-accent z-10" style="box-shadow:0 0 14px 3px rgba(192,57,58,0.75)"></div>
+        {{-- Card strip --}}
+        <div id="case-strip" class="absolute top-3 flex" style="gap:8px"></div>
+    </div>
+
+    <div class="mt-8 text-center" style="position:relative;z-index:20">
+        <p id="case-winner-tier" class="text-xs font-bold uppercase tracking-widest mb-2 transition-opacity duration-300 opacity-0"></p>
+        <p id="case-winner-title" class="text-white font-bold text-2xl px-6 transition-opacity duration-500 opacity-0 max-w-lg"></p>
+    </div>
+</div>

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -14,8 +14,9 @@
                     $poster   = $roulette->poster_paths[0] ?? null;
                 @endphp
 
+                <div class="flex-shrink-0 w-36 md:w-44">
                 <a href="/roulettes/{{ $roulette->slug }}"
-                   class="group relative flex-shrink-0 w-36 md:w-44 rounded-xl overflow-hidden block bg-slate-900 long-single">
+                   class="group relative rounded-xl overflow-hidden block bg-slate-900 long-single">
                     <div class="aspect-[2/3] relative overflow-hidden">
 
                         @if($poster)
@@ -43,11 +44,13 @@
                                 </div>
                             @endif
                             <h3 class="text-sm font-semibold text-white leading-snug">{{ $roulette->name }}</h3>
-                            <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Roll →</span>
+                            <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Batch →</span>
                         </div>
 
                     </div>
                 </a>
+                <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
+                </div>
 
             @endforeach
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,7 +8,7 @@
     <meta name="description" content="Random Movie Picker — find the perfect film for tonight.">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script>!function(){var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);if(m)document.documentElement.dataset.theme=m[1]}()</script>
-    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js', 'resources/js/custom/search.js'])
+    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js', 'resources/js/custom/search.js', 'resources/js/custom/roulettes.js'])
     @yield('scripts', '')
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-204204564-1"></script>
     <script>
@@ -220,5 +220,6 @@
     </footer>
     @endunless
 
+    @include('includes.case-overlay')
 </body>
 </html>

--- a/resources/views/my-roulettes/index.blade.php
+++ b/resources/views/my-roulettes/index.blade.php
@@ -63,8 +63,9 @@
                         $poster   = $roulette->poster_paths[0] ?? null;
                     @endphp
 
+                    <div class="flex-shrink-0 w-36 md:w-44">
                     <a href="/roulettes/{{ $roulette->slug }}"
-                       class="group relative flex-shrink-0 w-36 md:w-44 rounded-xl overflow-hidden block bg-slate-900">
+                       class="group relative rounded-xl overflow-hidden block bg-slate-900">
                         <div class="aspect-[2/3] relative overflow-hidden">
 
                             @if($poster)
@@ -99,11 +100,13 @@
                                     </div>
                                 @endif
                                 <h3 class="text-sm font-semibold text-white leading-snug">{{ $roulette->name }}</h3>
-                                <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Roll →</span>
+                                <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Batch →</span>
                             </div>
 
                         </div>
                     </a>
+                    <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
+                    </div>
                 @endforeach
             </div>
         </div>

--- a/resources/views/tv/batch.blade.php
+++ b/resources/views/tv/batch.blade.php
@@ -36,9 +36,10 @@
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex gap-3 sm:justify-end">
         @if(isset($providersArray) && isset($all_genres))
-            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Adjust Criteria</button>
+            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
         @endif
-        <a href="{{ Request::url() }}" class="btn-accent flex-1 sm:flex-none text-center">New Batch</a>
+        <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
+        <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
     </div>
 </div>
 

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -151,32 +151,4 @@
 </div>
 @endif
 
-{{-- Case opening overlay --}}
-<div id="case-overlay" class="hidden fixed inset-0 z-50 flex flex-col items-center justify-center" style="background:rgba(0,0,0,0.88);backdrop-filter:blur(8px)">
-
-    {{-- Sunburst rays (behind everything) --}}
-    <div id="case-rays" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0" style="width:900px;height:900px;z-index:1">
-        <div id="case-rays-inner" style="width:100%;height:100%;border-radius:50%"></div>
-    </div>
-    {{-- Central radial glow --}}
-    <div id="case-glow" class="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full opacity-0" style="width:320px;height:320px;z-index:2"></div>
-
-    <p class="text-gray-500 text-xs uppercase tracking-widest mb-8" style="position:relative;z-index:20">Good luck...</p>
-
-    <div id="case-viewport" class="relative w-full overflow-hidden" style="height:220px;z-index:20">
-        {{-- Fade edges --}}
-        <div class="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-black to-transparent z-10 pointer-events-none"></div>
-        <div class="absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-black to-transparent z-10 pointer-events-none"></div>
-        {{-- Center indicator --}}
-        <div class="absolute inset-y-0 left-1/2 -translate-x-px w-0.5 bg-accent z-10" style="box-shadow:0 0 14px 3px rgba(192,57,58,0.75)"></div>
-        {{-- Card strip --}}
-        <div id="case-strip" class="absolute top-3 flex" style="gap:8px"></div>
-    </div>
-
-    <div class="mt-8 text-center" style="position:relative;z-index:20">
-        <p id="case-winner-tier" class="text-xs font-bold uppercase tracking-widest mb-2 transition-opacity duration-300 opacity-0"></p>
-        <p id="case-winner-title" class="text-white font-bold text-2xl px-6 transition-opacity duration-500 opacity-0 max-w-lg"></p>
-    </div>
-</div>
-
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,13 +54,15 @@ Route::get('/criteria',  CriteriaController::class);
 
 Route::match(['get', 'post'], '/movie',    [MoviePickController::class, 'single']);
 Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
-Route::get('/movie/{id}', MovieController::class)->name('movie');
+Route::get('/movie/roll',     [MoviePickController::class, 'rollJson']);
+Route::get('/movie/{id}',     MovieController::class)->name('movie');
 
 // TV Shows
 Route::get('/tv/criteria',                     TvCriteriaController::class);
 Route::match(['get', 'post'], '/tv/pick',      [TvPickController::class, 'single'])->name('tv.pick');
 Route::match(['get', 'post'], '/tv/multiple',  [TvPickController::class, 'batch']);
-Route::get('/tv/{id}', TvShowController::class)->name('tv.show');
+Route::get('/tv/roll',        [TvPickController::class, 'rollJson']);
+Route::get('/tv/{id}',        TvShowController::class)->name('tv.show');
 Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
 Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
 
@@ -98,8 +100,9 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
     Route::delete('users/{user}/roulettes/{roulette}',         [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
 });
 
-Route::get('/roulettes',        [RouletteController::class, 'index']);
-Route::get('/roulettes/{slug}', [RouletteController::class, 'pick']);
+Route::get('/roulettes',                [RouletteController::class, 'index']);
+Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'movies']);
+Route::get('/roulettes/{slug}',         [RouletteController::class, 'pick']);
 
 // Legacy roulette URLs → redirect to new slugs
 Route::get('/roulettes/netflix/horror',    fn() => redirect('/roulettes/netflix-horror', 301));

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig({
                 'resources/js/custom/trailerModal.js',
                 'resources/js/custom/watchlist.js',
                 'resources/js/custom/search.js',
+                'resources/js/custom/roulettes.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Summary

- Roulette cards now have two separate buttons: **Batch** (goes to batch page) and **Roll** (triggers animation). Covers both system and personal roulettes.
- Batch pages (movie + TV) get a **Roll** button in the sticky bar that animates from the currently loaded cards, plus renamed "Adjust Criteria" → "Criteria" and "New Batch" demoted to secondary
- Homepage **Random Movie** / **Random TV Show** buttons now trigger the roll animation using a fresh random discover list (random page 1–20 of popular results) instead of navigating directly
- Shared `caseOpening.js` module extracted so animation logic isn't duplicated across watchlist and roulettes
- Case opening overlay moved to the main layout so it's available on every page
- New JSON endpoints: `GET /movie/roll`, `GET /tv/roll`, `GET /roulettes/{slug}/movies`

## Test plan

- [ ] Roulette page: Roll button fetches movies and plays animation, Batch button goes to batch page
- [ ] My Roulettes page: same Roll/Batch behavior
- [ ] Movie batch page: Roll button animates from loaded cards, New Batch reloads
- [ ] TV batch page: same
- [ ] Homepage "Random Movie": animation plays with random discover results, navigates to winner
- [ ] Homepage "Random TV Show": same for TV
- [ ] Watchlist Roll: still works as before (no regression)
- [ ] Escape key cancels overlay on any page