### PR TITLE
Fixes & features backlog

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -25,6 +25,7 @@ class Controller extends BaseController
             'title'        => $isTv ? ($m['name'] ?? $m['title'] ?? '') : ($m['title'] ?? ''),
             'poster_path'  => $m['poster_path'] ?? null,
             'vote_average' => $m['vote_average'] ?? 0,
+            'media_type'   => $mediaType,
             'url'          => $isTv ? route('tv.show', $m['id']) : route('movie', $m['id']),
         ], $items);
     }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,6 +9,9 @@ class HomeController extends Controller
 {
     public function __invoke(TmdbClient $tmdb): View
     {
+        // Homepage visit breaks any prior batch context
+        session()->forget('batchUrl');
+
         $savedIds = $this->savedWatchlistIds();
 
         $normalize = fn(array $data) => array_merge($data, [

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,12 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\MovieService;
 use App\Services\TmdbClient;
 use Illuminate\View\View;
 
 class HomeController extends Controller
 {
-    public function __invoke(TmdbClient $tmdb): View
+    public function __invoke(TmdbClient $tmdb, MovieService $movieService): View
     {
         // Homepage visit breaks any prior batch context
         session()->forget('batchUrl');
@@ -21,10 +22,18 @@ class HomeController extends Controller
             ]), $data['results'] ?? []),
         ]);
 
+        $trendingDay   = $tmdb->trending('day');
+        $tvTrendingDay = $normalize($tmdb->trendingTv('day'));
+
+        $movieGenres = $movieService->genres($tmdb, 'movie');
+        $tvGenres    = $movieService->genres($tmdb, 'tv');
+
         return view('home', [
-            'trendingDay'   => $tmdb->trending('day'),
-            'tvTrendingDay' => $normalize($tmdb->trendingTv('day')),
-            'savedIds'      => $savedIds,
+            'trendingDay'        => $trendingDay,
+            'tvTrendingDay'      => $tvTrendingDay,
+            'savedIds'           => $savedIds,
+            'trendingGenres'     => $movieService->movieGenresMap($trendingDay['results']   ?? [], $movieGenres),
+            'tvTrendingGenres'   => $movieService->movieGenresMap($tvTrendingDay['results'] ?? [], $tvGenres),
         ]);
     }
 }

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -67,6 +67,7 @@ class MovieController extends Controller
                     'title'        => $item->title,
                     'poster_path'  => $item->poster_path,
                     'release_date' => $item->year ? $item->year . '-01-01' : null,
+                    'vote_average' => $item->vote_average ?? 0,
                 ])->values()->all()];
                 $similarTitle = 'More from Your Watchlist';
             }

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -84,8 +84,13 @@ class MoviePickController extends PickController
         $results = $tmdb->discover($criteria, $country);
         $picked  = $movieService->pickBatch($results['results'] ?? []);
 
-        session(['lastBatchResults' => $picked, 'lastBatchType' => 'movie']);
-        session()->forget('batchUrl');
+        session([
+            'lastBatchResults'  => $picked,
+            'lastBatchType'     => 'movie',
+            'batchUrl'          => url('/multiple'),
+            'savedBatchUrl'     => url('/multiple'),
+            'savedBatchResults' => $picked,
+        ]);
 
         return response()->json($this->toRollCards($picked));
     }
@@ -93,7 +98,6 @@ class MoviePickController extends PickController
     public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         session([self::SESSION_KEY => self::DEFAULTS]);
-        session()->forget('batchUrl');
 
         $country = $movieService->getUserCountry();
         $results = $tmdb->discover([
@@ -105,7 +109,13 @@ class MoviePickController extends PickController
 
         $picked = $movieService->pickBatch($results['results'] ?? []);
 
-        session(['lastBatchResults' => $picked, 'lastBatchType' => 'movie']);
+        session([
+            'lastBatchResults'  => $picked,
+            'lastBatchType'     => 'movie',
+            'batchUrl'          => url('/multiple'),
+            'savedBatchUrl'     => url('/multiple'),
+            'savedBatchResults' => $picked,
+        ]);
 
         return response()->json($this->toRollCards($picked));
     }

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -29,32 +29,36 @@ class PersonController extends Controller
         $tvRollFilter    = $movieService->tvCreditFilter();
         $tvDisplayFilter = $movieService->tvCreditFilter(minEpisodes: 2);
 
-        // Known for: top 8 by vote_count, deduplicated by title ID
-        $knownFor = collect($person->combined_credits->cast ?? [])
-            ->sortByDesc('vote_count')
-            ->unique('id')
-            ->take(8)
-            ->values();
-
-        // Movies: all credits sorted by vote_count (most notable first)
-        $movies = $credits->filter(fn($c) => ($c->media_type ?? '') === 'movie')
+        // 4 filmography tabs
+        $movieCast = collect($person->combined_credits->cast ?? [])
+            ->filter(fn($c) => ($c->media_type ?? '') === 'movie')
             ->sortByDesc('vote_count')
             ->values();
 
-        // TV: filter out true one-offs/talk shows, sort by vote_count
-        $tvShows = $credits->filter(fn($c) => ($c->media_type ?? '') === 'tv')
+        $tvCast = collect($person->combined_credits->cast ?? [])
+            ->filter(fn($c) => ($c->media_type ?? '') === 'tv')
             ->filter($tvDisplayFilter)
             ->sortByDesc('vote_count')
             ->values();
 
-        $hasMovieCast = collect($person->combined_credits->cast ?? [])
-            ->contains(fn($c) => ($c->media_type ?? '') === 'movie');
-        $hasMovieCrew = collect($person->combined_credits->crew ?? [])
-            ->contains(fn($c) => ($c->media_type ?? '') === 'movie');
+        $movieCrew = collect($person->combined_credits->crew ?? [])
+            ->filter(fn($c) => ($c->media_type ?? '') === 'movie')
+            ->unique('id')
+            ->sortByDesc('vote_count')
+            ->values();
 
-        $hasTvCast = collect($person->combined_credits->cast ?? [])->contains($tvRollFilter);
-        $hasTvCrew = collect($person->combined_credits->crew ?? [])->contains($tvRollFilter);
+        $tvCrew = collect($person->combined_credits->crew ?? [])
+            ->filter(fn($c) => ($c->media_type ?? '') === 'tv')
+            ->filter($tvDisplayFilter)
+            ->unique('id')
+            ->sortByDesc('vote_count')
+            ->values();
 
-        return view('person', compact('person', 'knownFor', 'movies', 'tvShows', 'hasMovieCast', 'hasMovieCrew', 'hasTvCast', 'hasTvCrew'));
+        $hasMovieCast = $movieCast->isNotEmpty();
+        $hasMovieCrew = $movieCrew->isNotEmpty();
+        $hasTvCast    = $tvCast->isNotEmpty();
+        $hasTvCrew    = $tvCrew->isNotEmpty();
+
+        return view('person', compact('person', 'movieCast', 'tvCast', 'movieCrew', 'tvCrew', 'hasMovieCast', 'hasMovieCrew', 'hasTvCast', 'hasTvCrew'));
     }
 }

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -26,8 +26,7 @@ class PersonController extends Controller
             ->sortByDesc('vote_count')
             ->values();
 
-        $tvRollFilter    = $movieService->tvCreditFilter();
-        $tvDisplayFilter = $movieService->tvCreditFilter(minEpisodes: 2);
+        $tvDisplayFilter = $movieService->tvCreditFilter();
 
         // 4 filmography tabs
         $movieCast = collect($person->combined_credits->cast ?? [])

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -87,8 +87,13 @@ class TvPickController extends PickController
         $results = $tmdb->discoverTv($criteria, $country);
         $picked  = $movieService->pickBatch($results['results'] ?? []);
 
-        session(['lastBatchResults' => $picked, 'lastBatchType' => 'tv']);
-        session()->forget('batchUrl');
+        session([
+            'lastBatchResults'  => $picked,
+            'lastBatchType'     => 'tv',
+            'batchUrl'          => url('/tv/multiple'),
+            'savedBatchUrl'     => url('/tv/multiple'),
+            'savedBatchResults' => $picked,
+        ]);
 
         return response()->json($this->toRollCards($picked, 'tv'));
     }
@@ -96,7 +101,6 @@ class TvPickController extends PickController
     public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         session([self::SESSION_KEY => self::DEFAULTS]);
-        session()->forget('batchUrl');
 
         $country = $movieService->getUserCountry();
         $results = $tmdb->discoverTv([
@@ -107,7 +111,13 @@ class TvPickController extends PickController
 
         $picked = $movieService->pickBatch($results['results'] ?? []);
 
-        session(['lastBatchResults' => $picked, 'lastBatchType' => 'tv']);
+        session([
+            'lastBatchResults'  => $picked,
+            'lastBatchType'     => 'tv',
+            'batchUrl'          => url('/tv/multiple'),
+            'savedBatchUrl'     => url('/tv/multiple'),
+            'savedBatchResults' => $picked,
+        ]);
 
         return response()->json($this->toRollCards($picked, 'tv'));
     }

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -282,9 +282,10 @@ class UserRouletteController extends Controller
         if ($withoutGenres = $request->input('tags.without_genre', [])) {
             $tags['without_genre'] = array_values($withoutGenres);
         }
-        if ($era = $request->input('tags.era')) {
-            $tags['era'] = [$era];
-        }
+        $yearFrom = $request->input('tags.year_from');
+        $yearTo   = $request->input('tags.year_to');
+        if ($yearFrom !== null && $yearFrom !== '') $tags['year_from'] = (int) $yearFrom;
+        if ($yearTo   !== null && $yearTo   !== '') $tags['year_to']   = (int) $yearTo;
         if ($country = $request->input('tags.country')) {
             $tags['country'] = [$country];
         }

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -292,6 +292,18 @@ class UserRouletteController extends Controller
         if ($language = $request->input('tags.language')) {
             $tags['language'] = [$language];
         }
+        if ($withCast = array_filter($request->input('tags.with_cast', []))) {
+            $tags['with_cast'] = array_values(array_map('strval', $withCast));
+        }
+        if ($withCrew = array_filter($request->input('tags.with_crew', []))) {
+            $tags['with_crew'] = array_values(array_map('strval', $withCrew));
+        }
+        $voteGte   = $request->input('tags.vote_average_gte');
+        $voteLte   = $request->input('tags.vote_average_lte');
+        $voteCount = $request->input('tags.vote_count_gte');
+        if ($voteGte   !== null && $voteGte   !== '') $tags['vote_average_gte'] = (float) $voteGte;
+        if ($voteLte   !== null && $voteLte   !== '') $tags['vote_average_lte'] = (float) $voteLte;
+        if ($voteCount !== null && $voteCount !== '') $tags['vote_count_gte']   = (int)   $voteCount;
         return $tags;
     }
 }

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -235,6 +235,48 @@ class UserRouletteController extends Controller
         }
     }
 
+    public function fromCriteria(Request $request)
+    {
+        if (Roulette::where('user_id', auth()->id())->count() >= 20) {
+            return back()->with('error', 'You can have at most 20 roulettes.');
+        }
+
+        $request->validate(['name' => 'required|string|max:80']);
+
+        $mediaType  = $request->input('media_type') === 'tv' ? 'tv' : 'movie';
+        $sessionKey = $mediaType === 'tv' ? 'tvInput' : 'userInput';
+        $criteria   = array_diff_key(
+            session($sessionKey, []),
+            array_flip(['total_pages', 'page'])
+        );
+
+        $mapper = new RouletteTagMapper();
+        $tags   = $mapper->criteriaToTags($criteria, $mediaType);
+
+        if (empty($tags)) {
+            return back()->with('error', 'No criteria to save as a roulette.');
+        }
+
+        $fingerprint = ($mediaType === 'tv' ? 'tv:' : '') . Roulette::fingerprintFromTags($tags);
+        $existing    = Roulette::where('tag_fingerprint', $fingerprint)->whereNotNull('poster_paths')->first();
+
+        Roulette::create([
+            'user_id'         => auth()->id(),
+            'is_system'       => false,
+            'name'            => $request->input('name'),
+            'slug'            => Roulette::generateSlug($request->input('name')),
+            'description'     => null,
+            'tags'            => $tags,
+            'tag_fingerprint' => $fingerprint,
+            'is_public'       => $request->boolean('is_public'),
+            'row'             => null,
+            'media_type'      => $mediaType,
+            'poster_paths'    => $existing?->poster_paths,
+        ]);
+
+        return redirect()->route('my-roulettes.manage')->with('success', '"' . $request->input('name') . '" saved to My Roulettes.');
+    }
+
     public function reorderRows(Request $request)
     {
         $rows = $request->validate(['rows' => 'required|array', 'rows.*' => 'string'])['rows'];

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -111,8 +111,8 @@ class UserRouletteController extends Controller
 
     public function store(Request $request)
     {
-        if (Roulette::where('user_id', auth()->id())->count() >= 20) {
-            return back()->withErrors(['limit' => 'You can have at most 20 roulettes.'])->withInput();
+        if (Roulette::where('user_id', auth()->id())->count() >= 100) {
+            return back()->withErrors(['limit' => 'You can have at most 100 roulettes.'])->withInput();
         }
 
         $data = $this->validated($request);
@@ -237,8 +237,8 @@ class UserRouletteController extends Controller
 
     public function fromCriteria(Request $request)
     {
-        if (Roulette::where('user_id', auth()->id())->count() >= 20) {
-            return back()->with('error', 'You can have at most 20 roulettes.');
+        if (Roulette::where('user_id', auth()->id())->count() >= 100) {
+            return back()->with('error', 'You can have at most 100 roulettes.');
         }
 
         $request->validate(['name' => 'required|string|max:80']);

--- a/app/Http/Controllers/WatchlistController.php
+++ b/app/Http/Controllers/WatchlistController.php
@@ -10,6 +10,36 @@ use Illuminate\Support\Facades\Auth;
 
 class WatchlistController extends Controller
 {
+    /**
+     * Normalize TV compound genre names to canonical movie-style names so the
+     * watchlist genre filter works uniformly for both media types.
+     *   "Action & Adventure" → "Action, Adventure"
+     *   "Sci-Fi & Fantasy"   → "Sci-Fi, Fantasy"
+     *   "War & Politics"     → "War"
+     */
+    private static function normalizeGenres(string $raw): string
+    {
+        $expansions = [
+            'Action & Adventure' => ['Action', 'Adventure'],
+            'Sci-Fi & Fantasy'   => ['Sci-Fi', 'Fantasy'],
+            'War & Politics'     => ['War'],
+        ];
+
+        $normalized = [];
+        foreach (array_map('trim', explode(',', $raw)) as $genre) {
+            if ($genre === '') continue;
+            if (isset($expansions[$genre])) {
+                foreach ($expansions[$genre] as $g) {
+                    $normalized[] = $g;
+                }
+            } else {
+                $normalized[] = $genre;
+            }
+        }
+
+        return implode(', ', array_unique($normalized));
+    }
+
     public function index(TmdbClient $tmdb, MovieService $movieService)
     {
         session(['batchUrl' => route('watchlist')]);
@@ -35,11 +65,23 @@ class WatchlistController extends Controller
                     }
                     $genreString = $movieService->genresString($info);
                     if ($genreString) {
+                        $genreString = static::normalizeGenres($genreString);
                         $item->update(['genres' => $genreString]);
                         $item->genres = $genreString;
                     }
                 } catch (\Throwable) {}
             }
+        }
+
+        // Normalize existing items that still carry TV compound genre names
+        $compound = ['Action & Adventure', 'Sci-Fi & Fantasy', 'War & Politics'];
+        $toNormalize = $items->filter(fn($i) =>
+            $i->genres && collect($compound)->contains(fn($c) => str_contains($i->genres, $c))
+        );
+        foreach ($toNormalize as $item) {
+            $normalized = static::normalizeGenres($item->genres);
+            $item->update(['genres' => $normalized]);
+            $item->genres = $normalized;
         }
 
         $genres = $items->pluck('genres')
@@ -72,12 +114,14 @@ class WatchlistController extends Controller
             return response()->json(['saved' => false]);
         }
 
+        $rawGenres = $request->genres;
+
         $user->watchlist()->create([
             'tmdb_id'      => $request->tmdb_id,
             'title'        => $request->title,
             'poster_path'  => $request->poster_path,
             'year'         => $request->year,
-            'genres'       => $request->genres,
+            'genres'       => $rawGenres ? static::normalizeGenres($rawGenres) : null,
             'vote_average' => $request->vote_average ?: null,
             'type'         => $request->input('type', 'movie'),
             'status'       => 'saved',

--- a/app/Http/Controllers/WatchlistController.php
+++ b/app/Http/Controllers/WatchlistController.php
@@ -3,12 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Models\Watchlist;
+use App\Services\MovieService;
+use App\Services\TmdbClient;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class WatchlistController extends Controller
 {
-    public function index()
+    public function index(TmdbClient $tmdb, MovieService $movieService)
     {
         session(['batchUrl' => route('watchlist')]);
 
@@ -16,6 +18,29 @@ class WatchlistController extends Controller
             ->watchlist()
             ->orderByDesc('created_at')
             ->get();
+
+        // Back-fill genres for items saved without them (up to 15 per load)
+        $missing = $items->whereNull('genres');
+        if ($missing->isNotEmpty()) {
+            $movieGenreList = null;
+            $tvGenreList    = null;
+            foreach ($missing->take(15) as $item) {
+                try {
+                    if ($item->type === 'tv') {
+                        $tvGenreList ??= $movieService->genres($tmdb, 'tv');
+                        $info = $tmdb->tvShow($item->tmdb_id);
+                    } else {
+                        $movieGenreList ??= $movieService->genres($tmdb, 'movie');
+                        $info = $tmdb->movie($item->tmdb_id);
+                    }
+                    $genreString = $movieService->genresString($info);
+                    if ($genreString) {
+                        $item->update(['genres' => $genreString]);
+                        $item->genres = $genreString;
+                    }
+                } catch (\Throwable) {}
+            }
+        }
 
         $genres = $items->pluck('genres')
             ->filter()

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -69,11 +69,14 @@ class RouletteTagMapper
     public function normalizeTags(array $raw): array
     {
         $tags = [];
-        if (!empty($raw['platform'])) $tags['platform'] = [$raw['platform']];
-        if (!empty($raw['genre']))    $tags['genre']    = array_values((array) $raw['genre']);
+        if (!empty($raw['platform']))      $tags['platform']      = [$raw['platform']];
+        if (!empty($raw['genre']))         $tags['genre']         = array_values((array) $raw['genre']);
         if (!empty($raw['without_genre'])) $tags['without_genre'] = array_values((array) $raw['without_genre']);
-        if (!empty($raw['era']))      $tags['era']      = [$raw['era']];
-        if (!empty($raw['country']))  $tags['country']  = [$raw['country']];
+        if (!empty($raw['era']))           $tags['era']           = [$raw['era']];
+        if (!empty($raw['country']))       $tags['country']       = [$raw['country']];
+        if (!empty($raw['language']))      $tags['language']      = [$raw['language']];
+        if (isset($raw['year_from']) && $raw['year_from'] !== '') $tags['year_from'] = (int) $raw['year_from'];
+        if (isset($raw['year_to'])   && $raw['year_to']   !== '') $tags['year_to']   = (int) $raw['year_to'];
         return $tags;
     }
 
@@ -115,7 +118,15 @@ class RouletteTagMapper
             $criteria['with_original_language'] = $tags['language'][0];
         }
 
-        if (!empty($tags['era'])) {
+        // year_from/year_to take priority; fall back to legacy era slugs
+        if (!empty($tags['year_from']) || !empty($tags['year_to'])) {
+            if (!empty($tags['year_from'])) {
+                $criteria['primary_release_date.gte'] = (int) $tags['year_from'];
+            }
+            if (!empty($tags['year_to'])) {
+                $criteria['primary_release_date.lte'] = (int) $tags['year_to'];
+            }
+        } elseif (!empty($tags['era'])) {
             $era   = (array) $tags['era'];
             $range = $era[0] === 'recent'
                 ? ['gte' => (int) date('Y') - 2]
@@ -173,7 +184,15 @@ class RouletteTagMapper
             if ($code) $criteria['with_origin_country'] = $code;
         }
 
-        if (!empty($tags['era'])) {
+        // year_from/year_to take priority; fall back to legacy era slugs
+        if (!empty($tags['year_from']) || !empty($tags['year_to'])) {
+            if (!empty($tags['year_from'])) {
+                $criteria['first_air_date.gte'] = (int) $tags['year_from'];
+            }
+            if (!empty($tags['year_to'])) {
+                $criteria['first_air_date.lte'] = (int) $tags['year_to'];
+            }
+        } elseif (!empty($tags['era'])) {
             $era   = (array) $tags['era'];
             $range = $era[0] === 'recent'
                 ? ['gte' => (int) date('Y') - 2]

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -227,4 +227,87 @@ class RouletteTagMapper
 
         return $criteria;
     }
+
+    /**
+     * Reverse-map session criteria (userInput / tvInput) back to roulette tag format.
+     * Used by UserRouletteController::fromCriteria() when saving a batch's criteria.
+     */
+    public function criteriaToTags(array $criteria, string $mediaType = 'movie'): array
+    {
+        $tags = [];
+
+        // Platform — take first recognised provider ID
+        if (!empty($criteria['with_watch_providers'])) {
+            $flipped = array_flip(self::PLATFORM_IDS);
+            foreach ((array) $criteria['with_watch_providers'] as $id) {
+                if ($slug = ($flipped[(int) $id] ?? null)) {
+                    $tags['platform'] = [$slug];
+                    break;
+                }
+            }
+        }
+
+        // Genre include / exclude
+        $genreMap     = $mediaType === 'tv' ? self::TV_GENRE_IDS : self::GENRE_IDS;
+        $flippedGenre = array_flip($genreMap);
+
+        if (!empty($criteria['with_genres'])) {
+            $slugs = [];
+            foreach ((array) $criteria['with_genres'] as $id) {
+                if ($slug = ($flippedGenre[(int) $id] ?? null)) $slugs[] = $slug;
+            }
+            if ($slugs) $tags['genre'] = array_values(array_unique($slugs));
+        }
+
+        if (!empty($criteria['without_genres'])) {
+            $slugs = [];
+            foreach ((array) $criteria['without_genres'] as $id) {
+                if ($slug = ($flippedGenre[(int) $id] ?? null)) $slugs[] = $slug;
+            }
+            if ($slugs) $tags['without_genre'] = array_values(array_unique($slugs));
+        }
+
+        // Language / Country
+        if (!empty($criteria['with_original_language'])) {
+            $tags['language'] = [$criteria['with_original_language']];
+        }
+        if (!empty($criteria['with_origin_country'])) {
+            $tags['country'] = [$criteria['with_origin_country']];
+        }
+
+        // Year range (session keys use underscore notation)
+        $gteKey = $mediaType === 'tv' ? 'first_air_date_gte' : 'primary_release_date_gte';
+        $lteKey = $mediaType === 'tv' ? 'first_air_date_lte' : 'primary_release_date_lte';
+        if (!empty($criteria[$gteKey])) $tags['year_from'] = (int) $criteria[$gteKey];
+        if (!empty($criteria[$lteKey])) $tags['year_to']   = (int) $criteria[$lteKey];
+
+        // Score / quality
+        if (isset($criteria['vote_average_gte']) && $criteria['vote_average_gte'] !== '') {
+            $tags['vote_average_gte'] = (float) $criteria['vote_average_gte'];
+        }
+        if (isset($criteria['vote_average_lte']) && $criteria['vote_average_lte'] !== '') {
+            $tags['vote_average_lte'] = (float) $criteria['vote_average_lte'];
+        }
+        if (isset($criteria['vote_count_gte']) && $criteria['vote_count_gte'] !== '') {
+            $tags['vote_count_gte'] = (int) $criteria['vote_count_gte'];
+        }
+
+        // People
+        if (!empty($criteria['with_cast'])) {
+            $cast = is_array($criteria['with_cast'])
+                ? $criteria['with_cast']
+                : explode(',', (string) $criteria['with_cast']);
+            $cast = array_values(array_map('strval', array_filter($cast)));
+            if ($cast) $tags['with_cast'] = $cast;
+        }
+        if (!empty($criteria['with_crew'])) {
+            $crew = is_array($criteria['with_crew'])
+                ? $criteria['with_crew']
+                : explode(',', (string) $criteria['with_crew']);
+            $crew = array_values(array_map('strval', array_filter($crew)));
+            if ($crew) $tags['with_crew'] = $crew;
+        }
+
+        return $tags;
+    }
 }

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -77,6 +77,11 @@ class RouletteTagMapper
         if (!empty($raw['language']))      $tags['language']      = [$raw['language']];
         if (isset($raw['year_from']) && $raw['year_from'] !== '') $tags['year_from'] = (int) $raw['year_from'];
         if (isset($raw['year_to'])   && $raw['year_to']   !== '') $tags['year_to']   = (int) $raw['year_to'];
+        if (!empty($raw['with_cast']))  $tags['with_cast']  = array_values(array_map('strval', (array) $raw['with_cast']));
+        if (!empty($raw['with_crew']))  $tags['with_crew']  = array_values(array_map('strval', (array) $raw['with_crew']));
+        if (isset($raw['vote_average_gte']) && $raw['vote_average_gte'] !== '') $tags['vote_average_gte'] = (float) $raw['vote_average_gte'];
+        if (isset($raw['vote_average_lte']) && $raw['vote_average_lte'] !== '') $tags['vote_average_lte'] = (float) $raw['vote_average_lte'];
+        if (isset($raw['vote_count_gte'])   && $raw['vote_count_gte']   !== '') $tags['vote_count_gte']   = (int)   $raw['vote_count_gte'];
         return $tags;
     }
 
@@ -141,6 +146,12 @@ class RouletteTagMapper
                 }
             }
         }
+
+        if (!empty($tags['with_cast']))        $criteria['with_cast']        = (array) $tags['with_cast'];
+        if (!empty($tags['with_crew']))        $criteria['with_crew']        = (array) $tags['with_crew'];
+        if (isset($tags['vote_average_gte']) && $tags['vote_average_gte'] !== '') $criteria['vote_average.gte'] = $tags['vote_average_gte'];
+        if (isset($tags['vote_average_lte']) && $tags['vote_average_lte'] !== '') $criteria['vote_average.lte'] = $tags['vote_average_lte'];
+        if (isset($tags['vote_count_gte'])   && $tags['vote_count_gte']   !== '') $criteria['vote_count.gte']   = $tags['vote_count_gte'];
 
         return $criteria;
     }
@@ -207,6 +218,12 @@ class RouletteTagMapper
                 }
             }
         }
+
+        if (!empty($tags['with_cast']))        $criteria['with_cast']        = (array) $tags['with_cast'];
+        if (!empty($tags['with_crew']))        $criteria['with_crew']        = (array) $tags['with_crew'];
+        if (isset($tags['vote_average_gte']) && $tags['vote_average_gte'] !== '') $criteria['vote_average.gte'] = $tags['vote_average_gte'];
+        if (isset($tags['vote_average_lte']) && $tags['vote_average_lte'] !== '') $criteria['vote_average.lte'] = $tags['vote_average_lte'];
+        if (isset($tags['vote_count_gte'])   && $tags['vote_count_gte']   !== '') $criteria['vote_count.gte']   = $tags['vote_count_gte'];
 
         return $criteria;
     }

--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -36,18 +36,24 @@ export function runCaseOpening(cards, winnerIdx, fullUrl, mediaType = 'movie') {
         return;
     }
 
-    const winner = cards[winnerIdx];
+    const winner     = cards[winnerIdx];
+    const nonWinners = cards.filter((_, i) => i !== winnerIdx);
 
-    // For small pools use all cards (incl. winner as fake-outs) so the strip
-    // looks varied. For larger pools exclude the winner from filler so it only
-    // appears at the landing position.
-    const source = cards.length <= 5 ? cards : cards.filter((_, i) => i !== winnerIdx);
-    const pool   = [];
+    // Always use the full card pool so the winner can appear as fake-outs
+    const pool = [];
     while (pool.length < STRIP_LEN) {
-        pool.push(...[...source].sort(() => Math.random() - 0.5));
+        pool.push(...[...cards].sort(() => Math.random() - 0.5));
     }
     const strip = pool.slice(0, STRIP_LEN);
     strip[WINNER_POS] = winner;
+
+    // Winner must not be its own immediate neighbour at the landing position
+    for (const offset of [-1, 1]) {
+        const pos = WINNER_POS + offset;
+        if (pos >= 0 && pos < strip.length && strip[pos] === winner) {
+            strip[pos] = nonWinners[Math.floor(Math.random() * nonWinners.length)];
+        }
+    }
 
     const overlay   = document.getElementById('case-overlay');
     const stripEl   = document.getElementById('case-strip');

--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -29,11 +29,22 @@ export function getTier(rating, mediaType = 'movie') {
 }
 
 export function runCaseOpening(cards, winnerIdx, fullUrl, mediaType = 'movie') {
+    // Single card: no animation needed — just navigate
+    if (cards.length <= 1) {
+        window.showProgress?.();
+        window.location.href = fullUrl;
+        return;
+    }
+
     const winner = cards[winnerIdx];
-    const others = cards.filter((_, i) => i !== winnerIdx);
-    const pool = [];
+
+    // For small pools use all cards (incl. winner as fake-outs) so the strip
+    // looks varied. For larger pools exclude the winner from filler so it only
+    // appears at the landing position.
+    const source = cards.length <= 5 ? cards : cards.filter((_, i) => i !== winnerIdx);
+    const pool   = [];
     while (pool.length < STRIP_LEN) {
-        pool.push(...[...others].sort(() => Math.random() - 0.5));
+        pool.push(...[...source].sort(() => Math.random() - 0.5));
     }
     const strip = pool.slice(0, STRIP_LEN);
     strip[WINNER_POS] = winner;

--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -14,11 +14,21 @@ const TIERS = [
     { min: 0,   color: '#6b7280', label: 'Mixed'       },
 ];
 
-export function getTier(rating) {
-    return TIERS.find(t => (rating || 0) >= t.min) || TIERS[TIERS.length - 1];
+// TV scores skew higher — use stricter thresholds
+const TIERS_TV = [
+    { min: 9.0, color: '#f59e0b', label: 'Masterpiece' },
+    { min: 8.2, color: '#c0393a', label: 'Excellent'   },
+    { min: 7.5, color: '#8b5cf6', label: 'Great'       },
+    { min: 6.5, color: '#3b82f6', label: 'Good'        },
+    { min: 0,   color: '#6b7280', label: 'Mixed'       },
+];
+
+export function getTier(rating, mediaType = 'movie') {
+    const table = mediaType === 'tv' ? TIERS_TV : TIERS;
+    return table.find(t => (rating || 0) >= t.min) || table[table.length - 1];
 }
 
-export function runCaseOpening(cards, winnerIdx, fullUrl) {
+export function runCaseOpening(cards, winnerIdx, fullUrl, mediaType = 'movie') {
     const winner = cards[winnerIdx];
     const others = cards.filter((_, i) => i !== winnerIdx);
     const pool = [];
@@ -39,7 +49,7 @@ export function runCaseOpening(cards, winnerIdx, fullUrl) {
 
     stripEl.innerHTML = '';
     strip.forEach((card, i) => {
-        const tier = getTier(card.rating);
+        const tier = getTier(card.rating, card.media_type || mediaType);
         const el = document.createElement('div');
         el.className = 'case-card flex-shrink-0 rounded-lg overflow-hidden relative';
         el.style.cssText = `width:${CARD_W}px;height:${CARD_H}px;box-shadow:0 0 10px 2px ${tier.color}44;outline:1px solid ${tier.color}55`;
@@ -83,7 +93,7 @@ export function runCaseOpening(cards, winnerIdx, fullUrl) {
     }));
 
     setTimeout(() => {
-        const tier     = getTier(winner.rating);
+        const tier     = getTier(winner.rating, winner.media_type || mediaType);
         const winnerEl = document.getElementById('case-winner-card');
 
         stripEl.style.transition = 'transform 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94)';

--- a/resources/js/custom/rouletteForm.js
+++ b/resources/js/custom/rouletteForm.js
@@ -36,6 +36,7 @@ $(document).ready(function () {
             timer = setTimeout(function () {
                 const params = { q: query };
                 if (dept === 'Acting') params.dept = dept;
+                else params.exclude_dept = 'Acting';
                 $.getJSON('/tmdb/search/people', params)
                     .done(function (data) {
                         data.forEach(function (p) {

--- a/resources/js/custom/rouletteForm.js
+++ b/resources/js/custom/rouletteForm.js
@@ -1,0 +1,97 @@
+import TomSelect from 'tom-select';
+
+$(document).ready(function () {
+
+    // ── People TomSelect ──────────────────────────────────────────────
+
+    function makePeopleTs(id, dept) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const placeholder = dept === 'Acting' ? 'Search actors…' : 'Search directors, writers…';
+        const ts = new TomSelect('#' + id, {
+            plugins: ['remove_button'],
+            placeholder,
+            maxOptions: null,
+            create: false,
+            render: {
+                option: function (data, escape) {
+                    const img = data.profile
+                        ? `<img src="https://image.tmdb.org/t/p/w45${escape(data.profile)}" class="w-7 h-7 rounded-full object-cover flex-shrink-0">`
+                        : `<div class="w-7 h-7 rounded-full bg-white/10 flex-shrink-0"></div>`;
+                    return `<div class="flex items-center gap-2 py-0.5">${img}<span>${escape(data.text)}</span></div>`;
+                },
+            },
+        });
+
+        let timer;
+        ts.on('type', function (query) {
+            clearTimeout(timer);
+            if (!query) return;
+            if (!ts.loading) {
+                ts.loading++;
+                ts.wrapper.classList.add(ts.settings.loadingClass);
+                ts.clearOptions();
+                ts.refreshOptions(false);
+            }
+            timer = setTimeout(function () {
+                const params = { q: query };
+                if (dept === 'Acting') params.dept = dept;
+                $.getJSON('/tmdb/search/people', params)
+                    .done(function (data) {
+                        data.forEach(function (p) {
+                            ts.addOption({ value: String(p.id), text: p.name, profile: p.profile_path || '' });
+                        });
+                    })
+                    .always(function () {
+                        ts.loading = Math.max(ts.loading - 1, 0);
+                        if (!ts.loading) ts.wrapper.classList.remove(ts.settings.loadingClass);
+                        ts.refreshOptions(true);
+                    });
+            }, 400);
+        });
+
+        // Sync underlying <select> on add/remove (TomSelect v2 doesn't do this for dynamic options)
+        ts.on('item_add', function (value) {
+            const sel = document.getElementById(id);
+            if (!sel) return;
+            let opt = sel.querySelector('option[value="' + value + '"]');
+            if (!opt) { opt = document.createElement('option'); opt.value = value; sel.appendChild(opt); }
+            opt.selected = true;
+        });
+        ts.on('item_remove', function (value) {
+            const sel = document.getElementById(id);
+            if (!sel) return;
+            const opt = sel.querySelector('option[value="' + value + '"]');
+            if (opt) opt.remove();
+        });
+
+        window['_ts_' + id] = ts;
+    }
+
+    function restorePeople(ids, tsId) {
+        if (!ids || !ids.length) return;
+        const ts  = window['_ts_' + tsId];
+        const sel = document.getElementById(tsId);
+        if (!ts) return;
+        ids.forEach(function (personId) {
+            $.getJSON('/tmdb/people/' + personId)
+                .done(function (d) {
+                    const val = String(d.id);
+                    ts.addOption({ value: val, text: d.name });
+                    ts.addItem(val, true);
+                    if (sel) {
+                        let opt = sel.querySelector('option[value="' + val + '"]');
+                        if (!opt) { opt = document.createElement('option'); opt.value = val; sel.appendChild(opt); }
+                        opt.selected = true;
+                    }
+                });
+        });
+    }
+
+    makePeopleTs('roulette-with_cast', 'Acting');
+    makePeopleTs('roulette-with_crew', null);
+
+    // Restore existing values when editing a roulette
+    restorePeople(window._rouletteWithCast || [], 'roulette-with_cast');
+    restorePeople(window._rouletteWithCrew || [], 'roulette-with_crew');
+});

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -12,10 +12,11 @@ function toCards(movies) {
     return movies
         .filter(m => m.poster_path)
         .map(m => ({
-            url:    m.url,
-            poster: `https://image.tmdb.org/t/p/w342${m.poster_path}`,
-            title:  m.title,
-            rating: m.vote_average,
+            url:        m.url,
+            poster:     `https://image.tmdb.org/t/p/w342${m.poster_path}`,
+            title:      m.title,
+            rating:     m.vote_average,
+            media_type: m.media_type || 'movie',
         }));
 }
 
@@ -53,6 +54,15 @@ document.addEventListener('change', function (e) {
 
 document.addEventListener('DOMContentLoaded', function () {
     syncAnimToggles();
+
+    // Clear stale roll context when landing on hub/index pages
+    const ROLL_CHAIN_BREAKERS = ['/', '/roulettes', '/my-roulettes', '/criteria', '/tv/criteria'];
+    if (ROLL_CHAIN_BREAKERS.includes(window.location.pathname)) {
+        sessionStorage.removeItem('rollSource');
+        sessionStorage.removeItem('rollBackUrl');
+        sessionStorage.removeItem('rollBackLabel');
+    }
+
     const rollSource = sessionStorage.getItem('rollSource');
     if (rollSource === 'person') {
         document.querySelectorAll('.js-criteria-btn').forEach(el => el.classList.add('hidden'));
@@ -72,10 +82,11 @@ function getBatchCards(rowSelector) {
     document.querySelectorAll(`${rowSelector} [data-batch-card]`).forEach(el => {
         if (!el.dataset.poster) return;
         cards.push({
-            url:    el.dataset.url,
-            poster: `https://image.tmdb.org/t/p/w342${el.dataset.poster}`,
-            title:  el.dataset.title,
-            rating: parseFloat(el.dataset.rating) || 0,
+            url:        el.dataset.url,
+            poster:     `https://image.tmdb.org/t/p/w342${el.dataset.poster}`,
+            title:      el.dataset.title,
+            rating:     parseFloat(el.dataset.rating) || 0,
+            media_type: el.dataset.mediaType || 'movie',
         });
     });
     return cards;
@@ -86,9 +97,10 @@ function rollCards(cards, source) {
     document.querySelectorAll('.modal-wrap').forEach(m => m.classList.add('hidden'));
     const rollSource = source || sessionStorage.getItem('rollSource');
     if (rollSource) sessionStorage.setItem('rollSource', rollSource);
-    const winnerIdx = Math.floor(Math.random() * cards.length);
+    const winnerIdx  = Math.floor(Math.random() * cards.length);
+    const mediaType  = cards[winnerIdx].media_type || 'movie';
     if (localStorage.getItem('wl_animation') !== '0') {
-        runCaseOpening(cards, winnerIdx, cards[winnerIdx].url);
+        runCaseOpening(cards, winnerIdx, cards[winnerIdx].url, mediaType);
     } else {
         window.location.href = cards[winnerIdx].url;
     }

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -104,6 +104,31 @@ $(document).ready(function () {
         });
     });
 
+    // Rebuild genre dropdown options to match only the currently selected type
+    function rebuildGenreOptions() {
+        const type = $('.type-filter.active').data('type');
+
+        const genreSet = new Set();
+        $('.watchlist-card').each(function () {
+            const cardType = $(this).attr('data-type') || 'movie';
+            if (type === 'all' || cardType === type) {
+                ($(this).attr('data-genres') || '')
+                    .split(',').map(g => g.trim()).filter(Boolean)
+                    .forEach(g => genreSet.add(g));
+            }
+        });
+
+        const sorted = [...genreSet].sort();
+
+        [genreSelect, excludeSelect].forEach(ts => {
+            if (!ts) return;
+            ts.clear(true);          // clear selections silently
+            ts.clearOptions();
+            sorted.forEach(g => ts.addOption({ value: g, text: g }));
+            ts.refreshOptions(false);
+        });
+    }
+
     // Combined filter: status tab + type tab + genre include/exclude selects
     function applyFilters() {
         const status          = $('.watchlist-filter.active').data('filter');
@@ -143,6 +168,7 @@ $(document).ready(function () {
     $(document).on('click', '.type-filter', function () {
         $('.type-filter').removeClass('active').addClass('text-gray-400');
         $(this).addClass('active').removeClass('text-gray-400');
+        rebuildGenreOptions();
         applyFilters();
     });
 

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -104,31 +104,6 @@ $(document).ready(function () {
         });
     });
 
-    // Rebuild genre dropdown options to match only the currently selected type
-    function rebuildGenreOptions() {
-        const type = $('.type-filter.active').data('type');
-
-        const genreSet = new Set();
-        $('.watchlist-card').each(function () {
-            const cardType = $(this).attr('data-type') || 'movie';
-            if (type === 'all' || cardType === type) {
-                ($(this).attr('data-genres') || '')
-                    .split(',').map(g => g.trim()).filter(Boolean)
-                    .forEach(g => genreSet.add(g));
-            }
-        });
-
-        const sorted = [...genreSet].sort();
-
-        [genreSelect, excludeSelect].forEach(ts => {
-            if (!ts) return;
-            ts.clear(true);          // clear selections silently
-            ts.clearOptions();
-            sorted.forEach(g => ts.addOption({ value: g, text: g }));
-            ts.refreshOptions(false);
-        });
-    }
-
     // Combined filter: status tab + type tab + genre include/exclude selects
     function applyFilters() {
         const status          = $('.watchlist-filter.active').data('filter');
@@ -165,7 +140,6 @@ $(document).ready(function () {
     $(document).on('click', '.type-filter', function () {
         $('.type-filter').removeClass('active').addClass('text-gray-400');
         $(this).addClass('active').removeClass('text-gray-400');
-        rebuildGenreOptions();
         applyFilters();
     });
 

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -144,13 +144,10 @@ $(document).ready(function () {
             const statusMatch  = status === 'all' || cardStatus === status;
             const typeMatch    = type === 'all'   || cardType === type;
             // All selected include-genres must be present (AND logic)
-            // Items without stored genres are never hidden by the include filter
             const genreMatch   = activeGenres.size === 0
-                || cardGenres.length === 0
-                || [...activeGenres].every(g => cardGenres.includes(g));
-            // No selected exclude-genre may be present (only applies when genres are stored)
+                || (cardGenres.length > 0 && [...activeGenres].every(g => cardGenres.includes(g)));
+            // No selected exclude-genre may be present
             const excludeMatch = excludedGenres.size === 0
-                || cardGenres.length === 0
                 || !cardGenres.some(g => excludedGenres.has(g));
 
             $(this).toggle(statusMatch && typeMatch && genreMatch && excludeMatch);

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -1,17 +1,26 @@
 import TomSelect from 'tom-select';
 import { getTier, runCaseOpening } from './caseOpening.js';
 
-let genreSelect = null;
+let genreSelect   = null;
+let excludeSelect = null;
 
 $(document).ready(function () {
 
     const csrf = () => $('meta[name="csrf-token"]').attr('content');
 
-    // Init genre multi-select
+    // Init genre multi-selects
     if (document.getElementById('genre-select')) {
         genreSelect = new TomSelect('#genre-select', {
             plugins: ['remove_button'],
             placeholder: 'Filter by genre…',
+            onItemAdd() { this.setTextboxValue(''); this.refreshOptions(); },
+            onChange() { applyFilters(); },
+        });
+    }
+    if (document.getElementById('exclude-genre-select')) {
+        excludeSelect = new TomSelect('#exclude-genre-select', {
+            plugins: ['remove_button'],
+            placeholder: 'Exclude genre…',
             onItemAdd() { this.setTextboxValue(''); this.refreshOptions(); },
             onChange() { applyFilters(); },
         });
@@ -95,22 +104,31 @@ $(document).ready(function () {
         });
     });
 
-    // Combined filter: status tab + type tab + genre select
+    // Combined filter: status tab + type tab + genre include/exclude selects
     function applyFilters() {
-        const status = $('.watchlist-filter.active').data('filter');
-        const type   = $('.type-filter.active').data('type');
-        const activeGenres = new Set(genreSelect ? genreSelect.getValue() : []);
+        const status          = $('.watchlist-filter.active').data('filter');
+        const type            = $('.type-filter.active').data('type');
+        const activeGenres    = new Set(genreSelect   ? genreSelect.getValue()   : []);
+        const excludedGenres  = new Set(excludeSelect ? excludeSelect.getValue() : []);
 
         $('.watchlist-card').each(function () {
             const cardStatus = $(this).attr('data-status');
             const cardType   = $(this).attr('data-type') || 'movie';
-            const cardGenres = ($(this).attr('data-genres') || '').split(',').map(g => g.trim());
+            const cardGenres = ($(this).attr('data-genres') || '').split(',').map(g => g.trim()).filter(Boolean);
 
-            const statusMatch = status === 'all' || cardStatus === status;
-            const typeMatch   = type === 'all'   || cardType === type;
-            const genreMatch  = activeGenres.size === 0 || cardGenres.some(g => activeGenres.has(g));
+            const statusMatch  = status === 'all' || cardStatus === status;
+            const typeMatch    = type === 'all'   || cardType === type;
+            // All selected include-genres must be present (AND logic)
+            // Items without stored genres are never hidden by the include filter
+            const genreMatch   = activeGenres.size === 0
+                || cardGenres.length === 0
+                || [...activeGenres].every(g => cardGenres.includes(g));
+            // No selected exclude-genre may be present (only applies when genres are stored)
+            const excludeMatch = excludedGenres.size === 0
+                || cardGenres.length === 0
+                || !cardGenres.some(g => excludedGenres.has(g));
 
-            $(this).toggle(statusMatch && typeMatch && genreMatch);
+            $(this).toggle(statusMatch && typeMatch && genreMatch && excludeMatch);
         });
 
         $('#wl-count').text('(' + $('.watchlist-card:visible').length + ')');
@@ -170,16 +188,18 @@ $(document).ready(function () {
     function buildCards() {
         const cards = [];
         $('.watchlist-card:visible').each(function () {
-            const link   = $(this).find('a[href]').first();
-            const img    = $(this).find('img').first();
-            const title  = $(this).data('title') || '';
-            const rating = parseFloat($(this).data('rating')) || 0;
+            const link      = $(this).find('a[href]').first();
+            const img       = $(this).find('img').first();
+            const title     = $(this).data('title') || '';
+            const rating    = parseFloat($(this).data('rating')) || 0;
+            const mediaType = ($(this).data('type') || 'movie') === 'tv' ? 'tv' : 'movie';
             if (link.length && img.length) {
                 cards.push({
-                    url:    link.attr('href'),
-                    poster: (img.attr('src') || '').replace('w500', 'w342'),
+                    url:        link.attr('href'),
+                    poster:     (img.attr('src') || '').replace('w500', 'w342'),
                     title,
                     rating,
+                    media_type: mediaType,
                 });
             }
         });
@@ -208,7 +228,8 @@ $(document).ready(function () {
             const cards      = buildCards();
             const winnerHref = picked.find('a').first().attr('href');
             const winnerIdx  = cards.findIndex(c => c.url === winnerHref);
-            runCaseOpening(cards, winnerIdx >= 0 ? winnerIdx : 0, url);
+            const winner     = cards[winnerIdx >= 0 ? winnerIdx : 0];
+            runCaseOpening(cards, winnerIdx >= 0 ? winnerIdx : 0, url, winner?.media_type || 'movie');
         } else {
             window.showProgress?.();
             window.location.href = url;

--- a/resources/views/admin/roulettes/form.blade.php
+++ b/resources/views/admin/roulettes/form.blade.php
@@ -188,6 +188,7 @@
 @endsection
 
 @section('scripts')
+@vite(['resources/js/custom/rouletteForm.js'])
 <style>
 @media (max-width: 639px) {
     #poster-grid { display: flex; overflow-x: auto; gap: 0.5rem; padding-bottom: 0.375rem; }

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -17,7 +17,66 @@
         <div>
             <h1 class="text-2xl font-bold text-white">{{ $tag ?? ($isTv ? 'TV Batch' : 'Movie Batch') }}</h1>
         </div>
+        @auth
+        <button type="button" id="save-roulette-btn"
+                class="btn-secondary text-sm flex items-center gap-1.5">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+            </svg>
+            Save as Roulette
+        </button>
+        @endauth
     </div>
+
+    {{-- Save as Roulette modal --}}
+    @auth
+    <div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
+        <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+            <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
+            <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
+                @csrf
+                <input type="hidden" name="media_type" value="{{ $isTv ? 'tv' : 'movie' }}">
+                <div class="mb-4">
+                    <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
+                    <input type="text" name="name" required maxlength="80"
+                           class="input-dark w-full" placeholder="e.g. Sci-Fi on Netflix…"
+                           id="save-roulette-name">
+                </div>
+                <div class="mb-6">
+                    <label class="flex items-center gap-2 cursor-pointer">
+                        <input type="checkbox" name="is_public" value="1"
+                               class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
+                        <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
+                    </label>
+                </div>
+                <div class="flex gap-3">
+                    <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
+                    <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <script>
+    (function () {
+        const modal    = document.getElementById('save-roulette-modal');
+        const nameInput = document.getElementById('save-roulette-name');
+        document.getElementById('save-roulette-btn').addEventListener('click', function () {
+            modal.classList.remove('hidden');
+            nameInput.focus();
+        });
+        document.getElementById('save-roulette-cancel').addEventListener('click', function () {
+            modal.classList.add('hidden');
+        });
+        document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
+            modal.classList.add('hidden');
+        });
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') modal.classList.add('hidden');
+        });
+    })();
+    </script>
+    @endauth
 
     {{-- Carousel --}}
     @include('includes.carousel', array_merge(

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -35,7 +35,7 @@
             @if(isset($providersArray) && isset($all_genres))
                 <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
             @endif
-            <a href="{{ Request::url() }}" class="btn-secondary flex-1 sm:flex-none text-center long-single">New Batch</a>
+            <a href="{{ Request::url() }}" class="btn-secondary flex-none text-center long-single">New Batch</a>
             <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none">Roll</button>
         </div>
     </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -79,13 +79,17 @@
         <div class="section-divider"></div>
 
         {{-- Movie mood tiles --}}
+        {{-- Genre IDs: Comedy 35, Thriller 53, Drama 18, Horror 27, Romance 10749, Action 28, Crime 80, Animation 16, Family 10751 --}}
         <div id="mood-movies" class="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
 
+            {{-- Funny: Comedy, decent quality floor --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
+                <input type="hidden" name="vote_average_gte" value="6.0">
+                <input type="hidden" name="vote_count_gte" value="200">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
@@ -97,12 +101,15 @@
                 </button>
             </form>
 
+            {{-- Intense: Thriller, no comedy/romance fluff --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="53">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="without_genres[]" value="10749">
+                <input type="hidden" name="vote_average_gte" value="6.5">
+                <input type="hidden" name="vote_count_gte" value="200">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
@@ -111,10 +118,12 @@
                 </button>
             </form>
 
+            {{-- Feel-good: Drama, high quality bar --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="7.5">
+                <input type="hidden" name="vote_count_gte" value="200">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
                 <input type="hidden" name="without_genres[]" value="80">
@@ -134,12 +143,15 @@
                 </button>
             </form>
 
+            {{-- Dark: Horror, filter out comedy/family/very low rated --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="without_genres[]" value="10751">
+                <input type="hidden" name="vote_average_gte" value="6.0">
+                <input type="hidden" name="vote_count_gte" value="200">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
@@ -148,12 +160,15 @@
                 </button>
             </form>
 
+            {{-- Romantic: Romance, exclude action/horror/thriller --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="10749">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
                 <input type="hidden" name="without_genres[]" value="28">
+                <input type="hidden" name="vote_average_gte" value="6.5">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
@@ -162,11 +177,14 @@
                 </button>
             </form>
 
+            {{-- Mindless: Action, exclude horror/heavy drama --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="28">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="18">
+                <input type="hidden" name="vote_average_gte" value="6.0">
+                <input type="hidden" name="vote_count_gte" value="200">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
@@ -178,13 +196,17 @@
 
         </div>
 
-        {{-- TV mood tiles (genre IDs: Comedy 35, Crime 80, Drama 18, Mystery 9648, Action&Adventure 10759, Animation 16, Family 10751) --}}
+        {{-- TV mood tiles --}}
+        {{-- Genre IDs: Comedy 35, Crime 80, Drama 18, Mystery 9648, Action&Adventure 10759, Romance 10749, Animation 16, Family 10751 --}}
         <div id="mood-tv" class="hidden grid grid-cols-3 sm:grid-cols-6 gap-3 mt-6">
 
+            {{-- Funny: Comedy, exclude animation (separate category) --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
+                <input type="hidden" name="vote_average_gte" value="7.0">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
@@ -196,12 +218,15 @@
                 </button>
             </form>
 
+            {{-- Intense: Crime or Action&Adventure, no comedy --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="80">
                 <input type="hidden" name="with_genres[]" value="10759">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
+                <input type="hidden" name="vote_average_gte" value="7.0">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
@@ -210,10 +235,12 @@
                 </button>
             </form>
 
+            {{-- Feel-good: Drama, high quality bar, no crime/mystery --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="7.5">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <input type="hidden" name="without_genres[]" value="80">
                 <input type="hidden" name="without_genres[]" value="9648">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!">
@@ -232,12 +259,15 @@
                 </button>
             </form>
 
+            {{-- Dark: Mystery, no comedy/family --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="9648">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="without_genres[]" value="10751">
+                <input type="hidden" name="vote_average_gte" value="7.0">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
@@ -246,12 +276,15 @@
                 </button>
             </form>
 
+            {{-- Romantic: Romance genre (was incorrectly Drama), no action/crime --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
-                <input type="hidden" name="with_genres[]" value="18">
+                <input type="hidden" name="with_genres[]" value="10749">
                 <input type="hidden" name="without_genres[]" value="80">
                 <input type="hidden" name="without_genres[]" value="9648">
                 <input type="hidden" name="without_genres[]" value="10759">
+                <input type="hidden" name="vote_average_gte" value="7.0">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
@@ -260,10 +293,13 @@
                 </button>
             </form>
 
+            {{-- Mindless: Action & Adventure, no heavy drama --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
                 <input type="hidden" name="with_genres[]" value="10759">
                 <input type="hidden" name="without_genres[]" value="18">
+                <input type="hidden" name="vote_average_gte" value="6.5">
+                <input type="hidden" name="vote_count_gte" value="100">
                 <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -336,10 +336,10 @@
         <div class="section-divider mb-4"></div>
 
         <div id="trending-movies">
-            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-movies', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-movies', 'genres' => $trendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
         </div>
         <div id="trending-tv" class="hidden">
-            @include('includes.carousel', ['allMovies' => $tvTrendingDay, 'name' => 'swiper-trending-tv', 'genres' => [], 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds, 'linkBase' => 'tv'])
+            @include('includes.carousel', ['allMovies' => $tvTrendingDay, 'name' => 'swiper-trending-tv', 'genres' => $tvTrendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds, 'linkBase' => 'tv', 'mediaType' => 'tv'])
         </div>
     </section>
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -85,6 +85,7 @@
             {{-- Funny: Comedy, decent quality floor --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
@@ -104,6 +105,7 @@
             {{-- Intense: Thriller, no comedy/romance fluff --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="53">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
@@ -121,6 +123,7 @@
             {{-- Feel-good: Drama, high quality bar --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="7.5">
                 <input type="hidden" name="vote_count_gte" value="200">
@@ -146,6 +149,7 @@
             {{-- Dark: Horror, filter out comedy/family/very low rated --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
@@ -163,6 +167,7 @@
             {{-- Romantic: Romance, exclude action/horror/thriller --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="10749">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
@@ -180,6 +185,7 @@
             {{-- Mindless: Action, exclude horror/heavy drama --}}
             <form method="POST" action="/movie?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="28">
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="18">
@@ -203,6 +209,7 @@
             {{-- Funny: Comedy, exclude animation (separate category) --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="vote_average_gte" value="7.0">
@@ -221,6 +228,7 @@
             {{-- Intense: Crime or Action&Adventure, no comedy --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="80">
                 <input type="hidden" name="with_genres[]" value="10759">
                 <input type="hidden" name="without_genres[]" value="35">
@@ -238,6 +246,7 @@
             {{-- Feel-good: Drama, high quality bar, no crime/mystery --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="7.5">
                 <input type="hidden" name="vote_count_gte" value="100">
@@ -262,6 +271,7 @@
             {{-- Dark: Mystery, no comedy/family --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="9648">
                 <input type="hidden" name="without_genres[]" value="35">
                 <input type="hidden" name="without_genres[]" value="16">
@@ -279,6 +289,7 @@
             {{-- Romantic: Romance genre (was incorrectly Drama), no action/crime --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="10749">
                 <input type="hidden" name="without_genres[]" value="80">
                 <input type="hidden" name="without_genres[]" value="9648">
@@ -296,6 +307,7 @@
             {{-- Mindless: Action & Adventure, no heavy drama --}}
             <form method="POST" action="/tv/pick?a=1">
                 @csrf
+                <input type="hidden" name="with_original_language" value="en">
                 <input type="hidden" name="with_genres[]" value="10759">
                 <input type="hidden" name="without_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="6.5">

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -10,6 +10,7 @@
              data-title="{{ $title }}"
              data-rating="{{ $result['vote_average'] ?? 0 }}"
              data-poster="{{ $result['poster_path'] ?? '' }}"
+             data-media-type="{{ ($linkBase ?? 'movie') === 'tv' ? 'tv' : 'movie' }}"
              data-url="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : ($linkSuffix ?? '') }}">
             <a href="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}"
                class="block h-full group long-movie" data-name="{{ $title }}">

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -285,8 +285,8 @@
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
-            @else
-                <a href="{{ $batchUrl ?: '/multiple' }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
+            @elseif($batchUrl)
+                <a href="{{ $batchUrl }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
             @endif
         </div>
         {{-- Right --}}

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -296,11 +296,11 @@
             @else
                 @auth
                 <button type="button" id="save-roulette-btn"
-                        class="btn-secondary text-sm flex items-center gap-1.5">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        class="btn-secondary text-sm flex items-center gap-1.5" title="Save as Roulette">
+                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
                     </svg>
-                    Save as Roulette
+                    <span class="hidden sm:inline">Save as Roulette</span>
                 </button>
                 @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -294,12 +294,71 @@
             @if(request()->query('wl_status'))
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
+                @auth
+                <button type="button" id="save-roulette-btn"
+                        class="btn-secondary text-sm flex items-center gap-1.5">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                    </svg>
+                    Save as Roulette
+                </button>
+                @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
                 <a href="/movie" class="btn-accent long-single text-center" data-roll="movie-criteria">Roll</a>
             @endif
         </div>
     </div>
 </div>
+
+@auth
+{{-- Save as Roulette modal (movie page) --}}
+<div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
+    <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+        <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
+        <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
+            @csrf
+            <input type="hidden" name="media_type" value="movie">
+            <div class="mb-4">
+                <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
+                <input type="text" name="name" required maxlength="80"
+                       class="input-dark w-full" placeholder="e.g. Sci-Fi on Netflix…"
+                       id="save-roulette-name">
+            </div>
+            <div class="mb-6">
+                <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="checkbox" name="is_public" value="1"
+                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
+                    <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
+                </label>
+            </div>
+            <div class="flex gap-3">
+                <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
+                <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>
+<script>
+(function () {
+    const modal     = document.getElementById('save-roulette-modal');
+    const nameInput = document.getElementById('save-roulette-name');
+    document.getElementById('save-roulette-btn').addEventListener('click', function () {
+        modal.classList.remove('hidden');
+        nameInput.focus();
+    });
+    document.getElementById('save-roulette-cancel').addEventListener('click', function () {
+        modal.classList.add('hidden');
+    });
+    document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
+        modal.classList.add('hidden');
+    });
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') modal.classList.add('hidden');
+    });
+})();
+</script>
+@endauth
 
 @if(request()->query('wl_status'))
 <script>

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -144,7 +144,7 @@
         {{-- Tags --}}
         <div class="bg-white/3 border border-white/5 rounded-xl p-5">
             <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Tags</h3>
-            @include('roulettes._tag_form', ['roulette' => $roulette])
+            @include('roulettes._tag_form', ['roulette' => $roulette, 'mediaType' => old('media_type', $roulette?->media_type ?? 'movie')])
         </div>
 
         {{-- Public toggle --}}

--- a/resources/views/my-roulettes/form.blade.php
+++ b/resources/views/my-roulettes/form.blade.php
@@ -172,6 +172,7 @@
 @endsection
 
 @section('scripts')
+@vite(['resources/js/custom/rouletteForm.js'])
 <style>
 @media (max-width: 639px) {
     #poster-grid { display: flex; overflow-x: auto; gap: 0.5rem; padding-bottom: 0.375rem; }

--- a/resources/views/person.blade.php
+++ b/resources/views/person.blade.php
@@ -126,62 +126,42 @@
     </div>
     @endif
 
-    {{-- Known for --}}
-    @if($knownFor->isNotEmpty())
-    <div class="mb-10">
-        <div class="section-header mb-4">
-            <h2 class="text-xl font-bold text-white mb-3">Known For</h2>
-            <div class="section-divider"></div>
-        </div>
-        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
-            @foreach($knownFor as $item)
-            @php
-                $link  = ($item->media_type ?? '') === 'tv' ? '/tv/'.$item->id : '/movie/'.$item->id;
-                $title = $item->title ?? $item->name ?? '';
-                $year  = substr($item->release_date ?? $item->first_air_date ?? '', 0, 4);
-            @endphp
-            <a href="{{ $link }}" class="flex-shrink-0 w-28 group">
-                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] group-hover:ring-1 group-hover:ring-accent/50 transition-all">
-                    @if(!empty($item->poster_path))
-                        <img src="https://image.tmdb.org/t/p/w185{{ $item->poster_path }}"
-                             alt="{{ $title }}"
-                             class="w-full h-full object-cover" loading="lazy">
-                    @else
-                        <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs text-center px-2">{{ $title }}</div>
-                    @endif
-                </div>
-                <p class="text-xs text-gray-300 mt-1.5 font-medium leading-snug group-hover:text-white transition-colors truncate">{{ $title }}</p>
-                @if($year)<p class="text-xs text-gray-600">{{ $year }}</p>@endif
-            </a>
-            @endforeach
-        </div>
-    </div>
-    @endif
-
-    {{-- Filmography --}}
-    @php $showMovies = $movies->isNotEmpty(); $showTv = $tvShows->isNotEmpty(); @endphp
-    @if($showMovies || $showTv)
+    {{-- Filmography — 4 tabs --}}
+    @php
+        $tabs = array_filter([
+            $hasMovieCast ? ['id' => 'movie-cast', 'label' => 'Movies', 'sub' => 'Acting',    'count' => $movieCast->count()] : null,
+            $hasTvCast    ? ['id' => 'tv-cast',    'label' => 'TV',     'sub' => 'Acting',    'count' => $tvCast->count()]    : null,
+            $hasMovieCrew ? ['id' => 'movie-crew', 'label' => 'Movies', 'sub' => 'Crew',      'count' => $movieCrew->count()] : null,
+            $hasTvCrew    ? ['id' => 'tv-crew',    'label' => 'TV',     'sub' => 'Crew',      'count' => $tvCrew->count()]    : null,
+        ]);
+        $firstTab = array_key_first($tabs) !== null ? $tabs[array_key_first($tabs)]['id'] : null;
+    @endphp
+    @if($firstTab)
     <div>
         <div class="section-header mb-4">
             <h2 class="text-xl font-bold text-white mb-3">Filmography</h2>
             <div class="section-divider"></div>
         </div>
 
-        {{-- Tabs --}}
-        @if($showMovies && $showTv)
-        <div class="flex gap-1 mb-4">
-            <button id="tab-movies" onclick="switchTab('movies')"
-                class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors bg-white/10 text-white">Movies ({{ $movies->count() }})</button>
-            <button id="tab-tv" onclick="switchTab('tv')"
-                class="px-4 py-1.5 rounded-lg text-sm font-medium transition-colors text-gray-400 hover:text-white">TV Shows ({{ $tvShows->count() }})</button>
+        {{-- Tab buttons --}}
+        @if(count($tabs) > 1)
+        <div class="flex flex-wrap gap-1 mb-4">
+            @foreach($tabs as $tab)
+            <button id="tab-{{ $tab['id'] }}" onclick="switchFilmTab('{{ $tab['id'] }}')"
+                class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors {{ $tab['id'] === $firstTab ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white' }}">
+                {{ $tab['label'] }}
+                <span class="text-xs font-normal opacity-60 ml-0.5">{{ $tab['sub'] }}</span>
+                <span class="text-xs text-gray-600 ml-1">({{ $tab['count'] }})</span>
+            </button>
+            @endforeach
         </div>
         @endif
 
-        {{-- Movies list --}}
-        @if($showMovies)
-        <div id="list-movies">
+        {{-- Movie acting --}}
+        @if($hasMovieCast)
+        <div id="list-movie-cast" @if($firstTab !== 'movie-cast') style="display:none" @endif>
             <div class="flex flex-col divide-y divide-white/5">
-                @foreach($movies as $item)
+                @foreach($movieCast as $item)
                 @php $year = substr($item->release_date ?? '', 0, 4); @endphp
                 <a href="/movie/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
                     <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
@@ -194,8 +174,6 @@
                         <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->title ?? '' }}</p>
                         @if(!empty($item->character))
                             <p class="text-xs text-gray-600 truncate">as {{ $item->character }}</p>
-                        @elseif(!empty($item->job))
-                            <p class="text-xs text-gray-600 truncate">{{ $item->job }}</p>
                         @endif
                     </div>
                     @if(!empty($item->vote_average) && $item->vote_average > 0)
@@ -207,11 +185,11 @@
         </div>
         @endif
 
-        {{-- TV list --}}
-        @if($showTv)
-        <div id="list-tv" @if($showMovies && $showTv) style="display:none" @endif>
+        {{-- TV acting --}}
+        @if($hasTvCast)
+        <div id="list-tv-cast" @if($firstTab !== 'tv-cast') style="display:none" @endif>
             <div class="flex flex-col divide-y divide-white/5">
-                @foreach($tvShows as $item)
+                @foreach($tvCast as $item)
                 @php $year = substr($item->first_air_date ?? '', 0, 4); @endphp
                 <a href="/tv/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
                     <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
@@ -224,7 +202,61 @@
                         <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->name ?? '' }}</p>
                         @if(!empty($item->character))
                             <p class="text-xs text-gray-600 truncate">as {{ $item->character }}</p>
-                        @elseif(!empty($item->job))
+                        @endif
+                    </div>
+                    @if(!empty($item->vote_average) && $item->vote_average > 0)
+                        <span class="ml-auto text-xs text-gray-600 flex-shrink-0">★ {{ number_format($item->vote_average, 1) }}</span>
+                    @endif
+                </a>
+                @endforeach
+            </div>
+        </div>
+        @endif
+
+        {{-- Movie crew --}}
+        @if($hasMovieCrew)
+        <div id="list-movie-crew" @if($firstTab !== 'movie-crew') style="display:none" @endif>
+            <div class="flex flex-col divide-y divide-white/5">
+                @foreach($movieCrew as $item)
+                @php $year = substr($item->release_date ?? '', 0, 4); @endphp
+                <a href="/movie/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
+                    <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
+                    <div class="w-8 h-12 flex-shrink-0 rounded overflow-hidden bg-white/[0.03]">
+                        @if(!empty($item->poster_path))
+                            <img src="https://image.tmdb.org/t/p/w92{{ $item->poster_path }}" class="w-full h-full object-cover" loading="lazy">
+                        @endif
+                    </div>
+                    <div class="min-w-0">
+                        <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->title ?? '' }}</p>
+                        @if(!empty($item->job))
+                            <p class="text-xs text-gray-600 truncate">{{ $item->job }}</p>
+                        @endif
+                    </div>
+                    @if(!empty($item->vote_average) && $item->vote_average > 0)
+                        <span class="ml-auto text-xs text-gray-600 flex-shrink-0">★ {{ number_format($item->vote_average, 1) }}</span>
+                    @endif
+                </a>
+                @endforeach
+            </div>
+        </div>
+        @endif
+
+        {{-- TV crew --}}
+        @if($hasTvCrew)
+        <div id="list-tv-crew" @if($firstTab !== 'tv-crew') style="display:none" @endif>
+            <div class="flex flex-col divide-y divide-white/5">
+                @foreach($tvCrew as $item)
+                @php $year = substr($item->first_air_date ?? '', 0, 4); @endphp
+                <a href="/tv/{{ $item->id }}" class="flex items-center gap-4 py-3 hover:bg-white/[0.03] -mx-2 px-2 rounded-lg transition-colors group">
+                    <span class="text-sm text-gray-600 w-10 flex-shrink-0 text-right">{{ $year ?: '—' }}</span>
+                    <div class="w-8 h-12 flex-shrink-0 rounded overflow-hidden bg-white/[0.03]">
+                        @if(!empty($item->poster_path))
+                            <img src="https://image.tmdb.org/t/p/w92{{ $item->poster_path }}" class="w-full h-full object-cover" loading="lazy">
+                        @endif
+                    </div>
+                    <div class="min-w-0">
+                        <p class="text-sm text-gray-300 group-hover:text-white transition-colors truncate">{{ $item->name ?? '' }}</p>
+                        @if(!empty($item->job))
                             <p class="text-xs text-gray-600 truncate">{{ $item->job }}</p>
                         @endif
                     </div>
@@ -241,15 +273,17 @@
 
 </div>
 
-@if($showMovies && $showTv)
+@if(isset($firstTab) && $firstTab && count($tabs ?? []) > 1)
 <script>
-function switchTab(tab) {
-    document.getElementById('list-movies').style.display = tab === 'movies' ? '' : 'none';
-    document.getElementById('list-tv').style.display     = tab === 'tv'     ? '' : 'none';
-    document.getElementById('tab-movies').className = 'px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ' +
-        (tab === 'movies' ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white');
-    document.getElementById('tab-tv').className = 'px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ' +
-        (tab === 'tv' ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white');
+const FILM_TABS = ['movie-cast','tv-cast','movie-crew','tv-crew'];
+function switchFilmTab(tab) {
+    FILM_TABS.forEach(id => {
+        const el = document.getElementById('list-' + id);
+        const btn = document.getElementById('tab-' + id);
+        if (el)  el.style.display = id === tab ? '' : 'none';
+        if (btn) btn.className = btn.className.replace(/bg-white\/10 text-white|text-gray-400 hover:text-white/g, '')
+            .trim() + ' ' + (id === tab ? 'bg-white/10 text-white' : 'text-gray-400 hover:text-white');
+    });
 }
 </script>
 @endif

--- a/resources/views/roulettes/_tag_form.blade.php
+++ b/resources/views/roulettes/_tag_form.blade.php
@@ -1,17 +1,36 @@
 @php
-    $currentTags = $roulette?->tags ?? [];
-    $genres = [
+    $currentTags  = $roulette?->tags ?? [];
+    $currentMedia = $mediaType ?? 'movie';
+
+    $movieGenres = [
         'action'=>'Action','adventure'=>'Adventure','animation'=>'Animation','comedy'=>'Comedy',
         'crime'=>'Crime','documentary'=>'Documentary','drama'=>'Drama','family'=>'Family',
         'fantasy'=>'Fantasy','history'=>'History','horror'=>'Horror','mystery'=>'Mystery',
         'romance'=>'Romance','sci-fi'=>'Sci-Fi','thriller'=>'Thriller','war'=>'War','western'=>'Western',
     ];
-    $platforms = ['netflix'=>'Netflix','prime'=>'Prime Video','hbo'=>'HBO','disney'=>'Disney+','apple'=>'Apple TV+'];
-    $eras = [
-        'recent'=>'New Releases','2020s'=>'The 2020s','2010s'=>'The 2010s','2000s'=>'The 2000s',
-        '1990s'=>'The Nineties','1980s'=>'The Eighties','1970s'=>'The Seventies',
-        '1960s'=>'The Sixties','1950s'=>'The Fifties','pre-1950'=>'Classic Hollywood',
+
+    // TV uses different TMDB genre IDs — action+adventure merge, sci-fi+fantasy merge,
+    // thriller maps to crime; TV-only: Kids (10762) and Reality (10764)
+    $tvGenres = [
+        'action'      => 'Action & Adventure',
+        'animation'   => 'Animation',
+        'comedy'      => 'Comedy',
+        'crime'       => 'Crime',
+        'documentary' => 'Documentary',
+        'drama'       => 'Drama',
+        'family'      => 'Family',
+        'fantasy'     => 'Sci-Fi & Fantasy',
+        'history'     => 'History',
+        'horror'      => 'Horror',
+        'kids'        => 'Kids',
+        'mystery'     => 'Mystery',
+        'reality'     => 'Reality',
+        'romance'     => 'Romance',
+        'war'         => 'War & Politics',
+        'western'     => 'Western',
     ];
+
+    $platforms = ['netflix'=>'Netflix','prime'=>'Prime Video','hbo'=>'HBO','disney'=>'Disney+','apple'=>'Apple TV+'];
     $countries = [
         'US'=>'United States','JP'=>'Japanese','KR'=>'Korean','FR'=>'French','ES'=>'Spanish',
         'IT'=>'Italian','CN'=>'Chinese','IN'=>'Indian','DE'=>'German','TR'=>'Turkish',
@@ -26,9 +45,10 @@
     $selectedPlatform      = $currentTags['platform'][0]      ?? null;
     $selectedGenres        = $currentTags['genre']             ?? [];
     $selectedWithoutGenres = $currentTags['without_genre']     ?? [];
-    $selectedEra           = $currentTags['era'][0]            ?? null;
     $selectedCountry       = $currentTags['country'][0]        ?? null;
     $selectedLanguage      = $currentTags['language'][0]       ?? null;
+    $selectedYearFrom      = $currentTags['year_from']         ?? '';
+    $selectedYearTo        = $currentTags['year_to']           ?? '';
 @endphp
 
 <div class="space-y-6">
@@ -36,8 +56,10 @@
     {{-- Include Genre --}}
     <div>
         <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Include Genre</label>
-        <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
-            @foreach($genres as $value => $label)
+
+        {{-- Movie genres --}}
+        <div data-genre-panel="movie" class="{{ $currentMedia === 'tv' ? 'hidden' : '' }} grid grid-cols-3 sm:grid-cols-4 gap-2">
+            @foreach($movieGenres as $value => $label)
                 <label class="flex items-center gap-2 cursor-pointer group">
                     <input type="checkbox" name="tags[genre][]" value="{{ $value }}"
                            class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent focus:ring-accent/50"
@@ -46,14 +68,41 @@
                 </label>
             @endforeach
         </div>
+
+        {{-- TV genres --}}
+        <div data-genre-panel="tv" class="{{ $currentMedia === 'tv' ? '' : 'hidden' }} grid grid-cols-3 sm:grid-cols-4 gap-2">
+            @foreach($tvGenres as $value => $label)
+                <label class="flex items-center gap-2 cursor-pointer group">
+                    <input type="checkbox" name="tags[genre][]" value="{{ $value }}"
+                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent focus:ring-accent/50"
+                           {{ in_array($value, $selectedGenres) ? 'checked' : '' }}>
+                    <span class="text-sm text-gray-300 group-hover:text-white transition-colors">{{ $label }}</span>
+                </label>
+            @endforeach
+        </div>
+
         @error('tags.genre') <p class="text-red-400 text-xs mt-1">{{ $message }}</p> @enderror
     </div>
 
     {{-- Exclude Genre --}}
     <div>
         <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Exclude Genre</label>
-        <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
-            @foreach($genres as $value => $label)
+
+        {{-- Movie genres --}}
+        <div data-exclude-panel="movie" class="{{ $currentMedia === 'tv' ? 'hidden' : '' }} grid grid-cols-3 sm:grid-cols-4 gap-2">
+            @foreach($movieGenres as $value => $label)
+                <label class="flex items-center gap-2 cursor-pointer group">
+                    <input type="checkbox" name="tags[without_genre][]" value="{{ $value }}"
+                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-red-400 focus:ring-red-400/50"
+                           {{ in_array($value, $selectedWithoutGenres) ? 'checked' : '' }}>
+                    <span class="text-sm text-gray-300 group-hover:text-white transition-colors">{{ $label }}</span>
+                </label>
+            @endforeach
+        </div>
+
+        {{-- TV genres --}}
+        <div data-exclude-panel="tv" class="{{ $currentMedia === 'tv' ? '' : 'hidden' }} grid grid-cols-3 sm:grid-cols-4 gap-2">
+            @foreach($tvGenres as $value => $label)
                 <label class="flex items-center gap-2 cursor-pointer group">
                     <input type="checkbox" name="tags[without_genre][]" value="{{ $value }}"
                            class="w-4 h-4 rounded border-white/20 bg-white/5 text-red-400 focus:ring-red-400/50"
@@ -73,17 +122,6 @@
                 <option value="">None</option>
                 @foreach($platforms as $value => $label)
                     <option value="{{ $value }}" {{ $selectedPlatform === $value ? 'selected' : '' }}>{{ $label }}</option>
-                @endforeach
-            </select>
-        </div>
-
-        {{-- Era --}}
-        <div>
-            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Era</label>
-            <select name="tags[era]" class="input-dark w-full">
-                <option value="">None</option>
-                @foreach($eras as $value => $label)
-                    <option value="{{ $value }}" {{ $selectedEra === $value ? 'selected' : '' }}>{{ $label }}</option>
                 @endforeach
             </select>
         </div>
@@ -112,5 +150,92 @@
 
     </div>
 
+    {{-- Year Range --}}
+    <div>
+        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Year Range</label>
+        <div class="flex flex-wrap gap-1.5 mb-3">
+            <button type="button" class="decade-chip" data-from="" data-to="">Any</button>
+            <button type="button" class="decade-chip" data-from="{{ date('Y') - 2 }}" data-to="">Recent</button>
+            <button type="button" class="decade-chip" data-from="2020" data-to="">2020s</button>
+            <button type="button" class="decade-chip" data-from="2010" data-to="2019">2010s</button>
+            <button type="button" class="decade-chip" data-from="2000" data-to="2009">2000s</button>
+            <button type="button" class="decade-chip" data-from="1990" data-to="1999">90s</button>
+            <button type="button" class="decade-chip" data-from="1980" data-to="1989">80s</button>
+            <button type="button" class="decade-chip" data-from="1970" data-to="1979">70s</button>
+            <button type="button" class="decade-chip" data-from="" data-to="1969">Classic</button>
+        </div>
+        <div class="flex items-center gap-2">
+            <input type="number" name="tags[year_from]" id="tag-year-from"
+                   value="{{ $selectedYearFrom }}"
+                   class="input-dark w-24" placeholder="1900" min="1900" max="{{ date('Y') }}">
+            <span class="text-gray-500 text-sm">–</span>
+            <input type="number" name="tags[year_to]" id="tag-year-to"
+                   value="{{ $selectedYearTo }}"
+                   class="input-dark w-24" placeholder="{{ date('Y') }}" min="1900" max="{{ date('Y') }}">
+        </div>
+    </div>
+
     @error('tags') <p class="text-red-400 text-xs mt-1">{{ $message }}</p> @enderror
 </div>
+
+<style>
+.decade-chip {
+    padding: 3px 10px;
+    font-size: 0.75rem;
+    border-radius: 9999px;
+    background: rgba(255,255,255,0.05);
+    color: #9ca3af;
+    border: 1px solid rgba(255,255,255,0.08);
+    transition: background 0.15s, color 0.15s;
+    cursor: pointer;
+}
+.decade-chip:hover { background: rgba(255,255,255,0.1); color: #fff; }
+.decade-chip.active { background: rgba(192,57,58,0.25); color: #fff; border-color: rgba(192,57,58,0.5); }
+</style>
+
+<script>
+(function () {
+    // ── Decade chips ──────────────────────────────────────────────────
+    const fromInput = document.getElementById('tag-year-from');
+    const toInput   = document.getElementById('tag-year-to');
+
+    function updateActiveChip() {
+        const from = fromInput.value;
+        const to   = toInput.value;
+        document.querySelectorAll('.decade-chip').forEach(chip => {
+            chip.classList.toggle('active',
+                chip.dataset.from === from && chip.dataset.to === to);
+        });
+    }
+
+    document.querySelectorAll('.decade-chip').forEach(chip => {
+        chip.addEventListener('click', function () {
+            fromInput.value = this.dataset.from;
+            toInput.value   = this.dataset.to;
+            updateActiveChip();
+        });
+    });
+
+    fromInput.addEventListener('input', updateActiveChip);
+    toInput.addEventListener('input', updateActiveChip);
+    updateActiveChip(); // mark active chip on page load if values already set
+
+    // ── Genre panel toggle ────────────────────────────────────────────
+    function switchGenrePanel(type) {
+        document.querySelectorAll('[data-genre-panel], [data-exclude-panel]').forEach(el => {
+            const panel = el.dataset.genrePanel || el.dataset.excludePanel;
+            el.classList.toggle('hidden', panel !== type);
+            // uncheck all inputs in the hidden panel so they don't submit
+            if (panel !== type) {
+                el.querySelectorAll('input[type=checkbox]').forEach(cb => cb.checked = false);
+            }
+        });
+    }
+
+    document.querySelectorAll('input[name="media_type"]').forEach(radio => {
+        radio.addEventListener('change', function () {
+            switchGenrePanel(this.value);
+        });
+    });
+})();
+</script>

--- a/resources/views/roulettes/_tag_form.blade.php
+++ b/resources/views/roulettes/_tag_form.blade.php
@@ -49,6 +49,11 @@
     $selectedLanguage      = $currentTags['language'][0]       ?? null;
     $selectedYearFrom      = $currentTags['year_from']         ?? '';
     $selectedYearTo        = $currentTags['year_to']           ?? '';
+    $selectedVoteGte       = $currentTags['vote_average_gte']  ?? '';
+    $selectedVoteLte       = $currentTags['vote_average_lte']  ?? '';
+    $selectedVoteCount     = $currentTags['vote_count_gte']    ?? '';
+    $selectedWithCast      = $currentTags['with_cast']         ?? [];
+    $selectedWithCrew      = $currentTags['with_crew']         ?? [];
 @endphp
 
 <div class="space-y-6">
@@ -150,6 +155,45 @@
 
     </div>
 
+    {{-- People --}}
+    <div>
+        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">People</label>
+        <div class="flex flex-col gap-3">
+            <div>
+                <label class="block text-sm text-gray-400 mb-1">Actors</label>
+                <select id="roulette-with_cast" name="tags[with_cast][]" multiple></select>
+                <p class="text-xs text-gray-600 mt-1">Type to search, you can add multiple</p>
+            </div>
+            <div>
+                <label class="block text-sm text-gray-400 mb-1">Crew</label>
+                <select id="roulette-with_crew" name="tags[with_crew][]" multiple></select>
+                <p class="text-xs text-gray-600 mt-1">Directors, writers, producers</p>
+            </div>
+        </div>
+    </div>
+
+    {{-- Scores --}}
+    <div>
+        <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-3">Scores</label>
+        <div class="grid grid-cols-2 gap-3 mb-3">
+            <div>
+                <label class="block text-sm text-gray-400 mb-1">Min Rating</label>
+                <input type="number" name="tags[vote_average_gte]" value="{{ $selectedVoteGte }}"
+                       class="input-dark w-full" placeholder="0" min="0" max="10" step="0.1">
+            </div>
+            <div>
+                <label class="block text-sm text-gray-400 mb-1">Max Rating</label>
+                <input type="number" name="tags[vote_average_lte]" value="{{ $selectedVoteLte }}"
+                       class="input-dark w-full" placeholder="10" min="0" max="10" step="0.1">
+            </div>
+        </div>
+        <div>
+            <label class="block text-sm text-gray-400 mb-1">Min Vote Count</label>
+            <input type="number" name="tags[vote_count_gte]" value="{{ $selectedVoteCount }}"
+                   class="input-dark w-24" placeholder="10" min="0">
+        </div>
+    </div>
+
     {{-- Year Range --}}
     <div>
         <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Year Range</label>
@@ -177,6 +221,12 @@
 
     @error('tags') <p class="text-red-400 text-xs mt-1">{{ $message }}</p> @enderror
 </div>
+
+{{-- Pass existing people IDs so rouletteForm.js can restore them --}}
+<script>
+window._rouletteWithCast = @json(array_values(array_map('strval', $selectedWithCast)));
+window._rouletteWithCrew = @json(array_values(array_map('strval', $selectedWithCrew)));
+</script>
 
 <style>
 .decade-chip {

--- a/resources/views/roulettes/_tag_form.blade.php
+++ b/resources/views/roulettes/_tag_form.blade.php
@@ -32,9 +32,9 @@
 
     $platforms = ['netflix'=>'Netflix','prime'=>'Prime Video','hbo'=>'HBO','disney'=>'Disney+','apple'=>'Apple TV+'];
     $countries = [
-        'US'=>'United States','JP'=>'Japanese','KR'=>'Korean','FR'=>'French','ES'=>'Spanish',
-        'IT'=>'Italian','CN'=>'Chinese','IN'=>'Indian','DE'=>'German','TR'=>'Turkish',
-        'PT'=>'Portuguese','MX'=>'Mexican','SE'=>'Swedish','DK'=>'Danish','LT'=>'Lithuanian',
+        'US'=>'United States','JP'=>'Japan','KR'=>'South Korea','FR'=>'France','ES'=>'Spain',
+        'IT'=>'Italy','CN'=>'China','IN'=>'India','DE'=>'Germany','TR'=>'Turkey',
+        'PT'=>'Portugal','MX'=>'Mexico','SE'=>'Sweden','DK'=>'Denmark','LT'=>'Lithuania',
     ];
     $languages = [
         'en'=>'English','ja'=>'Japanese','ko'=>'Korean','fr'=>'French','es'=>'Spanish',

--- a/resources/views/roulettes/_tag_form.blade.php
+++ b/resources/views/roulettes/_tag_form.blade.php
@@ -118,7 +118,7 @@
         </div>
     </div>
 
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
 
         {{-- Platform --}}
         <div>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -372,13 +372,15 @@
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
-            @else
-                <a href="{{ $batchUrl ?: '/tv/multiple' }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
+            @elseif($batchUrl)
+                <a href="{{ $batchUrl }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
             @endif
         </div>
         {{-- Right actions --}}
         <div class="flex items-center gap-3">
-            <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
+            @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
+                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
+            @endif
             @if(request()->query('wl_status'))
                 @php
                     $wlParams = ['status' => request()->query('wl_status')];

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -381,11 +381,11 @@
             @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
                 @auth
                 <button type="button" id="save-roulette-btn"
-                        class="btn-secondary text-sm flex items-center gap-1.5">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        class="btn-secondary text-sm flex items-center gap-1.5" title="Save as Roulette">
+                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
                     </svg>
-                    Save as Roulette
+                    <span class="hidden sm:inline">Save as Roulette</span>
                 </button>
                 @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -379,6 +379,15 @@
         {{-- Right actions --}}
         <div class="flex items-center gap-3">
             @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
+                @auth
+                <button type="button" id="save-roulette-btn"
+                        class="btn-secondary text-sm flex items-center gap-1.5">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                    </svg>
+                    Save as Roulette
+                </button>
+                @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
             @endif
             @if(request()->query('wl_status'))
@@ -395,5 +404,55 @@
         </div>
     </div>
 </div>
+
+@auth
+{{-- Save as Roulette modal (TV show page) --}}
+<div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
+    <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+        <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
+        <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
+            @csrf
+            <input type="hidden" name="media_type" value="tv">
+            <div class="mb-4">
+                <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
+                <input type="text" name="name" required maxlength="80"
+                       class="input-dark w-full" placeholder="e.g. K-Drama on Netflix…"
+                       id="save-roulette-name">
+            </div>
+            <div class="mb-6">
+                <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="checkbox" name="is_public" value="1"
+                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
+                    <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
+                </label>
+            </div>
+            <div class="flex gap-3">
+                <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
+                <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>
+<script>
+(function () {
+    const modal     = document.getElementById('save-roulette-modal');
+    const nameInput = document.getElementById('save-roulette-name');
+    document.getElementById('save-roulette-btn').addEventListener('click', function () {
+        modal.classList.remove('hidden');
+        nameInput.focus();
+    });
+    document.getElementById('save-roulette-cancel').addEventListener('click', function () {
+        modal.classList.add('hidden');
+    });
+    document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
+        modal.classList.add('hidden');
+    });
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') modal.classList.add('hidden');
+    });
+})();
+</script>
+@endauth
 
 @endsection

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -23,11 +23,18 @@
                     </div>
                 </div>
 
-                {{-- Genre select + sort --}}
+                {{-- Genre selects + sort --}}
                 <div class="flex flex-col sm:flex-row gap-2">
                     @if($genres->isNotEmpty())
                         <div class="flex-1">
                             <select id="genre-select" multiple placeholder="Filter by genre...">
+                                @foreach($genres as $genre)
+                                    <option value="{{ $genre }}">{{ $genre }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="flex-1">
+                            <select id="exclude-genre-select" multiple placeholder="Exclude genre...">
                                 @foreach($genres as $genre)
                                     <option value="{{ $genre }}">{{ $genre }}</option>
                                 @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,7 @@ Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(
     Route::patch('/manage/{roulette}/toggle',    [UserRouletteController::class, 'togglePublic'])->name('toggle');
     Route::post('/manage/{roulette}/refresh-poster', [UserRouletteController::class, 'refreshPoster'])->name('refresh-poster');
     Route::post('/manage/rows/reorder',              [UserRouletteController::class, 'reorderRows'])->name('rows.reorder');
+    Route::post('/from-criteria',                    [UserRouletteController::class, 'fromCriteria'])->name('from-criteria');
 });
 
 // Admin (must be before /roulettes/{slug} wildcard)

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
                 'resources/js/custom/watchlist.js',
                 'resources/js/custom/search.js',
                 'resources/js/custom/roulettes.js',
+                'resources/js/custom/rouletteForm.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## What's in this PR

### Bug fixes
- Clear stale roll context (actor page → homepage no longer bleeds into trending picks)
- Show back-to-batch button correctly; clear batch context on homepage
- Fix New Batch button stretching on mobile sticky bar

### Watchlist
- Genre filter: AND logic (all selected genres must match)
- Exclude genre select
- Standardize TV/movie genres to canonical names (Action & Adventure → Action, Adventure etc.)
- Auto-backfill missing genres from TMDB on page load
- Preserve genre selection when switching Films/TV type filter
- Fix genre options for items saved from home page (genres were empty)

### Roulette / case opening
- Stricter rating tiers for TV shows
- Pass media type through animation so TV tiers are used for TV shows
- Single card: skip animation, navigate directly
- Winner always eligible as fake-out in strip (all pool sizes)
- Winner never its own immediate neighbour at landing position

### Mood tiles
- Add quality floors and vote count minimums
- Fix TV Romantic genre
- Add English language filter to all 12 mood tiles

### Person / actor page
- Replace "Known For" + 2-tab layout with 4-tab filmography: Movies acting, TV acting, Movies crew, TV crew

### User roulettes (full criteria parity)
- TV genre panel in roulette form
- Replace era dropdown with year range inputs + decade chips
- Add score filters (min/max rating, min vote count)
- Add actor/crew people search (TomSelect + TMDB proxy)
- Fix country names (Japan not Japanese, etc.)
- Fix platform/language/country grid layout

### Save as Roulette
- Reverse-map session criteria to roulette tags
- Modal on batch page, movie detail page, and TV show detail page
- Icon-only on mobile sticky bar to avoid crowding
- Raise user roulette limit from 20 to 100
