### PR TITLE
Query real total pages from TMDB for homepage roll

### DIFF
--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -7,6 +7,7 @@ use App\Services\MovieService;
 use App\Http\Requests\CriteriaRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 class MoviePickController extends PickController
@@ -100,12 +101,14 @@ class MoviePickController extends PickController
         session([self::SESSION_KEY => self::DEFAULTS]);
 
         $country = $movieService->getUserCountry();
-        $results = $tmdb->discover([
-            'sort_by'          => 'popularity.desc',
-            'page'             => rand(1, 20),
-            'vote_count.gte'   => 50,
-            'vote_average.gte' => 5,
-        ], $country);
+        $filters = ['vote_count.gte' => 50, 'vote_average.gte' => 5];
+
+        $totalPages = Cache::remember('homepage_movie_roll_pages_' . $country, now()->addDay(), function () use ($tmdb, $filters, $country) {
+            $first = $tmdb->discover(array_merge($filters, ['page' => 1]), $country);
+            return min($first['total_pages'] ?? 500, 500);
+        });
+
+        $results = $tmdb->discover(array_merge($filters, ['page' => rand(1, $totalPages)]), $country);
 
         $picked = $movieService->pickBatch($results['results'] ?? []);
 

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -7,6 +7,7 @@ use App\Services\MovieService;
 use App\Http\Requests\TvCriteriaRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 class TvPickController extends PickController
@@ -103,11 +104,14 @@ class TvPickController extends PickController
         session([self::SESSION_KEY => self::DEFAULTS]);
 
         $country = $movieService->getUserCountry();
-        $results = $tmdb->discoverTv([
-            'sort_by'          => 'popularity.desc',
-            'page'             => rand(1, 20),
-            'vote_average.gte' => 5,
-        ], $country);
+        $filters = ['vote_average.gte' => 5, 'vote_count.gte' => 20];
+
+        $totalPages = Cache::remember('homepage_tv_roll_pages_' . $country, now()->addDay(), function () use ($tmdb, $filters, $country) {
+            $first = $tmdb->discoverTv(array_merge($filters, ['page' => 1]), $country);
+            return min($first['total_pages'] ?? 500, 500);
+        });
+
+        $results = $tmdb->discoverTv(array_merge($filters, ['page' => rand(1, $totalPages)]), $country);
 
         $picked = $movieService->pickBatch($results['results'] ?? []);
 


### PR DESCRIPTION
## Summary

- Homepage "Random Movie" and "Random TV Show" roll buttons were hardcoded to `rand(1, 20)` — only ever picking from the top 400 results
- Now queries TMDB first to get the actual `total_pages` for the filter set, caches it per country for 24 hours, then picks a random page from the full range (up to TMDB's 500-page cap)
- Also renames `rollJson()` to `homepageRoll()` for clarity

## Test plan

- [x] Hit the homepage roll buttons several times and confirm varied, non-mainstream results appear
- [x] Check that the roll still respects the quality floor (vote_count / vote_average filters)
- [x] Confirm TV and movie rolls both work