### PR TITLE
Add IMDb, Rotten Tomatoes and Metacritic ratings to TV show pages

### DIFF
--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -3,13 +3,15 @@
 namespace App\Http\Controllers;
 
 use App\Services\TmdbClient;
+use App\Services\OmdbClient;
 use App\Services\MovieService;
+use App\Services\RatingsUrlBuilder;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class TvShowController extends Controller
 {
-    public function __invoke(Request $request, TmdbClient $tmdb, MovieService $movieService): View
+    public function __invoke(Request $request, TmdbClient $tmdb, OmdbClient $omdb, MovieService $movieService, RatingsUrlBuilder $link): View
     {
         $showId  = $request->route('id');
         $country = $movieService->getUserCountry();
@@ -20,6 +22,10 @@ class TvShowController extends Controller
         } catch (\Throwable) {
             abort(404);
         }
+
+        $imdbId   = $tmdbInfo->external_ids->imdb_id ?? null;
+        $omdbInfo = $omdb->tv($imdbId);
+        $urls     = $link->linksArray($omdbInfo, 'tv');
 
         $watchProviders = isset($tmdbInfo->{'watch/providers'}->results->$country->flatrate)
             ? $tmdbInfo->{'watch/providers'}->results->$country
@@ -62,7 +68,7 @@ class TvShowController extends Controller
         $savedIds   = $this->savedWatchlistIds();
 
         return view('tv.show', compact(
-            'tmdbInfo', 'genres', 'trailer', 'user_input', 'all_genres',
+            'tmdbInfo', 'omdbInfo', 'urls', 'genres', 'trailer', 'user_input', 'all_genres',
             'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country',
             'similarShows', 'similarTitle'
         ));

--- a/app/Services/OmdbClient.php
+++ b/app/Services/OmdbClient.php
@@ -39,4 +39,22 @@ class OmdbClient implements ApiMovie
             return (isset($data->Response) && $data->Response === 'False') ? null : $data;
         });
     }
+
+    public function tv($imdbId): ?object
+    {
+        if (empty($imdbId)) {
+            return null;
+        }
+
+        return Cache::remember('omdb_tv_' . $imdbId, now()->addHours(6), function () use ($imdbId) {
+            $url      = 'https://private.omdbapi.com/?' . http_build_query([
+                'apikey'   => config('api.OMDB'),
+                'i'        => $imdbId,
+                'tomatoes' => 'true',
+            ]);
+            $response = $this->client->get($url);
+            $data = json_decode($response->getBody()->getContents());
+            return (isset($data->Response) && $data->Response === 'False') ? null : $data;
+        });
+    }
 }

--- a/app/Services/RatingsUrlBuilder.php
+++ b/app/Services/RatingsUrlBuilder.php
@@ -4,52 +4,58 @@ namespace App\Services;
 
 class RatingsUrlBuilder
 {
-    private function metacritic(?object $movieObj): ?string
+    private function metacritic(?object $omdbObj, string $type = 'movie'): ?string
     {
-        if ($movieObj === null || !property_exists($movieObj, 'Title')) {
+        if ($omdbObj === null || !property_exists($omdbObj, 'Title')) {
             return null;
         }
 
-        $slug = preg_replace('/[^a-z0-9\-]/', '', str_replace([' ', '--'], ['-', '-'], strtolower($movieObj->Title)));
-        return 'https://www.metacritic.com/movie/' . $slug;
+        $slug = preg_replace('/[^a-z0-9\-]/', '', str_replace([' ', '--'], ['-', '-'], strtolower($omdbObj->Title)));
+        $section = $type === 'tv' ? 'tv' : 'movie';
+        return 'https://www.metacritic.com/' . $section . '/' . $slug;
     }
 
-    private function rottenTomatoes(?object $movieObj): string
+    private function rottenTomatoes(?object $omdbObj, string $type = 'movie'): string
     {
-        if ($movieObj === null || !property_exists($movieObj, 'Title')) {
+        if ($omdbObj === null || !property_exists($omdbObj, 'Title')) {
             return '#';
         }
 
-        if (isset($movieObj->tomatoURL)) {
-            return $movieObj->tomatoURL;
+        if (isset($omdbObj->tomatoURL)) {
+            return $omdbObj->tomatoURL;
         }
 
-        $string = strtolower($movieObj->Title);
+        $string = strtolower($omdbObj->Title);
 
         if (str_starts_with($string, 'the ')) {
             $string = ltrim(substr($string, 4));
         }
 
         $string = str_replace('&', 'and', $string);
-        $slug   = preg_replace('/[^a-z0-9\_]/', '', str_replace(' ', '_', $string));
 
-        return 'https://www.rottentomatoes.com/m/' . $slug . '_' . $movieObj->Year;
+        if ($type === 'tv') {
+            $slug = preg_replace('/[^a-z0-9\_]/', '', str_replace(' ', '_', $string));
+            return 'https://www.rottentomatoes.com/tv/' . $slug;
+        }
+
+        $slug = preg_replace('/[^a-z0-9\_]/', '', str_replace(' ', '_', $string));
+        return 'https://www.rottentomatoes.com/m/' . $slug . '_' . $omdbObj->Year;
     }
 
-    private function imdb(?object $movieObj): ?string
+    private function imdb(?object $omdbObj): ?string
     {
-        if ($movieObj === null || !property_exists($movieObj, 'imdbID')) {
+        if ($omdbObj === null || !property_exists($omdbObj, 'imdbID')) {
             return null;
         }
-        return 'https://www.imdb.com/title/' . $movieObj->imdbID;
+        return 'https://www.imdb.com/title/' . $omdbObj->imdbID;
     }
 
-    public function linksArray(?object $movieObj): array
+    public function linksArray(?object $omdbObj, string $type = 'movie'): array
     {
         return [
-            'Internet Movie Database' => $this->imdb($movieObj),
-            'Rotten Tomatoes'         => $this->rottenTomatoes($movieObj),
-            'Metacritic'              => $this->metacritic($movieObj),
+            'Internet Movie Database' => $this->imdb($omdbObj),
+            'Rotten Tomatoes'         => $this->rottenTomatoes($omdbObj, $type),
+            'Metacritic'              => $this->metacritic($omdbObj, $type),
         ];
     }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -328,7 +328,7 @@ class TmdbClient implements ApiMovie
     {
         return Cache::remember('tmdb_tv_' . $id, now()->addHours(6), function () use ($id) {
             $url = 'https://api.themoviedb.org/3/tv/' . $id . '?'
-                . http_build_query(['append_to_response' => 'videos,credits,similar,watch/providers']);
+                . http_build_query(['append_to_response' => 'videos,credits,similar,watch/providers,external_ids']);
 
             $response = $this->client->get($url);
             return json_decode($response->getBody()->getContents());

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -142,6 +142,21 @@
                 </div>
             @endif
 
+            {{-- Ratings --}}
+            @if(isset($omdbInfo->Ratings) && count($omdbInfo->Ratings) > 0)
+            <div>
+                <h3 class="text-xs sm:text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2 md:mb-3">Ratings</h3>
+                @foreach ($omdbInfo->Ratings as $rating)
+                    @php $url = $urls[$rating->Source] ?? '#'; @endphp
+                    <a class="rating-pill" href="{{ $url }}"
+                        {{ $url !== '#' ? 'target="_blank"' : '' }}>
+                        <span class="text-gray-400 text-xs sm:text-sm truncate">{{ $rating->Source }}</span>
+                        <span class="ml-auto font-semibold text-accent text-xs sm:text-sm flex-shrink-0">{{ $rating->Value }}</span>
+                    </a>
+                @endforeach
+            </div>
+            @endif
+
             {{-- Plot --}}
             <div>
                 <h3 class="text-xs sm:text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2">Overview</h3>


### PR DESCRIPTION
## Summary

- Fetches the IMDb ID for TV shows via TMDB's `external_ids` endpoint (added to `append_to_response`)
- Calls OMDb with that ID to get IMDb rating, Rotten Tomatoes score, and Metacritic score
- Displays ratings as linked pills on the TV show detail page, matching the existing movie layout
- `RatingsUrlBuilder` updated to generate TV-specific URLs (`/tv/` paths on RT and Metacritic)

## Test plan

- [x] Open a popular TV show page and confirm IMDb / RT / Metacritic ratings appear
- [x] Click each rating pill and verify the link goes to the correct page
- [x] Open a show with no OMDb data and confirm the ratings section is hidden gracefully
- [x] Confirm movie detail pages are unaffected