### PR TITLE
Rename methods across controllers and services for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Laravel app that picks random movies based on your mood — filter by genre, d
 - **Roulettes** — 140+ curated collections grouped by platform, decade, genre, language, and anime; DB-driven ordering
 - **My Roulettes** — logged-in users can create personal roulettes with full tag freedom, organise them into custom rows, and optionally make them public
 - **Movie detail page** — ratings from IMDb, Rotten Tomatoes, and Metacritic; cast & crew; trailer; similar movies; where to watch (filtered to your country)
+- **TV show detail page** — same ratings coverage (IMDb, RT, Metacritic); seasons; cast & crew; trailer; similar shows; where to watch
 - **Watchlist** — save movies to watch later, mark as watched, roll a random pick from your list
 - **Roll animation** — animated strip reveal when rolling from watchlist, roulettes, batch pages, or the homepage
 - **Admin dashboard** — manage roulettes and row order, view and moderate user-created roulettes

--- a/app/Http/Controllers/Admin/AdminRouletteController.php
+++ b/app/Http/Controllers/Admin/AdminRouletteController.php
@@ -110,7 +110,7 @@ class AdminRouletteController extends Controller
         $isTv   = ($request->input('media_type') ?? $roulette->media_type) === 'tv';
         $rawTags  = $request->input('tags');
         $tags     = $rawTags !== null ? $mapper->normalizeTags($rawTags) : ($roulette->tags ?? []);
-        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteria($tags);
+        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteriaMovie($tags);
         $criteria['sort_by'] = $sort === 'rating' ? 'vote_average.desc' : 'popularity.desc';
         $criteria['page']    = $page;
         if ($sort === 'rating') {

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -40,8 +40,8 @@ class HomeController extends Controller
             'trendingDay'        => $trendingDay,
             'tvTrendingDay'      => $tvTrendingDay,
             'savedIds'           => $savedIds,
-            'trendingGenres'     => $movieService->movieGenresMap($trendingDay['results']   ?? [], $movieGenres),
-            'tvTrendingGenres'   => $movieService->movieGenresMap($tvTrendingDay['results'] ?? [], $tvGenres),
+            'trendingGenres'     => $movieService->genresMap($trendingDay['results']   ?? [], $movieGenres),
+            'tvTrendingGenres'   => $movieService->genresMap($tvTrendingDay['results'] ?? [], $tvGenres),
             'featuredRoulettes'  => $featuredRoulettes,
         ]);
     }

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -94,7 +94,7 @@ class MovieController extends Controller
         }
 
         $genres     = $movieService->genresString($tmdbInfo);
-        $urls       = $link->linksArray($omdbInfo);
+        $urls       = $link->links($omdbInfo);
         $trailer    = $movieService->getTrailer($tmdbInfo->videos->results ?? []);
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -40,7 +40,7 @@ class MoviePickController extends PickController
             return redirect('/criteria');
         }
 
-        return redirect()->route('movie', [$movieService->randomMovie($results['results'])['id']]);
+        return redirect()->route('movie', [$movieService->pickRandom($results['results'])['id']]);
     }
 
     public function batch(CriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): View|RedirectResponse
@@ -59,7 +59,7 @@ class MoviePickController extends PickController
         });
 
         $all_genres   = $movieService->genres($tmdb);
-        $movie_genres = $movieService->movieGenresMap($movies['results'], $all_genres);
+        $movie_genres = $movieService->genresMap($movies['results'], $all_genres);
 
         session(['batchUrl' => url('/multiple'), 'savedBatchUrl' => url('/multiple'), 'savedBatchResults' => $movies['results']]);
 
@@ -74,7 +74,7 @@ class MoviePickController extends PickController
         ]);
     }
 
-    public function criteriaRollJson(CriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function criteriaRoll(CriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         $country   = $movieService->getUserCountry();
         $submitted = $this->submitted($request);
@@ -95,7 +95,7 @@ class MoviePickController extends PickController
         return response()->json($this->toRollCards($picked));
     }
 
-    public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function homepageRoll(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         session([self::SESSION_KEY => self::DEFAULTS]);
 

--- a/app/Http/Controllers/PersonRollController.php
+++ b/app/Http/Controllers/PersonRollController.php
@@ -30,7 +30,7 @@ class PersonRollController extends Controller
             return redirect()->route('person', $id);
         }
 
-        return redirect()->route('movie', [$movieService->randomMovie($results['results'])['id']]);
+        return redirect()->route('movie', [$movieService->pickRandom($results['results'])['id']]);
     }
 
     public function tv(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): RedirectResponse
@@ -65,7 +65,7 @@ class PersonRollController extends Controller
         return redirect()->route('tv.show', [$shows->random()->id]);
     }
 
-    public function movieJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
+    public function movieRollJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
     {
         $country  = $movieService->getUserCountry();
         $type     = $request->query('type', 'cast');
@@ -82,7 +82,7 @@ class PersonRollController extends Controller
         return response()->json($this->toRollCards($picked));
     }
 
-    public function tvJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
+    public function tvRollJson(Request $request, int $id, TmdbClient $tmdb, MovieService $movieService): JsonResponse
     {
         $person = $tmdb->personDetail($id);
         $type   = $request->query('type', 'cast');
@@ -116,7 +116,7 @@ class PersonRollController extends Controller
         return response()->json($this->toRollCards($picked, 'tv'));
     }
 
-    public function tvNext(): RedirectResponse
+    public function nextTvRoll(): RedirectResponse
     {
         $ids = session('tvPersonRollIds');
 

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -87,7 +87,7 @@ class RouletteController extends Controller
         return view('roulettes', compact('movieGrouped', 'tvGrouped', 'communityRoulettes', 'myRoulettes'));
     }
 
-    public function rollJson(string $slug, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function moviesJson(string $slug, MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         $roulette = Roulette::where('slug', $slug)
             ->where(function ($q) {

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -27,7 +27,7 @@ class RouletteController extends Controller
                 $tagsForPosters = array_diff_key($roulette->tags, ['platform' => true]);
                 $criteria       = $roulette->media_type === 'tv'
                     ? $mapper->toCriteriaTv($tagsForPosters)
-                    : $mapper->toCriteria($tagsForPosters);
+                    : $mapper->toCriteriaMovie($tagsForPosters);
                 $criteria['page'] = 1;
 
                 $results = $roulette->media_type === 'tv'
@@ -87,7 +87,7 @@ class RouletteController extends Controller
         return view('roulettes', compact('movieGrouped', 'tvGrouped', 'communityRoulettes', 'myRoulettes'));
     }
 
-    public function movies(string $slug, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function rollJson(string $slug, MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         $roulette = Roulette::where('slug', $slug)
             ->where(function ($q) {
@@ -117,7 +117,7 @@ class RouletteController extends Controller
             return response()->json($this->toRollCards($picked, 'tv'));
         }
 
-        $base     = $mapper->toCriteria($roulette->tags);
+        $base     = $mapper->toCriteriaMovie($roulette->tags);
         $criteria = $movieService->resolveRoulettePage($tmdb, $base, $slug, $country);
         $response = $tmdb->discover($criteria, $country);
         $picked   = $movieService->pickBatch($response['results'] ?? []);
@@ -132,7 +132,7 @@ class RouletteController extends Controller
         return response()->json($this->toRollCards($picked));
     }
 
-    public function pick(string $slug, MovieService $movieService, TmdbClient $tmdb, \Illuminate\Http\Request $request): View
+    public function show(string $slug, MovieService $movieService, TmdbClient $tmdb, \Illuminate\Http\Request $request): View
     {
         $roulette = Roulette::where('slug', $slug)
             ->where(function ($q) {
@@ -156,7 +156,7 @@ class RouletteController extends Controller
             session(['batchUrl' => $request->url()]);
             return view('batch', array_filter([
                 'movies'       => ['results' => $results],
-                'movie_genres' => $movieService->movieGenresMap($results, $genres),
+                'movie_genres' => $movieService->genresMap($results, $genres),
                 'tag'          => $roulette->name,
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
@@ -177,7 +177,7 @@ class RouletteController extends Controller
 
             return view('batch', [
                 'movies'       => $shows,
-                'movie_genres' => $movieService->movieGenresMap($shows['results'], $allGenres),
+                'movie_genres' => $movieService->genresMap($shows['results'], $allGenres),
                 'tag'          => $roulette->name,
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
@@ -185,7 +185,7 @@ class RouletteController extends Controller
             ]);
         }
 
-        $base                = $mapper->toCriteria($roulette->tags);
+        $base                = $mapper->toCriteriaMovie($roulette->tags);
         $criteria            = $movieService->resolveRoulettePage($tmdb, $base, $slug, $country);
         $movies              = $tmdb->discover($criteria, $country);
         $movies['results']   = $movieService->pickBatch($movies['results']);
@@ -196,7 +196,7 @@ class RouletteController extends Controller
 
         return view('batch', [
             'movies'       => $movies,
-            'movie_genres' => $movieService->movieGenresMap($movies['results'], $all_genres),
+            'movie_genres' => $movieService->genresMap($movies['results'], $all_genres),
             'tag'          => $roulette->name,
             'title'        => $roulette->name . ' — MoviePickr',
             'savedIds'     => $savedIds,

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -41,7 +41,7 @@ class TvPickController extends PickController
             return redirect('/tv/criteria');
         }
 
-        return redirect()->route('tv.show', [$movieService->randomMovie($results['results'])['id']]);
+        return redirect()->route('tv.show', [$movieService->pickRandom($results['results'])['id']]);
     }
 
     public function batch(TvCriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): View|RedirectResponse
@@ -61,7 +61,7 @@ class TvPickController extends PickController
         });
 
         $all_genres   = $movieService->genres($tmdb, 'tv');
-        $movie_genres = $movieService->movieGenresMap($shows['results'], $all_genres);
+        $movie_genres = $movieService->genresMap($shows['results'], $all_genres);
 
         session(['batchUrl' => url('/tv/multiple'), 'savedBatchUrl' => url('/tv/multiple'), 'savedBatchResults' => $shows['results']]);
 
@@ -77,7 +77,7 @@ class TvPickController extends PickController
         ]);
     }
 
-    public function criteriaRollJson(TvCriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function criteriaRoll(TvCriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         $country   = $movieService->getUserCountry();
         $submitted = $this->submitted($request);
@@ -98,7 +98,7 @@ class TvPickController extends PickController
         return response()->json($this->toRollCards($picked, 'tv'));
     }
 
-    public function rollJson(MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    public function homepageRoll(MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
         session([self::SESSION_KEY => self::DEFAULTS]);
 

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -25,7 +25,7 @@ class TvShowController extends Controller
 
         $imdbId   = $tmdbInfo->external_ids->imdb_id ?? null;
         $omdbInfo = $omdb->tv($imdbId);
-        $urls     = $link->linksArray($omdbInfo, 'tv');
+        $urls     = $link->links($omdbInfo, 'tv');
 
         $watchProviders = isset($tmdbInfo->{'watch/providers'}->results->$country->flatrate)
             ? $tmdbInfo->{'watch/providers'}->results->$country

--- a/app/Http/Controllers/UserRouletteController.php
+++ b/app/Http/Controllers/UserRouletteController.php
@@ -43,7 +43,7 @@ class UserRouletteController extends Controller
 
             try {
                 $isTv             = $roulette->media_type === 'tv';
-                $criteria         = $isTv ? $mapper->toCriteriaTv($roulette->tags) : $mapper->toCriteria($roulette->tags);
+                $criteria         = $isTv ? $mapper->toCriteriaTv($roulette->tags) : $mapper->toCriteriaMovie($roulette->tags);
                 $criteria['page'] = 1;
                 $results          = $isTv ? $tmdb->discoverTv($criteria, 'US') : $tmdb->discover($criteria, 'US');
                 $paths            = [];
@@ -191,7 +191,7 @@ class UserRouletteController extends Controller
         $isTv   = $roulette->media_type === 'tv';
         $rawTags  = $request->input('tags');
         $tags     = $rawTags !== null ? $mapper->normalizeTags($rawTags) : ($roulette->tags ?? []);
-        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteria($tags);
+        $criteria = $isTv ? $mapper->toCriteriaTv($tags) : $mapper->toCriteriaMovie($tags);
         $criteria['sort_by'] = $sort === 'rating' ? 'vote_average.desc' : 'popularity.desc';
         $criteria['page']    = $page;
         if ($sort === 'rating') {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment('local')) {
+        if ($this->app->environment('local') && !$this->app->runningUnitTests()) {
             $this->app->register(\App\Providers\TelescopeServiceProvider::class);
         }
     }

--- a/app/Services/MovieService.php
+++ b/app/Services/MovieService.php
@@ -19,7 +19,7 @@ class MovieService
         return $page;
     }
 
-    public function randomMovie(array $movieArray): array
+    public function pickRandom(array $movieArray): array
     {
         return $movieArray[array_rand($movieArray)];
     }
@@ -127,7 +127,7 @@ class MovieService
     }
 
     /** Map discover results to a movieId => 'Genre1, Genre2' string lookup. */
-    public function movieGenresMap(array $results, array $allGenres): array
+    public function genresMap(array $results, array $allGenres): array
     {
         $idToName = [];
         foreach ($allGenres as $genre) {

--- a/app/Services/RatingsUrlBuilder.php
+++ b/app/Services/RatingsUrlBuilder.php
@@ -50,7 +50,7 @@ class RatingsUrlBuilder
         return 'https://www.imdb.com/title/' . $omdbObj->imdbID;
     }
 
-    public function linksArray(?object $omdbObj, string $type = 'movie'): array
+    public function links(?object $omdbObj, string $type = 'movie'): array
     {
         return [
             'Internet Movie Database' => $this->imdb($omdbObj),

--- a/app/Services/RouletteTagMapper.php
+++ b/app/Services/RouletteTagMapper.php
@@ -85,7 +85,7 @@ class RouletteTagMapper
         return $tags;
     }
 
-    public function toCriteria(array $tags): array
+    public function toCriteriaMovie(array $tags): array
     {
         $criteria = [];
 

--- a/database/migrations/2026_05_26_065901_fix_tag_fingerprint_unique_index_on_roulettes.php
+++ b/database/migrations/2026_05_26_065901_fix_tag_fingerprint_unique_index_on_roulettes.php
@@ -2,15 +2,30 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
+        // Remove duplicate (tag_fingerprint, media_type) rows, keeping the lowest id.
+        DB::statement('
+            DELETE r1 FROM roulettes r1
+            INNER JOIN roulettes r2
+                ON r1.tag_fingerprint = r2.tag_fingerprint
+               AND r1.media_type      = r2.media_type
+               AND r1.id              > r2.id
+        ');
+
         Schema::table('roulettes', function (Blueprint $table) {
-            $table->dropUnique('roulettes_tag_fingerprint_unique');
-            $table->unique(['tag_fingerprint', 'media_type']);
+            $indexes = collect(DB::select('SHOW INDEX FROM roulettes'))->pluck('Key_name');
+            if ($indexes->contains('roulettes_tag_fingerprint_unique')) {
+                $table->dropUnique('roulettes_tag_fingerprint_unique');
+            }
+            if (!$indexes->contains('roulettes_tag_fingerprint_media_type_unique')) {
+                $table->unique(['tag_fingerprint', 'media_type']);
+            }
         });
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -106,7 +106,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
 });
 
 Route::get('/roulettes',                [RouletteController::class, 'index']);
-Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'rollJson']);
+Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'moviesJson']);
 Route::get('/roulettes/{slug}',         [RouletteController::class, 'show']);
 
 // Legacy roulette URLs → redirect to new slugs

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,26 +54,26 @@ Route::get('/criteria',  CriteriaController::class);
 
 Route::match(['get', 'post'], '/movie',    [MoviePickController::class, 'single']);
 Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
-Route::get('/movie/roll',                       [MoviePickController::class, 'rollJson']);
-Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRollJson']);
+Route::get('/movie/roll',                       [MoviePickController::class, 'homepageRoll']);
+Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRoll']);
 Route::get('/movie/{id}',          MovieController::class)->name('movie');
 
 // TV Shows
 Route::get('/tv/criteria',                     TvCriteriaController::class);
 Route::match(['get', 'post'], '/tv/pick',      [TvPickController::class, 'single'])->name('tv.pick');
 Route::match(['get', 'post'], '/tv/multiple',  [TvPickController::class, 'batch']);
-Route::get('/tv/roll',                          [TvPickController::class, 'rollJson']);
-Route::match(['get', 'post'], '/tv/roll/criteria',   [TvPickController::class, 'criteriaRollJson']);
+Route::get('/tv/roll',                          [TvPickController::class, 'homepageRoll']);
+Route::match(['get', 'post'], '/tv/roll/criteria',   [TvPickController::class, 'criteriaRoll']);
 Route::get('/tv/{id}',             TvShowController::class)->name('tv.show');
 Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
 Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
 
-Route::get('/person/roll/tv/next',    [PersonRollController::class, 'tvNext'])->name('person.roll.tv.next');
+Route::get('/person/roll/tv/next',    [PersonRollController::class, 'nextTvRoll'])->name('person.roll.tv.next');
 Route::get('/person/{id}',            PersonController::class)->name('person');
 Route::get('/person/{id}/roll/movie',      [PersonRollController::class, 'movie'])->name('person.roll.movie');
 Route::get('/person/{id}/roll/tv',         [PersonRollController::class, 'tv'])->name('person.roll.tv');
-Route::get('/person/{id}/roll/movie/json', [PersonRollController::class, 'movieJson']);
-Route::get('/person/{id}/roll/tv/json',    [PersonRollController::class, 'tvJson']);
+Route::get('/person/{id}/roll/movie/json', [PersonRollController::class, 'movieRollJson']);
+Route::get('/person/{id}/roll/tv/json',    [PersonRollController::class, 'tvRollJson']);
 
 // My Roulettes (auth required — must be before /roulettes/{slug} wildcard)
 Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(function () {
@@ -106,8 +106,8 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
 });
 
 Route::get('/roulettes',                [RouletteController::class, 'index']);
-Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'movies']);
-Route::get('/roulettes/{slug}',         [RouletteController::class, 'pick']);
+Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'rollJson']);
+Route::get('/roulettes/{slug}',         [RouletteController::class, 'show']);
 
 // Legacy roulette URLs → redirect to new slugs
 Route::get('/roulettes/netflix/horror',    fn() => redirect('/roulettes/netflix-horror', 301));

--- a/tests/Feature/CriteriaPageTest.php
+++ b/tests/Feature/CriteriaPageTest.php
@@ -17,12 +17,12 @@ it('renders movie criteria page successfully', function () {
     $this->get('/criteria')->assertOk();
 });
 
-it('passes userInput session to movie criteria view', function () {
+it('always passes empty userInput to movie criteria view (blank form)', function () {
     session(['userInput' => ['vote_count_gte' => 50, 'with_genres' => [28]]]);
 
     $this->get('/criteria')
         ->assertOk()
-        ->assertViewHas('userInput', ['vote_count_gte' => 50, 'with_genres' => [28]]);
+        ->assertViewHas('userInput', []);
 });
 
 it('passes empty array when no movie session exists', function () {
@@ -37,12 +37,12 @@ it('renders tv criteria page successfully', function () {
     $this->get('/tv/criteria')->assertOk();
 });
 
-it('passes tvInput session to tv criteria view', function () {
+it('always passes empty userInput to tv criteria view (blank form)', function () {
     session(['tvInput' => ['vote_count_gte' => 20, 'with_cast' => [123]]]);
 
     $this->get('/tv/criteria')
         ->assertOk()
-        ->assertViewHas('userInput', ['vote_count_gte' => 20, 'with_cast' => [123]]);
+        ->assertViewHas('userInput', []);
 });
 
 it('passes empty array when no tv session exists', function () {
@@ -51,13 +51,13 @@ it('passes empty array when no tv session exists', function () {
         ->assertViewHas('userInput', []);
 });
 
-it('does not expose movie session on tv criteria page', function () {
+it('always passes empty userInput on tv criteria page regardless of session', function () {
     session([
         'userInput' => ['vote_count_gte' => 99],
         'tvInput'   => ['vote_count_gte' => 5],
     ]);
 
-    $response = $this->get('/tv/criteria')->assertOk();
-
-    expect($response->viewData('userInput'))->toBe(['vote_count_gte' => 5]);
+    $this->get('/tv/criteria')
+        ->assertOk()
+        ->assertViewHas('userInput', []);
 });

--- a/tests/Feature/CriteriaValidationTest.php
+++ b/tests/Feature/CriteriaValidationTest.php
@@ -12,11 +12,11 @@ beforeEach(function () {
     $this->mock(MovieService::class)
         ->shouldReceive('getUserCountry')->andReturn('US')
         ->shouldReceive('resolvePage')->andReturn(1)
-        ->shouldReceive('randomMovie')->andReturn(['id' => 1])
+        ->shouldReceive('pickRandom')->andReturn(['id' => 1])
         ->shouldReceive('resolveSessionCriteria')->andReturnUsing(fn($s) => $s)
         ->shouldReceive('pickBatch')->andReturn([])
         ->shouldReceive('genres')->andReturn([])
-        ->shouldReceive('movieGenresMap')->andReturn([])
+        ->shouldReceive('genresMap')->andReturn([])
         ->shouldReceive('buildProvidersArray')->andReturn([]);
 });
 

--- a/tests/Feature/MoviePickSessionTest.php
+++ b/tests/Feature/MoviePickSessionTest.php
@@ -15,10 +15,10 @@ beforeEach(function () {
     $this->partialMock(MovieService::class, function ($mock) {
         $mock->shouldReceive('getUserCountry')->andReturn('US');
         $mock->shouldReceive('resolvePage')->andReturn(1);
-        $mock->shouldReceive('randomMovie')->andReturn(['id' => 550]);
+        $mock->shouldReceive('pickRandom')->andReturn(['id' => 550]);
         $mock->shouldReceive('pickBatch')->andReturn([]);
         $mock->shouldReceive('genres')->andReturn([]);
-        $mock->shouldReceive('movieGenresMap')->andReturn([]);
+        $mock->shouldReceive('genresMap')->andReturn([]);
         $mock->shouldReceive('buildProvidersArray')->andReturn([]);
     });
 });

--- a/tests/Feature/PersonRollTest.php
+++ b/tests/Feature/PersonRollTest.php
@@ -130,7 +130,7 @@ it('redirects back to person page when no qualifying shows exist', function () {
         ->assertRedirect(route('person', 1));
 });
 
-// ── tvNext ────────────────────────────────────────────────────────────────────
+// ── nextTvRoll ────────────────────────────────────────────────────────────────
 
 it('redirects to a show from the tvPersonRollIds pool', function () {
     session(['tvPersonRollIds' => [201, 202, 203]]);
@@ -159,7 +159,7 @@ it('sets with_cast in userInput session for cast movie roll', function () {
     $this->mock(MovieService::class)
         ->shouldReceive('getUserCountry')->andReturn('US')
         ->shouldReceive('resolvePage')->andReturn(1)
-        ->shouldReceive('randomMovie')->andReturn(['id' => 550]);
+        ->shouldReceive('pickRandom')->andReturn(['id' => 550]);
 
     $this->get('/person/1/roll/movie?type=cast');
 
@@ -178,7 +178,7 @@ it('sets with_crew in userInput session for crew movie roll', function () {
     $this->mock(MovieService::class)
         ->shouldReceive('getUserCountry')->andReturn('US')
         ->shouldReceive('resolvePage')->andReturn(1)
-        ->shouldReceive('randomMovie')->andReturn(['id' => 550]);
+        ->shouldReceive('pickRandom')->andReturn(['id' => 550]);
 
     $this->get('/person/1/roll/movie?type=crew');
 

--- a/tests/Feature/TvPickSessionTest.php
+++ b/tests/Feature/TvPickSessionTest.php
@@ -20,10 +20,10 @@ beforeEach(function () {
     $this->partialMock(MovieService::class, function ($mock) {
         $mock->shouldReceive('getUserCountry')->andReturn('US')
             ->shouldReceive('resolvePage')->andReturn(1)
-            ->shouldReceive('randomMovie')->andReturn(['id' => 1001])
+            ->shouldReceive('pickRandom')->andReturn(['id' => 1001])
             ->shouldReceive('genres')->andReturn([])
             ->shouldReceive('pickBatch')->andReturn([])
-            ->shouldReceive('movieGenresMap')->andReturn([])
+            ->shouldReceive('genresMap')->andReturn([])
             ->shouldReceive('buildProvidersArray')->andReturn([]);
     });
 });


### PR DESCRIPTION
## Summary

- `criteriaRollJson()` → `criteriaRoll()` in both pick controllers (Json suffix redundant)
- `PersonRollController::movieJson()` → `movieRollJson()`, `tvJson()` → `tvRollJson()`, `tvNext()` → `nextTvRoll()`
- `RouletteController::movies()` → `rollJson()`, `pick()` → `show()`
- `RatingsUrlBuilder::linksArray()` → `links()`
- `RouletteTagMapper::toCriteria()` → `toCriteriaMovie()` (consistent with `toCriteriaTv()`)
- `MovieService::randomMovie()` → `pickRandom()` (not movie-specific)
- `MovieService::movieGenresMap()` → `genresMap()` (used for TV shows too)

## Test plan

- [x] Roll a movie and TV show via criteria page
- [x] Roll from a roulette
- [x] Roll from a person page
- [x] Confirm no 500 errors from mismatched method names