### PR TITLE
Homepage roulettes teaser, nav search bar, Roulettes nav highlight

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -29,7 +29,7 @@ class HomeController extends Controller
         $movieGenres = $movieService->genres($tmdb, 'movie');
         $tvGenres    = $movieService->genres($tmdb, 'tv');
 
-        $featuredSlugs    = ['new-releases', 'tv-new-releases', 'netflix-drama', 'netflix-horror', '90s-nostalgia', 'tv-anime', 'tv-korean', 'comedy-films', 'action-films'];
+        $featuredSlugs     = ['new-releases', 'tv-new-releases', 'netflix-drama', 'netflix-horror', '90s-nostalgia', 'tv-anime', 'tv-korean', 'genre-comedy', 'genre-action'];
         $featuredRoulettes = Roulette::whereIn('slug', $featuredSlugs)
             ->where('is_public', true)
             ->get()

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Roulette;
 use App\Services\MovieService;
 use App\Services\TmdbClient;
 use Illuminate\View\View;
@@ -28,12 +29,20 @@ class HomeController extends Controller
         $movieGenres = $movieService->genres($tmdb, 'movie');
         $tvGenres    = $movieService->genres($tmdb, 'tv');
 
+        $featuredSlugs    = ['new-releases', 'tv-new-releases', 'netflix-drama', 'netflix-horror', '90s-nostalgia', 'tv-anime', 'tv-korean', 'comedy-films', 'action-films'];
+        $featuredRoulettes = Roulette::whereIn('slug', $featuredSlugs)
+            ->where('is_public', true)
+            ->get()
+            ->sortBy(fn($r) => array_search($r->slug, $featuredSlugs))
+            ->values();
+
         return view('home', [
             'trendingDay'        => $trendingDay,
             'tvTrendingDay'      => $tvTrendingDay,
             'savedIds'           => $savedIds,
             'trendingGenres'     => $movieService->movieGenresMap($trendingDay['results']   ?? [], $movieGenres),
             'tvTrendingGenres'   => $movieService->movieGenresMap($tvTrendingDay['results'] ?? [], $tvGenres),
+            'featuredRoulettes'  => $featuredRoulettes,
         ]);
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -138,6 +138,23 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
 
+    .nav-link {
+        color: var(--text-secondary);
+        transition: color 0.2s;
+    }
+    .nav-link:hover { color: var(--text-primary); }
+
+    .nav-link-highlight {
+        color: #c0393a;
+        font-weight: 500;
+        text-shadow: 0 0 12px rgba(192, 57, 58, 0.5);
+        transition: color 0.2s, text-shadow 0.2s;
+    }
+    .nav-link-highlight:hover {
+        color: #d44445;
+        text-shadow: 0 0 18px rgba(192, 57, 58, 0.7);
+    }
+
     .scrollbar-hide { scrollbar-width: none; -ms-overflow-style: none; }
     .scrollbar-hide::-webkit-scrollbar { display: none; }
 

--- a/resources/views/admin/roulettes/_table.blade.php
+++ b/resources/views/admin/roulettes/_table.blade.php
@@ -26,23 +26,14 @@
                     {{-- Poster thumbnail --}}
                     <td class="py-2 px-2">
                         @php $poster = ($roulette->poster_paths ?? [])[0] ?? null; @endphp
-                        <div class="relative group w-9 h-[52px] flex-shrink-0">
+                        <div class="w-9 h-[52px] flex-shrink-0">
                             @if($poster)
                                 <img src="https://image.tmdb.org/t/p/w92{{ $poster }}"
                                      alt="{{ $roulette->name }}"
-                                     class="roulette-poster w-full h-full object-cover rounded"
-                                     data-id="{{ $roulette->id }}">
+                                     class="w-full h-full object-cover rounded">
                             @else
-                                <div class="w-full h-full bg-white/5 rounded roulette-poster-placeholder" data-id="{{ $roulette->id }}"></div>
+                                <div class="w-full h-full bg-white/5 rounded"></div>
                             @endif
-                            <button type="button"
-                                    class="roll-poster-btn absolute inset-0 flex items-center justify-center bg-black/60 {{ $poster ? 'opacity-0 group-hover:opacity-100' : 'opacity-100' }} rounded transition-opacity text-white"
-                                    data-id="{{ $roulette->id }}"
-                                    title="Roll poster">
-                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                                </svg>
-                            </button>
                         </div>
                     </td>
                     <td class="py-3 px-3">

--- a/resources/views/admin/roulettes/index.blade.php
+++ b/resources/views/admin/roulettes/index.blade.php
@@ -85,47 +85,9 @@
 @endsection
 
 @section('scripts')
-<style>@keyframes spin { to { transform: rotate(360deg); } }</style>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    // Poster roll buttons
-    document.addEventListener('click', e => {
-        const btn = e.target.closest('.roll-poster-btn');
-        if (!btn) return;
-
-        const id  = btn.dataset.id;
-        const svg = btn.querySelector('svg');
-        btn.disabled = true;
-        svg.style.animation = 'spin 0.6s linear infinite';
-
-        fetch(`/admin/roulettes/${id}/refresh-poster`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content },
-        })
-        .then(r => r.json())
-        .then(data => {
-            if (!data.poster_path) return;
-            const url = `https://image.tmdb.org/t/p/w92${data.poster_path}`;
-            const cell = btn.closest('td');
-            // Replace placeholder div with img if needed
-            let img = cell.querySelector('.roulette-poster');
-            const placeholder = cell.querySelector('.roulette-poster-placeholder');
-            if (placeholder) {
-                img = document.createElement('img');
-                img.className = 'roulette-poster w-full h-full object-cover rounded';
-                img.dataset.id = id;
-                placeholder.replaceWith(img);
-                btn.classList.remove('opacity-100');
-                btn.classList.add('opacity-0', 'group-hover:opacity-100');
-            }
-            img.src = url;
-        })
-        .finally(() => {
-            btn.disabled = false;
-            svg.style.animation = '';
-        });
-    });
 
 
     @if(!$q)

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -324,6 +324,56 @@
         </div>
     </section>
 
+    {{-- Featured Roulettes --}}
+    @if($featuredRoulettes->isNotEmpty())
+    @include('includes.roulette-labels')
+    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12 border-b border-white/5">
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="text-xl sm:text-2xl font-bold text-white">Curated Roulettes</h2>
+            <a href="/roulettes" class="text-sm text-accent hover:underline">Browse all →</a>
+        </div>
+        <div class="section-divider mb-5"></div>
+        <div class="flex gap-3 overflow-x-auto pb-2">
+            @foreach($featuredRoulettes as $roulette)
+                @php
+                    $tags     = $roulette->tags;
+                    $platform = $tags['platform'][0] ?? null;
+                    $logo     = $platform ? ($platformLogos[$platform] ?? null) : null;
+                    $poster   = $roulette->poster_paths[0] ?? null;
+                    $isTv     = $roulette->media_type === 'tv';
+                @endphp
+                <div class="flex-shrink-0 w-36 md:w-44">
+                    <a href="/roulettes/{{ $roulette->slug }}"
+                       data-roulette-batch
+                       class="group relative rounded-xl overflow-hidden block bg-slate-900 long-single">
+                        <div class="aspect-[2/3] relative overflow-hidden">
+                            @if($poster)
+                                <img src="https://image.tmdb.org/t/p/w342{{ $poster }}"
+                                     class="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                                     loading="lazy">
+                            @else
+                                <div class="absolute inset-0 bg-gradient-to-br from-slate-700 to-slate-900"></div>
+                            @endif
+                            <div class="absolute inset-0 bg-gradient-to-t from-black via-black/30 to-transparent"></div>
+                            @if($logo)
+                                <img src="{{ $logo }}" class="absolute top-2 right-2 h-5 drop-shadow-lg" loading="lazy">
+                            @endif
+                            @if($isTv)
+                                <span class="absolute top-2 left-2 text-[10px] px-1.5 py-0.5 rounded-full bg-accent/80 text-white">TV</span>
+                            @endif
+                            <div class="absolute bottom-0 left-0 right-0 p-3">
+                                <h3 class="text-sm font-semibold text-white leading-snug">{{ $roulette->name }}</h3>
+                                <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Batch →</span>
+                            </div>
+                        </div>
+                    </a>
+                    <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
+                </div>
+            @endforeach
+        </div>
+    </section>
+    @endif
+
     {{-- Trending --}}
     <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12">
         <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -324,13 +324,35 @@
         </div>
     </section>
 
+    {{-- Trending --}}
+    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12 border-b border-white/5">
+        <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+            <h2 class="text-xl sm:text-2xl font-bold text-white">Trending Today</h2>
+            <div class="flex gap-1 bg-white/5 p-1 rounded-lg shrink-0">
+                <button id="trend-movies" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Movies</button>
+                <button id="trend-tv" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">TV</button>
+            </div>
+        </div>
+        <div class="section-divider mb-4"></div>
+
+        <div id="trending-movies">
+            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-movies', 'genres' => $trendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
+        </div>
+        <div id="trending-tv" class="hidden">
+            @include('includes.carousel', ['allMovies' => $tvTrendingDay, 'name' => 'swiper-trending-tv', 'genres' => $tvTrendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds, 'linkBase' => 'tv', 'mediaType' => 'tv'])
+        </div>
+    </section>
+
     {{-- Featured Roulettes --}}
     @if($featuredRoulettes->isNotEmpty())
     @include('includes.roulette-labels')
-    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12 border-b border-white/5">
-        <div class="flex items-center justify-between mb-3">
-            <h2 class="text-xl sm:text-2xl font-bold text-white">Curated Roulettes</h2>
-            <a href="/roulettes" class="text-sm text-accent hover:underline">Browse all →</a>
+    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12">
+        <div class="flex flex-wrap items-end justify-between gap-3 mb-3">
+            <div>
+                <h2 class="text-xl sm:text-2xl font-bold text-white">Curated Roulettes</h2>
+                <p class="text-gray-500 text-sm mt-0.5">Handpicked collections — hit Roll and let fate decide.</p>
+            </div>
+            <a href="/roulettes" class="btn-secondary text-sm px-4 py-2 flex-shrink-0">Browse all roulettes →</a>
         </div>
         <div class="section-divider mb-5"></div>
         <div class="flex gap-3 overflow-x-auto pb-2">
@@ -370,28 +392,37 @@
                     <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
                 </div>
             @endforeach
+
+            {{-- Create your own CTA card --}}
+            <div class="flex-shrink-0 w-36 md:w-44">
+                <a href="{{ auth()->check() ? route('my-roulettes.create') : route('auth.google') }}"
+                   class="group relative rounded-xl overflow-hidden block long-single border border-dashed border-white/15 hover:border-accent/50 transition-colors bg-white/3 hover:bg-white/5">
+                    <div class="aspect-[2/3] relative flex flex-col items-center justify-center p-4 text-center">
+                        <div class="w-10 h-10 rounded-full bg-accent/10 group-hover:bg-accent/20 transition-colors flex items-center justify-center mb-3">
+                            @auth
+                                <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                                </svg>
+                            @else
+                                <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                                </svg>
+                            @endauth
+                        </div>
+                        @auth
+                            <p class="text-xs font-semibold text-white leading-snug mb-1">Create Your Own</p>
+                            <p class="text-[10px] text-gray-500 leading-snug">Build a roulette from your favourite genres, platforms or actors</p>
+                        @else
+                            <p class="text-xs font-semibold text-white leading-snug mb-1">Sign in to Create</p>
+                            <p class="text-[10px] text-gray-500 leading-snug">Save your own roulettes and roll them any time</p>
+                        @endauth
+                    </div>
+                </a>
+                <div class="h-[30px] mt-2"></div>{{-- spacer to align with Roll buttons --}}
+            </div>
         </div>
     </section>
     @endif
-
-    {{-- Trending --}}
-    <section class="max-w-7xl mx-auto px-4 py-8 sm:py-12">
-        <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
-            <h2 class="text-xl sm:text-2xl font-bold text-white">Trending Today</h2>
-            <div class="flex gap-1 bg-white/5 p-1 rounded-lg shrink-0">
-                <button id="trend-movies" class="trend-toggle active text-xs px-3 py-1.5 rounded-md transition-all">Movies</button>
-                <button id="trend-tv" class="trend-toggle text-xs px-3 py-1.5 rounded-md transition-all text-gray-400">TV</button>
-            </div>
-        </div>
-        <div class="section-divider mb-4"></div>
-
-        <div id="trending-movies">
-            @include('includes.carousel', ['allMovies' => $trendingDay, 'name' => 'swiper-trending-movies', 'genres' => $trendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
-        </div>
-        <div id="trending-tv" class="hidden">
-            @include('includes.carousel', ['allMovies' => $tvTrendingDay, 'name' => 'swiper-trending-tv', 'genres' => $tvTrendingGenres, 'clearCriteria' => true, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds, 'linkBase' => 'tv', 'mediaType' => 'tv'])
-        </div>
-    </section>
 
     {{-- About --}}
     <section class="bg-white/[0.02] border-y border-white/5 py-10 sm:py-16">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,21 +25,29 @@
 
     {{-- Navigation --}}
     <nav class="fixed top-0 left-0 right-0 z-50 h-16 bg-[#0f0f0f]/90 backdrop-blur-lg border-b border-white/5">
-        <div class="max-w-7xl mx-auto px-4 h-full flex items-center justify-between gap-4">
+        <div class="max-w-7xl mx-auto px-4 h-full flex items-center gap-4">
 
             {{-- Logo --}}
             <a href="/" class="text-lg font-bold flex-shrink-0">
                 <span class="text-white">Movie</span><span class="text-accent">Pickr</span>
             </a>
 
-            {{-- Desktop nav --}}
-            <div class="hidden md:flex items-center gap-5 flex-1 justify-end">
+            {{-- Desktop search — fills middle --}}
+            <div id="desktop-search-wrap" class="relative hidden md:block flex-1 max-w-lg">
+                <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+                <input id="desktop-search-input" type="text" placeholder="Search movies, shows, people…" autocomplete="off"
+                    class="w-full bg-white/5 border border-white/10 rounded-lg pl-9 pr-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 focus:bg-white/7 transition-all duration-200">
+                <div id="desktop-search-results" class="hidden absolute left-0 top-full mt-1 w-full min-w-72 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden shadow-2xl z-50 divide-y divide-white/5"></div>
+            </div>
+
+            {{-- Desktop nav links — right side --}}
+            <div class="hidden md:flex items-center gap-5 flex-shrink-0 ml-auto">
                 @auth
                     @if(auth()->user()->email === config('api.admin_email'))
                         <a href="{{ route('admin.dashboard') }}" class="text-xs font-medium px-2 py-1 rounded-md bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 transition-colors">Admin</a>
                     @endif
                 @endauth
-                <a href="/roulettes" class="nav-link text-sm">Roulettes</a>
+                <a href="/roulettes" class="nav-link-highlight text-sm">Roulettes</a>
 
                 {{-- User section --}}
                 @auth
@@ -62,13 +70,6 @@
                     @endif
                 @endauth
 
-                {{-- Search --}}
-                <div id="desktop-search-wrap" class="relative">
-                    <input id="desktop-search-input" type="text" placeholder="Search…" autocomplete="off"
-                        class="w-40 focus:w-56 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 outline-none focus:border-white/20 transition-all duration-200">
-                    <div id="desktop-search-results" class="hidden absolute right-0 top-full mt-1 w-72 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden shadow-2xl z-50 divide-y divide-white/5"></div>
-                </div>
-
                 @include('includes.anim-toggle')
 
                 {{-- Theme toggle --}}
@@ -82,7 +83,7 @@
             </div>
 
             {{-- Mobile hamburger --}}
-            <button class="hamburger md:hidden" aria-label="Menu">
+            <button class="hamburger md:hidden ml-auto" aria-label="Menu">
                 <span></span><span></span><span></span>
             </button>
         </div>
@@ -100,11 +101,18 @@
                 <div id="mobile-search-results" class="hidden mt-1 bg-[#1a1a1a] border border-white/10 rounded-xl overflow-hidden divide-y divide-white/5"></div>
             </div>
 
+            {{-- Roulettes --}}
+            <a href="/roulettes" class="flex items-center justify-between px-4 py-3.5 rounded-xl text-sm font-semibold transition-colors mb-1" style="color:#c0393a; background:rgba(192,57,58,0.08)">
+                Roulettes
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
+            </a>
+
             {{-- Movies --}}
+            <div class="h-px bg-white/5 my-1"></div>
             <p class="px-4 pt-1 pb-0.5 text-xs font-semibold text-gray-600 uppercase tracking-wider">Movies</p>
-            <a href="/movie?i=new" class="long-single flex items-center justify-between px-4 py-3.5 rounded-xl bg-white/5 hover:bg-white/8 text-white font-medium text-sm transition-colors">
+            <a href="/movie?i=new" class="long-single flex items-center justify-between px-4 py-3.5 rounded-xl bg-accent/15 hover:bg-accent/25 text-white font-medium text-sm transition-colors">
                 Random Movie
-                <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
+                <svg class="w-4 h-4 text-accent/60" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
             </a>
             <a href="/multiple?i=new" class="flex items-center justify-between px-4 py-3.5 rounded-xl bg-white/5 hover:bg-white/8 text-white font-medium text-sm transition-colors">
                 Random Batch
@@ -117,9 +125,9 @@
             {{-- TV Shows --}}
             <div class="h-px bg-white/5 my-2"></div>
             <p class="px-4 pb-0.5 text-xs font-semibold text-gray-600 uppercase tracking-wider">TV Shows</p>
-            <a href="/tv/pick?i=new" class="long-single flex items-center justify-between px-4 py-3.5 rounded-xl bg-white/5 hover:bg-white/8 text-white font-medium text-sm transition-colors">
+            <a href="/tv/pick?i=new" class="long-single flex items-center justify-between px-4 py-3.5 rounded-xl bg-accent/15 hover:bg-accent/25 text-white font-medium text-sm transition-colors">
                 Random TV Show
-                <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
+                <svg class="w-4 h-4 text-accent/60" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
             </a>
             <a href="/tv/multiple?i=new" class="flex items-center justify-between px-4 py-3.5 rounded-xl bg-white/5 hover:bg-white/8 text-white font-medium text-sm transition-colors">
                 Random TV Batch
@@ -127,12 +135,6 @@
             </a>
             <a href="/tv/criteria" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">
                 TV Criteria
-            </a>
-
-            {{-- Nav links --}}
-            <div class="h-px bg-white/5 my-2"></div>
-            <a href="/roulettes" class="flex items-center gap-2 px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">
-                Roulettes
             </a>
 
             {{-- Account --}}

--- a/resources/views/my-roulettes/manage.blade.php
+++ b/resources/views/my-roulettes/manage.blade.php
@@ -85,21 +85,13 @@
                             <div class="flex items-center gap-3 px-3 py-3 hover:bg-white/2 transition-colors">
 
                                 {{-- Poster thumbnail --}}
-                                <div class="relative group/poster w-9 h-[52px] flex-shrink-0">
+                                <div class="w-9 h-[52px] flex-shrink-0">
                                     @if($poster)
                                         <img src="https://image.tmdb.org/t/p/w92{{ $poster }}"
-                                             class="roulette-poster w-full h-full object-cover rounded"
-                                             data-id="{{ $roulette->id }}">
+                                             class="w-full h-full object-cover rounded">
                                     @else
-                                        <div class="w-full h-full bg-white/5 rounded roulette-poster-placeholder" data-id="{{ $roulette->id }}"></div>
+                                        <div class="w-full h-full bg-white/5 rounded"></div>
                                     @endif
-                                    <button type="button"
-                                            class="roll-poster-btn absolute inset-0 flex items-center justify-center bg-black/60 {{ $poster ? 'opacity-0 group-hover/poster:opacity-100' : 'opacity-100' }} rounded transition-opacity text-white"
-                                            data-id="{{ $roulette->id }}" title="Roll poster">
-                                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                                        </svg>
-                                    </button>
                                 </div>
 
                                 {{-- Name + tags --}}
@@ -166,48 +158,9 @@
 @endsection
 
 @section('scripts')
-<style>@keyframes spin { to { transform: rotate(360deg); } }</style>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    // Poster roll buttons
-    document.addEventListener('click', e => {
-        const btn = e.target.closest('.roll-poster-btn');
-        if (!btn) return;
-
-        const id  = btn.dataset.id;
-        const svg = btn.querySelector('svg');
-        btn.disabled = true;
-        svg.style.animation = 'spin 0.6s linear infinite';
-
-        fetch(`/my-roulettes/manage/${id}/refresh-poster`, {
-            method: 'POST',
-            headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content },
-        })
-        .then(r => r.json())
-        .then(data => {
-            if (!data.poster_path) return;
-            const url = `https://image.tmdb.org/t/p/w92${data.poster_path}`;
-            const cell = btn.closest('.relative');
-            let img = cell.querySelector('.roulette-poster');
-            const placeholder = cell.querySelector('.roulette-poster-placeholder');
-            if (placeholder) {
-                img = document.createElement('img');
-                img.className = 'roulette-poster w-full h-full object-cover rounded';
-                img.dataset.id = id;
-                placeholder.replaceWith(img);
-                btn.classList.remove('opacity-100');
-                btn.classList.add('opacity-0', 'group-hover/poster:opacity-100');
-            }
-            img.src = url;
-        })
-        .finally(() => {
-            btn.disabled = false;
-            svg.style.animation = '';
-        });
-    });
-
-
     const btns   = document.querySelectorAll('.group-btn');
     const panels = document.querySelectorAll('.group-panel');
 


### PR DESCRIPTION
## What's in this PR

**Homepage**
- Added "Curated Roulettes" section (9 handpicked collections) between trending and about sections
- Trending section moved before roulettes
- "Browse all roulettes →" button in section header
- "Create Your Own" CTA card at the end of the row (auth-aware copy)

**Nav — desktop**
- Search bar moved to center of navbar, stretches to fill empty space between logo and nav links
- Search icon added inside the input

**Nav — Roulettes link**
- Accent red color with subtle text-shadow glow on desktop
- Moved to top of mobile menu (below search), with red-tinted background tile
- Random Movie and Random TV Show buttons in mobile menu get accent tint highlight