### PR TITLE
Roll animation improvements

### DIFF
--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -99,8 +99,33 @@ class MoviePickController extends Controller
         return null;
     }
 
+    public function criteriaRollJson(CriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country   = $movieService->getUserCountry();
+        $submitted = $this->submitted($request);
+        $criteria  = $movieService->resolveSessionCriteria($submitted, $request->isMethod('post') && !empty($submitted));
+        $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
+
+        $results = $tmdb->discover($criteria, $country);
+        $picked  = $movieService->pickBatch($results['results'] ?? []);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('movie', $m['id']),
+        ], $picked));
+    }
+
     public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
+        session(['userInput' => [
+            'with_original_language'   => 'en',
+            'primary_release_date_gte' => 1990,
+            'vote_average_gte'         => 7,
+            'vote_count_gte'           => 100,
+        ]]);
+
         $country = $movieService->getUserCountry();
         $results = $tmdb->discover([
             'sort_by'            => 'popularity.desc',

--- a/app/Http/Controllers/PersonRollController.php
+++ b/app/Http/Controllers/PersonRollController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\TmdbClient;
 use App\Services\MovieService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -62,6 +63,65 @@ class PersonRollController extends Controller
         ]);
 
         return redirect()->route('tv.show', [$shows->random()->id]);
+    }
+
+    public function movieJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
+    {
+        $country  = $movieService->getUserCountry();
+        $type     = $request->query('type', 'cast');
+        $criteria = $type === 'crew' ? ['with_crew' => [$id]] : ['with_cast' => [$id]];
+
+        session(['userInput' => $criteria + ['vote_count_gte' => 10]]);
+
+        $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
+        $results = $tmdb->discover($criteria, $country);
+
+        $picked = $movieService->pickBatch($results['results'] ?? []);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('movie', $m['id']),
+        ], $picked));
+    }
+
+    public function tvJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
+    {
+        $person = $tmdb->personDetail($id);
+        $type   = $request->query('type', 'cast');
+
+        $pool = $type === 'crew'
+            ? collect($person->combined_credits->crew ?? [])
+            : collect($person->combined_credits->cast ?? []);
+
+        $shows = $pool
+            ->filter($movieService->tvCreditFilter())
+            ->unique('id')
+            ->values();
+
+        if ($shows->isEmpty()) {
+            return response()->json([]);
+        }
+
+        $personKey = $type === 'crew' ? 'with_crew' : 'with_cast';
+        session([
+            'tvPersonRollIds' => $shows->pluck('id')->map(fn($i) => (int)$i)->toArray(),
+            'tvInput' => [
+                $personKey            => [$id],
+                $personKey . '_names' => [(string)($person->name ?? '')],
+                'vote_count_gte'      => 10,
+            ],
+        ]);
+
+        $picked = $shows->shuffle()->take(12);
+
+        return response()->json($picked->map(fn($m) => [
+            'title'        => $m->name ?? $m->title ?? '',
+            'poster_path'  => $m->poster_path ?? null,
+            'vote_average' => $m->vote_average ?? 0,
+            'url'          => route('tv.show', $m->id),
+        ])->values()->all());
     }
 
     public function tvNext(): RedirectResponse

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -120,8 +120,33 @@ class TvPickController extends Controller
         return null;
     }
 
+    public function criteriaRollJson(TvCriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country   = $movieService->getUserCountry();
+        $submitted = $this->submitted($request);
+        $criteria  = $this->resolveSessionCriteria($submitted, $request->isMethod('post') && !empty($submitted));
+        $criteria['page'] = $movieService->resolveTvPage($tmdb, $criteria, $country);
+
+        $results = $tmdb->discoverTv($criteria, $country);
+        $picked  = $movieService->pickBatch($results['results'] ?? []);
+
+        return response()->json(array_map(fn($m) => [
+            'title'        => $m['name'] ?? $m['title'] ?? '',
+            'poster_path'  => $m['poster_path'] ?? null,
+            'vote_average' => $m['vote_average'] ?? 0,
+            'url'          => route('tv.show', $m['id']),
+        ], $picked));
+    }
+
     public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
+        session(['tvInput' => [
+            'with_original_language' => 'en',
+            'first_air_date_gte'     => 1990,
+            'vote_average_gte'       => 7,
+            'vote_count_gte'         => 100,
+        ]]);
+
         $country = $movieService->getUserCountry();
         $results = $tmdb->discoverTv([
             'sort_by'          => 'popularity.desc',

--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -64,8 +64,10 @@ export function runCaseOpening(cards, winnerIdx, fullUrl) {
 
     const cw     = viewport.clientWidth;
     const center = cw / 2;
-    const startX = center - (START_POS  * STEP + CARD_W / 2);
-    const endX   = center - (WINNER_POS * STEP + CARD_W / 2);
+    const startX  = center - (START_POS  * STEP + CARD_W / 2);
+    const centerX = center - (WINNER_POS * STEP + CARD_W / 2);
+    const landOffset = Math.floor(Math.random() * (CARD_W - 20)) - (CARD_W - 20) / 2;
+    const landX   = centerX + landOffset;
 
     const prefetchLink = document.createElement('link');
     prefetchLink.rel  = 'prefetch';
@@ -77,12 +79,15 @@ export function runCaseOpening(cards, winnerIdx, fullUrl) {
 
     requestAnimationFrame(() => requestAnimationFrame(() => {
         stripEl.style.transition = 'transform 7s cubic-bezier(0.12, 0.9, 0.1, 1)';
-        stripEl.style.transform  = `translateX(${endX}px)`;
+        stripEl.style.transform  = `translateX(${landX}px)`;
     }));
 
     setTimeout(() => {
         const tier     = getTier(winner.rating);
         const winnerEl = document.getElementById('case-winner-card');
+
+        stripEl.style.transition = 'transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)';
+        stripEl.style.transform  = `translateX(${centerX}px)`;
 
         if (winnerEl) {
             winnerEl.style.outline    = `2px solid ${tier.color}`;

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -80,11 +80,14 @@ document.addEventListener('submit', function (e) {
     sessionStorage.removeItem('rollSource');
     sessionStorage.removeItem('rollBackUrl');
     sessionStorage.removeItem('rollBackLabel');
-    const body     = new FormData(form);
+    const body = new FormData(form);
+
+    if (btn) { btn.textContent = 'Loading…'; btn.disabled = true; }
 
     fetch(endpoint, { method: 'POST', body })
         .then(r => r.json())
         .then(movies => {
+            if (btn) { btn.textContent = isMovie ? 'Find Movie' : 'Find Show'; btn.disabled = false; }
             const cards = movies
                 .filter(m => m.poster_path)
                 .map(m => ({
@@ -105,6 +108,16 @@ document.addEventListener('click', function (e) {
         sessionStorage.removeItem('rollSource');
         sessionStorage.removeItem('rollBackUrl');
         sessionStorage.removeItem('rollBackLabel');
+        return;
+    }
+
+    // ── Roulette card "Batch →" link ──────────────────────────────
+    const batchLink = e.target.closest('[data-roulette-batch]');
+    if (batchLink) {
+        const isMyRoulettes = window.location.pathname.startsWith('/my-roulettes');
+        sessionStorage.setItem('rollSource',    'roulette');
+        sessionStorage.setItem('rollBackUrl',   isMyRoulettes ? '/my-roulettes' : '/roulettes');
+        sessionStorage.setItem('rollBackLabel', isMyRoulettes ? '← My Roulettes' : '← Roulettes');
         return;
     }
 
@@ -163,7 +176,10 @@ document.addEventListener('click', function (e) {
         'tv-criteria':    '/tv/roll/criteria',
     };
 
-    if (rollType && endpoints[rollType]) {
+    const isPersonRoll = rollType === 'person-movie' || rollType === 'person-tv';
+    const jsonUrl = isPersonRoll ? link.dataset.jsonUrl : (rollType ? endpoints[rollType] : null);
+
+    if (jsonUrl) {
         e.preventDefault();
         const fallback = link.href;
         if (rollType === 'movie' || rollType === 'tv') {
@@ -172,9 +188,13 @@ document.addEventListener('click', function (e) {
             sessionStorage.removeItem('rollBackLabel');
         }
 
-        fetch(endpoints[rollType])
+        const origText = link.textContent;
+        link.textContent = 'Loading…';
+
+        fetch(jsonUrl)
             .then(r => r.json())
             .then(movies => {
+                link.textContent = origText;
                 const cards = movies
                     .filter(m => m.poster_path)
                     .map(m => ({

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -1,5 +1,40 @@
 import { runCaseOpening } from './caseOpening.js';
 
+// ── Animation toggle (shared across all pages) ────────────────────────
+function syncAnimToggles() {
+    const on = localStorage.getItem('wl_animation') !== '0';
+    document.querySelectorAll('[data-anim-toggle]').forEach(input => {
+        input.checked = on;
+        const label = input.closest('label');
+        if (!label) return;
+        const track = label.querySelector('[data-anim-track]');
+        const thumb = label.querySelector('[data-anim-thumb]');
+        if (track) track.style.backgroundColor = on ? '#c0393a' : 'rgba(255,255,255,0.1)';
+        if (thumb) thumb.style.transform = on ? 'translateX(16px)' : 'translateX(0)';
+    });
+}
+
+document.addEventListener('change', function (e) {
+    if (e.target.matches('[data-anim-toggle]')) {
+        localStorage.setItem('wl_animation', e.target.checked ? '1' : '0');
+        syncAnimToggles();
+    }
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+    syncAnimToggles();
+    if (sessionStorage.getItem('rollSource') === 'roulette') {
+        document.querySelectorAll('.js-criteria-btn').forEach(el => el.classList.add('hidden'));
+        const backUrl   = sessionStorage.getItem('rollBackUrl')   || '/roulettes';
+        const backLabel = sessionStorage.getItem('rollBackLabel') || '← Roulettes';
+        document.querySelectorAll('.js-back-roulettes').forEach(el => {
+            el.href = backUrl;
+            el.textContent = backLabel;
+            el.classList.remove('hidden');
+        });
+    }
+});
+
 function getBatchCards(rowSelector) {
     const cards = [];
     document.querySelectorAll(`${rowSelector} [data-batch-card]`).forEach(el => {
@@ -14,14 +49,64 @@ function getBatchCards(rowSelector) {
     return cards;
 }
 
-function rollCards(cards) {
+function rollCards(cards, source) {
     if (!cards.length) return false;
+    document.querySelectorAll('.modal-wrap').forEach(m => m.classList.add('hidden'));
+    const rollSource = source || sessionStorage.getItem('rollSource');
+    if (rollSource) sessionStorage.setItem('rollSource', rollSource);
     const winnerIdx = Math.floor(Math.random() * cards.length);
-    runCaseOpening(cards, winnerIdx, cards[winnerIdx].url);
+    if (localStorage.getItem('wl_animation') !== '0') {
+        runCaseOpening(cards, winnerIdx, cards[winnerIdx].url);
+    } else {
+        window.location.href = cards[winnerIdx].url;
+    }
     return true;
 }
 
+document.addEventListener('submit', function (e) {
+    const form = e.target;
+    if (form.tagName !== 'FORM') return;
+
+    const btn        = e.submitter;
+    const formaction = (btn && btn.getAttribute('formaction')) || form.getAttribute('action') || '';
+    const isMovie    = /^\/movie(\?|$)/.test(formaction);
+    const isTv       = /^\/tv\/pick(\?|$)/.test(formaction);
+    if (!isMovie && !isTv) return;
+
+    e.preventDefault();
+
+    const endpoint = isMovie ? '/movie/roll/criteria' : '/tv/roll/criteria';
+    const fallback = formaction;
+    sessionStorage.removeItem('rollSource');
+    sessionStorage.removeItem('rollBackUrl');
+    sessionStorage.removeItem('rollBackLabel');
+    const body     = new FormData(form);
+
+    fetch(endpoint, { method: 'POST', body })
+        .then(r => r.json())
+        .then(movies => {
+            const cards = movies
+                .filter(m => m.poster_path)
+                .map(m => ({
+                    url:    m.url,
+                    poster: `https://image.tmdb.org/t/p/w342${m.poster_path}`,
+                    title:  m.title,
+                    rating: m.vote_average,
+                }));
+            if (!rollCards(cards)) window.location.href = fallback;
+        })
+        .catch(() => { window.location.href = fallback; });
+});
+
 document.addEventListener('click', function (e) {
+
+    // ── Back to Roulettes ─────────────────────────────────────────
+    if (e.target.closest('.js-back-roulettes')) {
+        sessionStorage.removeItem('rollSource');
+        sessionStorage.removeItem('rollBackUrl');
+        sessionStorage.removeItem('rollBackLabel');
+        return;
+    }
 
     // ── Roulette card Roll button ─────────────────────────────────
     const rouletteBtn = e.target.closest('[data-roulette-roll]');
@@ -47,7 +132,10 @@ document.addEventListener('click', function (e) {
                 rouletteBtn.textContent = orig;
                 rouletteBtn.disabled = false;
 
-                if (!rollCards(cards)) window.location.href = `/roulettes/${slug}`;
+                const isMyRoulettes = window.location.pathname.startsWith('/my-roulettes');
+                sessionStorage.setItem('rollBackUrl',   isMyRoulettes ? '/my-roulettes' : '/roulettes');
+                sessionStorage.setItem('rollBackLabel', isMyRoulettes ? '← My Roulettes' : '← Roulettes');
+                if (!rollCards(cards, 'roulette')) window.location.href = `/roulettes/${slug}`;
             })
             .catch(() => { window.location.href = `/roulettes/${slug}`; });
         return;
@@ -60,16 +148,31 @@ document.addEventListener('click', function (e) {
         return;
     }
 
-    // ── Homepage single pick buttons ──────────────────────────────
+    // ── Any [data-roll] or homepage single pick buttons ───────────
     const link = e.target.closest('a[href]');
     if (!link) return;
-    const href = link.getAttribute('href');
+    const href     = link.getAttribute('href');
+    const rollType = link.dataset.roll
+        || (href === '/movie?i=new' ? 'movie' : null)
+        || (href === '/tv/pick?i=new' ? 'tv' : null);
 
-    if (href === '/movie?i=new' || href === '/tv/pick?i=new') {
+    const endpoints = {
+        'movie':          '/movie/roll',
+        'tv':             '/tv/roll',
+        'movie-criteria': '/movie/roll/criteria',
+        'tv-criteria':    '/tv/roll/criteria',
+    };
+
+    if (rollType && endpoints[rollType]) {
         e.preventDefault();
-        const endpoint = href === '/movie?i=new' ? '/movie/roll' : '/tv/roll';
+        const fallback = link.href;
+        if (rollType === 'movie' || rollType === 'tv') {
+            sessionStorage.removeItem('rollSource');
+            sessionStorage.removeItem('rollBackUrl');
+            sessionStorage.removeItem('rollBackLabel');
+        }
 
-        fetch(endpoint)
+        fetch(endpoints[rollType])
             .then(r => r.json())
             .then(movies => {
                 const cards = movies
@@ -80,9 +183,9 @@ document.addEventListener('click', function (e) {
                         title:  m.title,
                         rating: m.vote_average,
                     }));
-                if (!rollCards(cards)) window.location.href = href;
+                if (!rollCards(cards)) window.location.href = fallback;
             })
-            .catch(() => { window.location.href = href; });
+            .catch(() => { window.location.href = fallback; });
         return;
     }
 });

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -166,25 +166,6 @@ $(document).ready(function () {
         setTimeout(() => $('#watchlist-roll').trigger('click'), 120);
     }
 
-    /* ── Animation toggle ──────────────────────────────────────────── */
-    function getAnimEnabled() {
-        return localStorage.getItem('wl_animation') !== '0';
-    }
-
-    function syncToggle() {
-        const on = getAnimEnabled();
-        document.getElementById('anim-toggle').checked = on;
-        document.getElementById('anim-track').style.backgroundColor = on ? '#c0393a' : 'rgba(255,255,255,0.1)';
-        document.getElementById('anim-thumb').style.transform = on ? 'translateX(16px)' : 'translateX(0)';
-    }
-
-    syncToggle();
-
-    $('#anim-toggle').on('change', function () {
-        localStorage.setItem('wl_animation', this.checked ? '1' : '0');
-        syncToggle();
-    });
-
     /* ── Case opening animation ────────────────────────────────────── */
     function buildCards() {
         const cards = [];
@@ -223,7 +204,7 @@ $(document).ready(function () {
         let url = picked.find('a').first().attr('href') + '?wl_status=' + status;
         if (genres) url += '&wl_genres=' + encodeURIComponent(genres);
 
-        if (getAnimEnabled()) {
+        if (localStorage.getItem('wl_animation') !== '0') {
             const cards      = buildCards();
             const winnerHref = picked.find('a').first().attr('href');
             const winnerIdx  = cards.findIndex(c => c.url === winnerHref);

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -25,12 +25,16 @@
 
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex gap-3 sm:justify-end">
-        @if(isset($providersArray) && isset($all_genres))
-            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
-        @endif
-        <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
-        <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
+        <div class="flex-shrink-0"></div>
+        <div class="flex items-center gap-3">
+            @if(isset($providersArray) && isset($all_genres))
+                <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
+            @endif
+            <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
+            @include('includes.anim-toggle')
+            <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
+        </div>
     </div>
 </div>
 

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -149,10 +149,13 @@
 
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
-    <div class="max-w-2xl mx-auto flex gap-2 sm:justify-end">
-        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden">Reset</button>
-        <button type="submit" form="criteria" formaction="/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
-        <button type="submit" form="criteria" formaction="/movie" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Movie</button>
+    <div class="max-w-2xl mx-auto flex items-center justify-between gap-2">
+        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden flex-shrink-0">Reset</button>
+        <div class="flex items-center gap-2 sm:ml-auto">
+            <button type="submit" form="criteria" formaction="/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
+            @include('includes.anim-toggle')
+            <button type="submit" form="criteria" formaction="/movie" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Movie</button>
+        </div>
     </div>
 </div>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,4 +1,5 @@
 @extends('layouts.app')
+@section('footer_pb', 'pb-16')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/watchlist.js'])
 @endsection
@@ -386,5 +387,12 @@
         }
     });
     </script>
+
+{{-- Sticky bottom bar --}}
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
+    <div class="max-w-7xl mx-auto flex items-center justify-end gap-3">
+        @include('includes.anim-toggle')
+    </div>
+</div>
 
 @endsection

--- a/resources/views/includes/anim-toggle.blade.php
+++ b/resources/views/includes/anim-toggle.blade.php
@@ -1,0 +1,8 @@
+<label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+    <span class="relative inline-block w-9 h-5">
+        <input type="checkbox" data-anim-toggle class="sr-only">
+        <span data-anim-track class="block w-9 h-5 rounded-full transition-colors duration-200"></span>
+        <span data-anim-thumb class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200 shadow"></span>
+    </span>
+    Animation
+</label>

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="flex-shrink-0 w-36 md:w-44">
                 <a href="/roulettes/{{ $roulette->slug }}"
+                   data-roulette-batch
                    class="group relative rounded-xl overflow-hidden block bg-slate-900 long-single">
                     <div class="aspect-[2/3] relative overflow-hidden">
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -294,15 +294,7 @@
         {{-- Right --}}
         <div class="flex items-center gap-3">
             @if(request()->query('wl_status'))
-                {{-- Animation toggle (shared with watchlist page) --}}
-                <label class="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
-                    <span class="relative inline-block w-9 h-5">
-                        <input type="checkbox" id="anim-toggle" class="sr-only">
-                        <span id="anim-track" class="block w-9 h-5 rounded-full transition-colors duration-200"></span>
-                        <span id="anim-thumb" class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200 shadow"></span>
-                    </span>
-                    Animation
-                </label>
+                @include('includes.anim-toggle')
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
                 @include('includes.anim-toggle')
@@ -315,26 +307,10 @@
 
 @if(request()->query('wl_status'))
 <script>
-(function () {
-    const track = document.getElementById('anim-track');
-    const thumb = document.getElementById('anim-thumb');
-    const toggle = document.getElementById('anim-toggle');
-    function sync() {
-        const on = localStorage.getItem('wl_animation') !== '0';
-        toggle.checked = on;
-        track.style.backgroundColor = on ? '#c0393a' : 'rgba(255,255,255,0.1)';
-        thumb.style.transform = on ? 'translateX(16px)' : 'translateX(0)';
-    }
-    sync();
-    toggle.addEventListener('change', function () {
-        localStorage.setItem('wl_animation', this.checked ? '1' : '0');
-        sync();
-    });
-    document.getElementById('wl-roll-btn').addEventListener('click', function () {
-        sessionStorage.setItem('wl_autoroll', '1');
-        window.location.href = '{{ route('watchlist') }}';
-    });
-})();
+document.getElementById('wl-roll-btn').addEventListener('click', function () {
+    sessionStorage.setItem('wl_autoroll', '1');
+    window.location.href = '{{ route('watchlist') }}';
+});
 </script>
 @endif
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -287,6 +287,8 @@
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
             @elseif(!empty($batchUrl))
                 <a href="{{ $batchUrl }}" class="btn-secondary text-center">← Batch</a>
+            @else
+                <a href="/roulettes" class="btn-secondary text-center hidden js-back-roulettes">← Roulettes</a>
             @endif
         </div>
         {{-- Right --}}
@@ -303,8 +305,9 @@
                 </label>
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
-                <button type="button" class="btn-secondary" data-modal-open="modal-form">Criteria</button>
-                <a href="/movie" class="btn-accent long-single text-center">Roll</a>
+                @include('includes.anim-toggle')
+                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
+                <a href="/movie" class="btn-accent long-single text-center" data-roll="movie-criteria">Roll</a>
             @endif
         </div>
     </div>

--- a/resources/views/my-roulettes/index.blade.php
+++ b/resources/views/my-roulettes/index.blade.php
@@ -116,4 +116,11 @@
     @endif
 
 </div>
+
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
+    <div class="max-w-7xl mx-auto flex items-center justify-end py-1">
+        @include('includes.anim-toggle')
+    </div>
+</div>
+
 @endsection

--- a/resources/views/person.blade.php
+++ b/resources/views/person.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.app')
 @section('page_title', ($person->name ?? 'Person').' — MoviePickr')
+@section('footer_pb', 'pb-20')
 @section('content')
 <div class="max-w-4xl mx-auto px-4 py-8">
 
@@ -61,12 +62,16 @@
                 <div class="flex flex-wrap gap-2">
                     @if($hasMovieCast)
                     <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'cast']) }}"
+                       data-roll="person-movie"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=cast') }}"
                        class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
                         Roll as actor
                     </a>
                     @endif
                     @if($hasMovieCrew)
                     <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'crew']) }}"
+                       data-roll="person-movie"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=crew') }}"
                        class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
                         Roll as crew
                     </a>
@@ -80,12 +85,16 @@
                 <div class="flex flex-wrap gap-2">
                     @if($hasTvCast)
                     <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'cast']) }}"
+                       data-roll="person-tv"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=cast') }}"
                        class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
                         Roll as actor
                     </a>
                     @endif
                     @if($hasTvCrew)
                     <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'crew']) }}"
+                       data-roll="person-tv"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=crew') }}"
                        class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
                         Roll as crew
                     </a>
@@ -231,6 +240,13 @@
     </div>
     @endif
 
+</div>
+
+{{-- Sticky bottom bar --}}
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
+    <div class="max-w-4xl mx-auto flex items-center justify-end gap-3">
+        @include('includes.anim-toggle')
+    </div>
 </div>
 
 @if($showMovies && $showTv)

--- a/resources/views/roulettes.blade.php
+++ b/resources/views/roulettes.blade.php
@@ -79,4 +79,10 @@
 
 </script>
 
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
+    <div class="max-w-7xl mx-auto flex items-center justify-end py-1">
+        @include('includes.anim-toggle')
+    </div>
+</div>
+
 @endsection

--- a/resources/views/tv/batch.blade.php
+++ b/resources/views/tv/batch.blade.php
@@ -34,12 +34,16 @@
 
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex gap-3 sm:justify-end">
-        @if(isset($providersArray) && isset($all_genres))
-            <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
-        @endif
-        <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
-        <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
+        <div class="flex-shrink-0"></div>
+        <div class="flex items-center gap-3">
+            @if(isset($providersArray) && isset($all_genres))
+                <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
+            @endif
+            <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
+            @include('includes.anim-toggle')
+            <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
+        </div>
     </div>
 </div>
 

--- a/resources/views/tv/criteria.blade.php
+++ b/resources/views/tv/criteria.blade.php
@@ -157,10 +157,13 @@
 
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
-    <div class="max-w-2xl mx-auto flex gap-2 sm:justify-end">
-        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden">Reset</button>
-        <button type="submit" form="criteria" formaction="/tv/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
-        <button type="submit" form="criteria" formaction="/tv/pick" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Show</button>
+    <div class="max-w-2xl mx-auto flex items-center justify-between gap-2">
+        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden flex-shrink-0">Reset</button>
+        <div class="flex items-center gap-2 sm:ml-auto">
+            <button type="submit" form="criteria" formaction="/tv/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
+            @include('includes.anim-toggle')
+            <button type="submit" form="criteria" formaction="/tv/pick" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Show</button>
+        </div>
     </div>
 </div>
 

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -373,11 +373,14 @@
             @if(!empty($batchUrl))
                 @php $backLabel = str_contains($batchUrl, 'watchlist') ? '← Watchlist' : '← Batch'; @endphp
                 <a href="{{ $batchUrl }}" class="btn-secondary text-center">{{ $backLabel }}</a>
+            @else
+                <a href="/roulettes" class="btn-secondary text-center hidden js-back-roulettes">← Roulettes</a>
             @endif
         </div>
         {{-- Right actions --}}
-        <div class="flex gap-3">
-            <button type="button" class="btn-secondary" data-modal-open="modal-form">Criteria</button>
+        <div class="flex items-center gap-3">
+            @include('includes.anim-toggle')
+            <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
             @if(request()->query('wl_status'))
                 @php
                     $wlParams = ['status' => request()->query('wl_status')];
@@ -387,7 +390,7 @@
             @elseif(session('tvPersonRollIds'))
                 <a href="{{ route('person.roll.tv.next') }}" class="btn-accent long-single text-center">Roll</a>
             @else
-                <a href="/tv/pick" class="btn-accent long-single text-center">Roll</a>
+                <a href="/tv/pick" class="btn-accent long-single text-center" data-roll="tv-criteria">Roll</a>
             @endif
         </div>
     </div>

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -138,15 +138,11 @@
 @if($items->isNotEmpty())
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex items-center justify-between py-1">
-        <label class="flex items-center gap-2.5 text-xs text-gray-400 cursor-pointer select-none">
-            <span class="relative inline-block w-9 h-5">
-                <input type="checkbox" id="anim-toggle" class="sr-only">
-                <span id="anim-track" class="block w-9 h-5 rounded-full transition-colors duration-200"></span>
-                <span id="anim-thumb" class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform duration-200 shadow"></span>
-            </span>
-            Animation
-        </label>
-        <button id="watchlist-roll" class="btn-accent px-8">Roll</button>
+        <div class="flex-shrink-0"></div>
+        <div class="flex items-center gap-3">
+            @include('includes.anim-toggle')
+            <button id="watchlist-roll" class="btn-accent px-8">Roll</button>
+        </div>
     </div>
 </div>
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,8 +70,10 @@ Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::cl
 
 Route::get('/person/roll/tv/next',    [PersonRollController::class, 'tvNext'])->name('person.roll.tv.next');
 Route::get('/person/{id}',            PersonController::class)->name('person');
-Route::get('/person/{id}/roll/movie', [PersonRollController::class, 'movie'])->name('person.roll.movie');
-Route::get('/person/{id}/roll/tv',    [PersonRollController::class, 'tv'])->name('person.roll.tv');
+Route::get('/person/{id}/roll/movie',      [PersonRollController::class, 'movie'])->name('person.roll.movie');
+Route::get('/person/{id}/roll/tv',         [PersonRollController::class, 'tv'])->name('person.roll.tv');
+Route::get('/person/{id}/roll/movie/json', [PersonRollController::class, 'movieJson']);
+Route::get('/person/{id}/roll/tv/json',    [PersonRollController::class, 'tvJson']);
 
 // My Roulettes (auth required — must be before /roulettes/{slug} wildcard)
 Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,15 +54,17 @@ Route::get('/criteria',  CriteriaController::class);
 
 Route::match(['get', 'post'], '/movie',    [MoviePickController::class, 'single']);
 Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
-Route::get('/movie/roll',     [MoviePickController::class, 'rollJson']);
-Route::get('/movie/{id}',     MovieController::class)->name('movie');
+Route::get('/movie/roll',                       [MoviePickController::class, 'rollJson']);
+Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRollJson']);
+Route::get('/movie/{id}',          MovieController::class)->name('movie');
 
 // TV Shows
 Route::get('/tv/criteria',                     TvCriteriaController::class);
 Route::match(['get', 'post'], '/tv/pick',      [TvPickController::class, 'single'])->name('tv.pick');
 Route::match(['get', 'post'], '/tv/multiple',  [TvPickController::class, 'batch']);
-Route::get('/tv/roll',        [TvPickController::class, 'rollJson']);
-Route::get('/tv/{id}',        TvShowController::class)->name('tv.show');
+Route::get('/tv/roll',                          [TvPickController::class, 'rollJson']);
+Route::match(['get', 'post'], '/tv/roll/criteria',   [TvPickController::class, 'criteriaRollJson']);
+Route::get('/tv/{id}',             TvShowController::class)->name('tv.show');
 Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
 Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
 


### PR DESCRIPTION
## Summary

- Strip lands at a random position within the winning card, then snaps to center on reveal
- New `/movie/roll/criteria` and `/tv/roll/criteria` endpoints so rolling from movie/TV pages and criteria forms uses the current session criteria instead of resetting it
- Roulette rolls use `sessionStorage` instead of a GET param to track context — back button (← Roulettes / ← My Roulettes) appears on movie and TV pages after rolling from a roulette
- Animation toggle extracted to a shared partial (`includes/anim-toggle.blade.php`) and added to every page where rolling can start: batch pages, watchlist, criteria forms, roulettes list, person pages, and homepage
- Sticky bar layout standardised across all pages: back/context button on left, secondary actions + toggle + Roll on right
- Person pages get animated roll via new JSON endpoints (`/person/{id}/roll/movie/json`, `/person/{id}/roll/tv/json`)
- Loading state on all roll buttons during fetch
- Roulette → batch → roll chain preserves context so the back button still shows after rolling from a roulette batch page
- Movie page `?wl_status` watchlist toggle now uses the shared partial

## Test plan

- [x] Roll from homepage — animation plays, criteria reset to defaults
- [x] Roll from movie/TV detail page — animation plays with current session criteria
- [x] Roll from criteria form (Find Movie / Find Show) — animation plays, Loading… shown on button
- [x] Roll from roulette card — back button appears on landing page; rolling again keeps back button
- [x] Click Batch → on a roulette card, then Roll on batch page — back button appears on landing page
- [x] Roll from person page (cast/crew, movies/TV) — animation plays
- [x] Roll from watchlist — animation plays
- [x] Animation toggle off — all rolls navigate directly with no animation
- [x] Toggle state persists across pages