### PR TITLE
Move Save as Roulette into criteria modal

### DIFF
--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -176,6 +176,46 @@
                     </div>
                 </div>
 
+                @auth
+                {{-- Save as Roulette inline --}}
+                <div id="criteria-save-roulette-row" class="hidden pt-3 border-t border-white/5">
+                    <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
+                        @csrf
+                        <input type="hidden" name="media_type" value="movie">
+                        <input type="text" name="name" required maxlength="80"
+                               class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="criteria-roulette-name">
+                        <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
+                            <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
+                            Public
+                        </label>
+                        <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
+                    </form>
+                </div>
+                <div class="pt-2">
+                    <button type="button" id="criteria-save-roulette-btn"
+                            class="text-xs text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                        </svg>
+                        Save current criteria as Roulette
+                    </button>
+                </div>
+                <script>
+                (function () {
+                    const btn = document.getElementById('criteria-save-roulette-btn');
+                    const row = document.getElementById('criteria-save-roulette-row');
+                    const inp = document.getElementById('criteria-roulette-name');
+                    if (btn && row) {
+                        btn.addEventListener('click', function () {
+                            row.classList.toggle('hidden');
+                            if (!row.classList.contains('hidden')) inp?.focus();
+                            btn.classList.toggle('text-gray-300');
+                        });
+                    }
+                })();
+                </script>
+                @endauth
+
             </div>
         </form>
     </div>

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -169,7 +169,18 @@
 
                 {{-- Actions --}}
                 <div class="flex items-center justify-between gap-2 pt-4 border-t border-white/5">
-                    <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                    <div class="flex items-center gap-2">
+                        <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                        @auth
+                        <button type="button" id="criteria-save-roulette-btn"
+                                class="btn-secondary text-sm flex items-center gap-1.5">
+                            <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                            </svg>
+                            Save as Roulette
+                        </button>
+                        @endauth
+                    </div>
                     <div class="flex gap-2">
                         <button type="submit" class="btn-secondary text-sm long-single" formaction="/multiple?a=true">Multiple</button>
                         <button type="submit" class="btn-accent text-sm long-single" formaction="/movie?a=true">Find Movie</button>
@@ -177,7 +188,7 @@
                 </div>
 
                 @auth
-                {{-- Save as Roulette inline --}}
+                {{-- Save as Roulette inline form (revealed on button click) --}}
                 <div id="criteria-save-roulette-row" class="hidden pt-3 border-t border-white/5">
                     <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
                         @csrf
@@ -191,15 +202,6 @@
                         <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
                     </form>
                 </div>
-                <div class="pt-2">
-                    <button type="button" id="criteria-save-roulette-btn"
-                            class="text-xs text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
-                        </svg>
-                        Save current criteria as Roulette
-                    </button>
-                </div>
                 <script>
                 (function () {
                     const btn = document.getElementById('criteria-save-roulette-btn');
@@ -209,7 +211,7 @@
                         btn.addEventListener('click', function () {
                             row.classList.toggle('hidden');
                             if (!row.classList.contains('hidden')) inp?.focus();
-                            btn.classList.toggle('text-gray-300');
+                            btn.classList.toggle('opacity-60');
                         });
                     }
                 })();

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -29,21 +29,59 @@
                 @endif
             </p>
         </div>
-        {{-- Save button in title row --}}
-        @auth
-            <button type="button" class="btn-secondary flex-shrink-0 watchlist-toggle"
-                data-tmdb-id="{{ $tmdbInfo->id }}"
-                data-title="{{ $tmdbInfo->title ?? $omdbInfo->Title }}"
-                data-poster="{{ $tmdbInfo->poster_path ?? '' }}"
-                data-year="{{ $omdbInfo->Year ?? date('Y', strtotime($tmdbInfo->release_date ?? '')) }}"
-                data-genres="{{ $genres ?? '' }}"
-                data-rating="{{ $tmdbInfo->vote_average ?? '' }}"
-                data-saved="{{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '1' : '0' }}">
-                {{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '★ Saved' : '☆ Save' }}
-            </button>
-        @else
-            <a href="{{ route('auth.google') }}" class="btn-secondary flex-shrink-0 text-center text-sm">☆ Save</a>
-        @endauth
+        {{-- Save buttons --}}
+        <div class="flex flex-col items-end gap-2 flex-shrink-0">
+            <div class="flex items-center gap-2">
+                @auth
+                    <button type="button" id="title-save-roulette-btn"
+                            class="btn-secondary text-sm flex items-center gap-1.5">
+                        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                        </svg>
+                        + Roulette
+                    </button>
+                    <button type="button" class="btn-secondary flex-shrink-0 watchlist-toggle"
+                        data-tmdb-id="{{ $tmdbInfo->id }}"
+                        data-title="{{ $tmdbInfo->title ?? $omdbInfo->Title }}"
+                        data-poster="{{ $tmdbInfo->poster_path ?? '' }}"
+                        data-year="{{ $omdbInfo->Year ?? date('Y', strtotime($tmdbInfo->release_date ?? '')) }}"
+                        data-genres="{{ $genres ?? '' }}"
+                        data-rating="{{ $tmdbInfo->vote_average ?? '' }}"
+                        data-saved="{{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '1' : '0' }}">
+                        {{ auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists() ? '★ Saved' : '☆ Save' }}
+                    </button>
+                @else
+                    <a href="{{ route('auth.google') }}" class="btn-secondary flex-shrink-0 text-center text-sm">☆ Save</a>
+                @endauth
+            </div>
+            @auth
+            <div id="title-save-roulette-form" class="hidden w-full">
+                <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
+                    @csrf
+                    <input type="hidden" name="media_type" value="movie">
+                    <input type="text" name="name" required maxlength="80"
+                           class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="title-roulette-name">
+                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
+                        <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
+                        Public
+                    </label>
+                    <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
+                </form>
+            </div>
+            <script>
+            (function () {
+                const btn = document.getElementById('title-save-roulette-btn');
+                const form = document.getElementById('title-save-roulette-form');
+                const inp  = document.getElementById('title-roulette-name');
+                btn.addEventListener('click', function () {
+                    form.classList.toggle('hidden');
+                    if (!form.classList.contains('hidden')) inp.focus();
+                    btn.classList.toggle('opacity-60');
+                });
+            })();
+            </script>
+            @endauth
+        </div>
     </div>
 
     {{-- Main content grid --}}

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -55,28 +55,49 @@
                 @endauth
             </div>
             @auth
-            <div id="title-save-roulette-form" class="hidden w-full">
-                <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
-                    @csrf
-                    <input type="hidden" name="media_type" value="movie">
-                    <input type="text" name="name" required maxlength="80"
-                           class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="title-roulette-name">
-                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
-                        <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
-                        Public
-                    </label>
-                    <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
-                </form>
+            {{-- Save as Roulette modal --}}
+            <div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+                <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
+                <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+                    <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
+                    <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
+                        @csrf
+                        <input type="hidden" name="media_type" value="movie">
+                        <div class="mb-4">
+                            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
+                            <input type="text" name="name" required maxlength="80"
+                                   class="input-dark w-full" placeholder="e.g. Sci-Fi on Netflix…"
+                                   id="save-roulette-name">
+                        </div>
+                        <div class="mb-6">
+                            <label class="flex items-center gap-2 cursor-pointer">
+                                <input type="checkbox" name="is_public" value="1"
+                                       class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
+                                <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
+                            </label>
+                        </div>
+                        <div class="flex gap-3">
+                            <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
+                            <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
+                        </div>
+                    </form>
+                </div>
             </div>
             <script>
             (function () {
-                const btn = document.getElementById('title-save-roulette-btn');
-                const form = document.getElementById('title-save-roulette-form');
-                const inp  = document.getElementById('title-roulette-name');
-                btn.addEventListener('click', function () {
-                    form.classList.toggle('hidden');
-                    if (!form.classList.contains('hidden')) inp.focus();
-                    btn.classList.toggle('opacity-60');
+                const modal = document.getElementById('save-roulette-modal');
+                const inp   = document.getElementById('save-roulette-name');
+                document.getElementById('title-save-roulette-btn').addEventListener('click', function () {
+                    modal.classList.remove('hidden'); inp.focus();
+                });
+                document.getElementById('save-roulette-cancel').addEventListener('click', function () {
+                    modal.classList.add('hidden');
+                });
+                document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
+                    modal.classList.add('hidden');
+                });
+                document.addEventListener('keydown', function (e) {
+                    if (e.key === 'Escape') modal.classList.add('hidden');
                 });
             })();
             </script>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -294,71 +294,12 @@
             @if(request()->query('wl_status'))
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
-                @auth
-                <button type="button" id="save-roulette-btn"
-                        class="btn-secondary text-sm flex items-center gap-1.5" title="Save as Roulette">
-                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
-                    </svg>
-                    <span class="hidden sm:inline">Save as Roulette</span>
-                </button>
-                @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
                 <a href="/movie" class="btn-accent long-single text-center" data-roll="movie-criteria">Roll</a>
             @endif
         </div>
     </div>
 </div>
-
-@auth
-{{-- Save as Roulette modal (movie page) --}}
-<div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
-    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
-    <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
-        <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
-        <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
-            @csrf
-            <input type="hidden" name="media_type" value="movie">
-            <div class="mb-4">
-                <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
-                <input type="text" name="name" required maxlength="80"
-                       class="input-dark w-full" placeholder="e.g. Sci-Fi on Netflix…"
-                       id="save-roulette-name">
-            </div>
-            <div class="mb-6">
-                <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" name="is_public" value="1"
-                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
-                    <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
-                </label>
-            </div>
-            <div class="flex gap-3">
-                <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
-                <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
-            </div>
-        </form>
-    </div>
-</div>
-<script>
-(function () {
-    const modal     = document.getElementById('save-roulette-modal');
-    const nameInput = document.getElementById('save-roulette-name');
-    document.getElementById('save-roulette-btn').addEventListener('click', function () {
-        modal.classList.remove('hidden');
-        nameInput.focus();
-    });
-    document.getElementById('save-roulette-cancel').addEventListener('click', function () {
-        modal.classList.add('hidden');
-    });
-    document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
-        modal.classList.add('hidden');
-    });
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') modal.classList.add('hidden');
-    });
-})();
-</script>
-@endauth
 
 @if(request()->query('wl_status'))
 <script>

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -175,7 +175,18 @@
 
                 {{-- Actions --}}
                 <div class="flex items-center justify-between gap-2 pt-4 border-t border-white/5">
-                    <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                    <div class="flex items-center gap-2">
+                        <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                        @auth
+                        <button type="button" id="criteria-save-roulette-btn"
+                                class="btn-secondary text-sm flex items-center gap-1.5">
+                            <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                            </svg>
+                            Save as Roulette
+                        </button>
+                        @endauth
+                    </div>
                     <div class="flex gap-2">
                         <button type="submit" class="btn-secondary text-sm long-single" formaction="/tv/multiple?a=true">Multiple</button>
                         <button type="submit" class="btn-accent text-sm long-single" formaction="/tv/pick?a=true">Find Show</button>
@@ -183,7 +194,7 @@
                 </div>
 
                 @auth
-                {{-- Save as Roulette inline --}}
+                {{-- Save as Roulette inline form (revealed on button click) --}}
                 <div id="criteria-save-roulette-row" class="hidden pt-3 border-t border-white/5">
                     <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
                         @csrf
@@ -197,15 +208,6 @@
                         <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
                     </form>
                 </div>
-                <div class="pt-2">
-                    <button type="button" id="criteria-save-roulette-btn"
-                            class="text-xs text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
-                        </svg>
-                        Save current criteria as Roulette
-                    </button>
-                </div>
                 <script>
                 (function () {
                     const btn = document.getElementById('criteria-save-roulette-btn');
@@ -215,7 +217,7 @@
                         btn.addEventListener('click', function () {
                             row.classList.toggle('hidden');
                             if (!row.classList.contains('hidden')) inp?.focus();
-                            btn.classList.toggle('text-gray-300');
+                            btn.classList.toggle('opacity-60');
                         });
                     }
                 })();

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -182,6 +182,46 @@
                     </div>
                 </div>
 
+                @auth
+                {{-- Save as Roulette inline --}}
+                <div id="criteria-save-roulette-row" class="hidden pt-3 border-t border-white/5">
+                    <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
+                        @csrf
+                        <input type="hidden" name="media_type" value="tv">
+                        <input type="text" name="name" required maxlength="80"
+                               class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="criteria-roulette-name">
+                        <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
+                            <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
+                            Public
+                        </label>
+                        <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
+                    </form>
+                </div>
+                <div class="pt-2">
+                    <button type="button" id="criteria-save-roulette-btn"
+                            class="text-xs text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                        </svg>
+                        Save current criteria as Roulette
+                    </button>
+                </div>
+                <script>
+                (function () {
+                    const btn = document.getElementById('criteria-save-roulette-btn');
+                    const row = document.getElementById('criteria-save-roulette-row');
+                    const inp = document.getElementById('criteria-roulette-name');
+                    if (btn && row) {
+                        btn.addEventListener('click', function () {
+                            row.classList.toggle('hidden');
+                            if (!row.classList.contains('hidden')) inp?.focus();
+                            btn.classList.toggle('text-gray-300');
+                        });
+                    }
+                })();
+                </script>
+                @endauth
+
             </div>
         </form>
     </div>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -29,23 +29,61 @@
                 @endif
             </p>
         </div>
-        {{-- Save button in title row --}}
-        @auth
-            @php $isSaved = auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists(); @endphp
-            <button type="button" class="btn-secondary flex-shrink-0 watchlist-toggle"
-                data-tmdb-id="{{ $tmdbInfo->id }}"
-                data-title="{{ $tmdbInfo->name }}"
-                data-poster="{{ $tmdbInfo->poster_path ?? '' }}"
-                data-year="{{ substr($tmdbInfo->first_air_date ?? '', 0, 4) }}"
-                data-genres="{{ $genres ?? '' }}"
-                data-rating="{{ $tmdbInfo->vote_average ?? '' }}"
-                data-media-type="tv"
-                data-saved="{{ $isSaved ? '1' : '0' }}">
-                {{ $isSaved ? '★ Saved' : '☆ Save' }}
-            </button>
-        @else
-            <a href="{{ route('auth.google') }}" class="btn-secondary flex-shrink-0 text-center text-sm">☆ Save</a>
-        @endauth
+        {{-- Save buttons --}}
+        <div class="flex flex-col items-end gap-2 flex-shrink-0">
+            <div class="flex items-center gap-2">
+                @auth
+                    @php $isSaved = auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists(); @endphp
+                    <button type="button" id="title-save-roulette-btn"
+                            class="btn-secondary text-sm flex items-center gap-1.5">
+                        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
+                        </svg>
+                        + Roulette
+                    </button>
+                    <button type="button" class="btn-secondary flex-shrink-0 watchlist-toggle"
+                        data-tmdb-id="{{ $tmdbInfo->id }}"
+                        data-title="{{ $tmdbInfo->name }}"
+                        data-poster="{{ $tmdbInfo->poster_path ?? '' }}"
+                        data-year="{{ substr($tmdbInfo->first_air_date ?? '', 0, 4) }}"
+                        data-genres="{{ $genres ?? '' }}"
+                        data-rating="{{ $tmdbInfo->vote_average ?? '' }}"
+                        data-media-type="tv"
+                        data-saved="{{ $isSaved ? '1' : '0' }}">
+                        {{ $isSaved ? '★ Saved' : '☆ Save' }}
+                    </button>
+                @else
+                    <a href="{{ route('auth.google') }}" class="btn-secondary flex-shrink-0 text-center text-sm">☆ Save</a>
+                @endauth
+            </div>
+            @auth
+            <div id="title-save-roulette-form" class="hidden w-full">
+                <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
+                    @csrf
+                    <input type="hidden" name="media_type" value="tv">
+                    <input type="text" name="name" required maxlength="80"
+                           class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="title-roulette-name">
+                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
+                        <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
+                        Public
+                    </label>
+                    <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
+                </form>
+            </div>
+            <script>
+            (function () {
+                const btn = document.getElementById('title-save-roulette-btn');
+                const form = document.getElementById('title-save-roulette-form');
+                const inp  = document.getElementById('title-roulette-name');
+                btn.addEventListener('click', function () {
+                    form.classList.toggle('hidden');
+                    if (!form.classList.contains('hidden')) inp.focus();
+                    btn.classList.toggle('opacity-60');
+                });
+            })();
+            </script>
+            @endauth
+        </div>
     </div>
 
     {{-- Main content grid --}}

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -57,28 +57,49 @@
                 @endauth
             </div>
             @auth
-            <div id="title-save-roulette-form" class="hidden w-full">
-                <form method="POST" action="{{ route('my-roulettes.from-criteria') }}" class="flex items-center gap-2">
-                    @csrf
-                    <input type="hidden" name="media_type" value="tv">
-                    <input type="text" name="name" required maxlength="80"
-                           class="input-dark flex-1 text-sm" placeholder="Roulette name…" id="title-roulette-name">
-                    <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer flex-shrink-0">
-                        <input type="checkbox" name="is_public" value="1" class="w-3.5 h-3.5 rounded border-white/20 bg-white/5 text-accent">
-                        Public
-                    </label>
-                    <button type="submit" class="btn-accent text-sm flex-shrink-0">Save</button>
-                </form>
+            {{-- Save as Roulette modal --}}
+            <div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+                <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
+                <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
+                    <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
+                    <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
+                        @csrf
+                        <input type="hidden" name="media_type" value="tv">
+                        <div class="mb-4">
+                            <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
+                            <input type="text" name="name" required maxlength="80"
+                                   class="input-dark w-full" placeholder="e.g. K-Drama on Netflix…"
+                                   id="save-roulette-name">
+                        </div>
+                        <div class="mb-6">
+                            <label class="flex items-center gap-2 cursor-pointer">
+                                <input type="checkbox" name="is_public" value="1"
+                                       class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
+                                <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
+                            </label>
+                        </div>
+                        <div class="flex gap-3">
+                            <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
+                            <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
+                        </div>
+                    </form>
+                </div>
             </div>
             <script>
             (function () {
-                const btn = document.getElementById('title-save-roulette-btn');
-                const form = document.getElementById('title-save-roulette-form');
-                const inp  = document.getElementById('title-roulette-name');
-                btn.addEventListener('click', function () {
-                    form.classList.toggle('hidden');
-                    if (!form.classList.contains('hidden')) inp.focus();
-                    btn.classList.toggle('opacity-60');
+                const modal = document.getElementById('save-roulette-modal');
+                const inp   = document.getElementById('save-roulette-name');
+                document.getElementById('title-save-roulette-btn').addEventListener('click', function () {
+                    modal.classList.remove('hidden'); inp.focus();
+                });
+                document.getElementById('save-roulette-cancel').addEventListener('click', function () {
+                    modal.classList.add('hidden');
+                });
+                document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
+                    modal.classList.add('hidden');
+                });
+                document.addEventListener('keydown', function (e) {
+                    if (e.key === 'Escape') modal.classList.add('hidden');
                 });
             })();
             </script>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -379,15 +379,6 @@
         {{-- Right actions --}}
         <div class="flex items-center gap-3">
             @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
-                @auth
-                <button type="button" id="save-roulette-btn"
-                        class="btn-secondary text-sm flex items-center gap-1.5" title="Save as Roulette">
-                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>
-                    </svg>
-                    <span class="hidden sm:inline">Save as Roulette</span>
-                </button>
-                @endauth
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
             @endif
             @if(request()->query('wl_status'))
@@ -404,55 +395,5 @@
         </div>
     </div>
 </div>
-
-@auth
-{{-- Save as Roulette modal (TV show page) --}}
-<div id="save-roulette-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
-    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" id="save-roulette-backdrop"></div>
-    <div class="relative bg-[#1a1a1a] border border-white/10 rounded-2xl p-6 w-full max-w-sm shadow-2xl">
-        <h2 class="text-lg font-bold text-white mb-4">Save as Roulette</h2>
-        <form method="POST" action="{{ route('my-roulettes.from-criteria') }}">
-            @csrf
-            <input type="hidden" name="media_type" value="tv">
-            <div class="mb-4">
-                <label class="block text-xs font-semibold uppercase tracking-widest text-gray-500 mb-2">Name</label>
-                <input type="text" name="name" required maxlength="80"
-                       class="input-dark w-full" placeholder="e.g. K-Drama on Netflix…"
-                       id="save-roulette-name">
-            </div>
-            <div class="mb-6">
-                <label class="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" name="is_public" value="1"
-                           class="w-4 h-4 rounded border-white/20 bg-white/5 text-accent">
-                    <span class="text-sm text-gray-300">Public — anyone with the link can roll this</span>
-                </label>
-            </div>
-            <div class="flex gap-3">
-                <button type="submit" class="btn-accent flex-1 py-2.5 text-sm">Save</button>
-                <button type="button" id="save-roulette-cancel" class="btn-secondary px-5 py-2.5 text-sm">Cancel</button>
-            </div>
-        </form>
-    </div>
-</div>
-<script>
-(function () {
-    const modal     = document.getElementById('save-roulette-modal');
-    const nameInput = document.getElementById('save-roulette-name');
-    document.getElementById('save-roulette-btn').addEventListener('click', function () {
-        modal.classList.remove('hidden');
-        nameInput.focus();
-    });
-    document.getElementById('save-roulette-cancel').addEventListener('click', function () {
-        modal.classList.add('hidden');
-    });
-    document.getElementById('save-roulette-backdrop').addEventListener('click', function () {
-        modal.classList.add('hidden');
-    });
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') modal.classList.add('hidden');
-    });
-})();
-</script>
-@endauth
 
 @endsection


### PR DESCRIPTION
Removes the Save as Roulette button from the sticky bar on movie and TV detail pages — it was ambiguous (looked like watchlist save) and crowded on mobile.

Now lives at the bottom of the Criteria modal as a small "Save current criteria as Roulette" link. Clicking it expands an inline name input + Public checkbox + Save button, no second modal needed.

Works on all pages that include the criteria modal: batch, movie detail, TV detail, criteria pages.
