### PR TITLE
Replace 3 parallel search calls with single multi-search endpoint

### DIFF
--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -81,33 +81,22 @@ class TmdbProxyController extends Controller
     {
         $query = trim($request->string('q'));
         if (!$query) {
-            return response()->json(['movies' => [], 'shows' => [], 'people' => []]);
+            return response()->json([]);
         }
 
-        $results = collect($tmdb->searchAll($query)['results'] ?? []);
-
-        $movies = $results
-            ->where('media_type', 'movie')
-            ->take(3)
+        $results = collect($tmdb->searchAll($query)['results'] ?? [])
+            ->filter(fn($r) => in_array($r['media_type'] ?? '', ['movie', 'tv', 'person']))
+            ->map(function ($r) {
+                if ($r['media_type'] === 'tv') {
+                    $r['title']        = $r['name'] ?? '';
+                    $r['release_date'] = $r['first_air_date'] ?? '';
+                }
+                return $r;
+            })
+            ->take(8)
             ->values()
             ->all();
 
-        $shows = $results
-            ->where('media_type', 'tv')
-            ->take(3)
-            ->map(fn($s) => array_merge($s, [
-                'title'        => $s['name'] ?? '',
-                'release_date' => $s['first_air_date'] ?? '',
-            ]))
-            ->values()
-            ->all();
-
-        $people = $results
-            ->where('media_type', 'person')
-            ->take(3)
-            ->values()
-            ->all();
-
-        return response()->json(compact('movies', 'shows', 'people'));
+        return response()->json($results);
     }
 }

--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -76,4 +76,38 @@ class TmdbProxyController extends Controller
 
         return response()->json($results);
     }
+
+    public function searchAll(Request $request, TmdbClient $tmdb): JsonResponse
+    {
+        $query = trim($request->string('q'));
+        if (!$query) {
+            return response()->json(['movies' => [], 'shows' => [], 'people' => []]);
+        }
+
+        $results = collect($tmdb->searchAll($query)['results'] ?? []);
+
+        $movies = $results
+            ->where('media_type', 'movie')
+            ->take(3)
+            ->values()
+            ->all();
+
+        $shows = $results
+            ->where('media_type', 'tv')
+            ->take(3)
+            ->map(fn($s) => array_merge($s, [
+                'title'        => $s['name'] ?? '',
+                'release_date' => $s['first_air_date'] ?? '',
+            ]))
+            ->values()
+            ->all();
+
+        $people = $results
+            ->where('media_type', 'person')
+            ->take(3)
+            ->values()
+            ->all();
+
+        return response()->json(compact('movies', 'shows', 'people'));
+    }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -372,6 +372,16 @@ class TmdbClient implements ApiMovie
         return json_decode($this->client->get($url)->getBody()->getContents(), true);
     }
 
+    public function searchAll(string $query): array
+    {
+        $url = 'https://api.themoviedb.org/3/search/multi?' . http_build_query([
+            'query'         => $query,
+            'language'      => 'en-US',
+            'include_adult' => 'false',
+        ]);
+        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /** Rename form keys like `vote_count_gte` → `vote_count.gte` for the API. */

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -8,11 +8,10 @@ $(document).ready(function () {
             .replace(/"/g, '&quot;');
     }
 
-    const TYPE_LABELS = { movie: 'Movie', tv: 'TV', person: 'Person' };
+    const TYPE_LABELS = { movie: 'Movie', tv: 'TV' };
 
     function buildResult(r) {
         const type = r.media_type;
-        const badge = `<span class="text-[10px] font-semibold uppercase tracking-wider text-gray-600 flex-shrink-0">${TYPE_LABELS[type] || ''}</span>`;
 
         if (type === 'person') {
             const photo = r.profile_path
@@ -21,14 +20,14 @@ $(document).ready(function () {
             const sub = r.known_for_department ? escHtml(r.known_for_department) : '';
             return `<a href="/person/${r.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
                 ${photo}
-                <div class="min-w-0 flex-1">
+                <div class="min-w-0">
                     <div class="text-sm text-white truncate">${escHtml(r.name)}</div>
                     ${sub ? `<div class="text-xs text-gray-500">${sub}</div>` : ''}
                 </div>
-                ${badge}
             </a>`;
         }
 
+        const badge = `<span class="text-[10px] font-semibold uppercase tracking-wider text-gray-600 flex-shrink-0">${TYPE_LABELS[type] || ''}</span>`;
         const href  = type === 'tv' ? `/tv/${r.id}` : `/movie/${r.id}`;
         const title = r.title || r.name || '';
         const year  = r.release_date ? r.release_date.substring(0, 4) : '';

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -11,16 +11,8 @@ $(document).ready(function () {
     function buildSection(label, items, linkBase, isTv) {
         if (!items.length) return '';
         const rows = items.map(function (m) {
-            const year    = m.release_date ? m.release_date.substring(0, 4) : '';
-            const endYear = m.last_air_date ? m.last_air_date.substring(0, 4) : '';
-            const active  = ['Returning Series', 'In Production', 'Planned', 'Pilot'].includes(m.tv_status);
-            const sub     = isTv
-                ? (year
-                    ? (active
-                        ? year + ' – present'
-                        : endYear && endYear !== year ? year + ' – ' + endYear : 'Since ' + year)
-                    : 'TV Series')
-                : year;
+            const year = m.release_date ? m.release_date.substring(0, 4) : '';
+            const sub  = isTv ? (year ? 'TV Series · ' + year : 'TV Series') : year;
             const poster = m.poster_path
                 ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(m.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
                 : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
@@ -69,14 +61,10 @@ $(document).ready(function () {
             if (!q) { $results.addClass('hidden').empty(); return; }
 
             timer = setTimeout(function () {
-                $.when(
-                    $.getJSON('/tmdb/search/movies', { q: q }),
-                    $.getJSON('/tmdb/search/tv',     { q: q }),
-                    $.getJSON('/tmdb/search/people', { q: q })
-                ).done(function (movieResp, tvResp, peopleResp) {
-                    const movies = (movieResp[0]  || []).slice(0, 3);
-                    const shows  = (tvResp[0]     || []).slice(0, 3);
-                    const people = (peopleResp[0] || []).slice(0, 3);
+                $.getJSON('/tmdb/search/all', { q: q }).done(function (resp) {
+                    const movies = resp.movies || [];
+                    const shows  = resp.shows  || [];
+                    const people = resp.people || [];
                     const html   = buildSection('Movies', movies, 'movie', false) +
                                    buildSection('TV Shows', shows, 'tv', true) +
                                    buildPeopleSection(people);

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -8,44 +8,42 @@ $(document).ready(function () {
             .replace(/"/g, '&quot;');
     }
 
-    function buildSection(label, items, linkBase, isTv) {
-        if (!items.length) return '';
-        const rows = items.map(function (m) {
-            const year = m.release_date ? m.release_date.substring(0, 4) : '';
-            const sub  = isTv ? (year ? 'TV Series · ' + year : 'TV Series') : year;
-            const poster = m.poster_path
-                ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(m.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
-                : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
-            return `<a href="/${linkBase}/${m.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
-                ${poster}
-                <div class="min-w-0">
-                    <div class="text-sm text-white truncate">${escHtml(m.title)}</div>
+    const TYPE_LABELS = { movie: 'Movie', tv: 'TV', person: 'Person' };
+
+    function buildResult(r) {
+        const type = r.media_type;
+        const badge = `<span class="text-[10px] font-semibold uppercase tracking-wider text-gray-600 flex-shrink-0">${TYPE_LABELS[type] || ''}</span>`;
+
+        if (type === 'person') {
+            const photo = r.profile_path
+                ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(r.profile_path)}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" loading="lazy">`
+                : `<div class="w-8 h-8 rounded-full bg-white/5 flex-shrink-0 flex items-center justify-center text-gray-600 text-xs font-bold">${escHtml(r.name.charAt(0).toUpperCase())}</div>`;
+            const sub = r.known_for_department ? escHtml(r.known_for_department) : '';
+            return `<a href="/person/${r.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
+                ${photo}
+                <div class="min-w-0 flex-1">
+                    <div class="text-sm text-white truncate">${escHtml(r.name)}</div>
                     ${sub ? `<div class="text-xs text-gray-500">${sub}</div>` : ''}
                 </div>
+                ${badge}
             </a>`;
-        }).join('');
-        return `<div class="px-3 pt-2 pb-1">
-                    <span class="text-xs font-semibold uppercase tracking-widest text-gray-600">${label}</span>
-                </div>${rows}`;
-    }
+        }
 
-    function buildPeopleSection(people) {
-        if (!people.length) return '';
-        const rows = people.map(function (p) {
-            const photo = p.profile_path
-                ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(p.profile_path)}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" loading="lazy">`
-                : `<div class="w-8 h-8 rounded-full bg-white/5 flex-shrink-0 flex items-center justify-center text-gray-600 text-xs font-bold">${escHtml(p.name.charAt(0).toUpperCase())}</div>`;
-            return `<a href="/person/${p.id}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
-                ${photo}
-                <div class="min-w-0">
-                    <div class="text-sm text-white truncate">${escHtml(p.name)}</div>
-                    ${p.known_for_department ? `<div class="text-xs text-gray-500">${escHtml(p.known_for_department)}</div>` : ''}
-                </div>
-            </a>`;
-        }).join('');
-        return `<div class="px-3 pt-2 pb-1">
-                    <span class="text-xs font-semibold uppercase tracking-widest text-gray-600">People</span>
-                </div>${rows}`;
+        const href  = type === 'tv' ? `/tv/${r.id}` : `/movie/${r.id}`;
+        const title = r.title || r.name || '';
+        const year  = r.release_date ? r.release_date.substring(0, 4) : '';
+        const thumb = r.poster_path
+            ? `<img src="https://image.tmdb.org/t/p/w92${escHtml(r.poster_path)}" class="w-8 h-12 object-cover rounded flex-shrink-0" loading="lazy">`
+            : `<div class="w-8 h-12 bg-white/5 rounded flex-shrink-0"></div>`;
+
+        return `<a href="${href}" class="search-result-item flex items-center gap-3 px-3 py-2 hover:bg-white/5 transition-colors">
+            ${thumb}
+            <div class="min-w-0 flex-1">
+                <div class="text-sm text-white truncate">${escHtml(title)}</div>
+                ${year ? `<div class="text-xs text-gray-500">${year}</div>` : ''}
+            </div>
+            ${badge}
+        </a>`;
     }
 
     function initSearch(inputSel, resultsSel) {
@@ -62,12 +60,7 @@ $(document).ready(function () {
 
             timer = setTimeout(function () {
                 $.getJSON('/tmdb/search/all', { q: q }).done(function (resp) {
-                    const movies = resp.movies || [];
-                    const shows  = resp.shows  || [];
-                    const people = resp.people || [];
-                    const html   = buildSection('Movies', movies, 'movie', false) +
-                                   buildSection('TV Shows', shows, 'tv', true) +
-                                   buildPeopleSection(people);
+                    const html = (resp || []).map(buildResult).join('');
                     if (!html) { $results.addClass('hidden').empty(); return; }
                     $results.html(html).removeClass('hidden');
                 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ Route::middleware('auth')->group(function () {
 Route::get('/userinput', UserInputController::class);
 
 Route::prefix('tmdb')->group(function () {
+    Route::get('/search/all',    [TmdbProxyController::class, 'searchAll']);
     Route::get('/search/movies', [TmdbProxyController::class, 'searchMovies']);
     Route::get('/search/people', [TmdbProxyController::class, 'searchPeople']);
     Route::get('/search/tv',     [TmdbProxyController::class, 'searchTv']);


### PR DESCRIPTION
## Summary

- Replaces 3 parallel search calls + up to 4 extra TV status calls with a single `/search/multi` endpoint
- Results returned in TMDB's relevance order as a unified list — no more separate Movies / TV Shows / People sections
- Movies and TV shows show a small "Movie" / "TV" badge; people are visually identified by their circular avatar, no badge needed
- Both desktop and mobile search bars updated (same `initSearch` function handles both)
- Old endpoints (`/search/movies`, `/search/tv`, `/search/people`) kept in place — still used by the criteria form actor/crew search

## Test plan
- [x] Search for a movie — appears with "Movie" badge
- [x] Search for a TV show — appears with "TV" badge
- [x] Search for a person — appears with circular avatar, no badge
- [x] Mixed query (e.g. "Tom Hanks") — person appears first, followed by their films in relevance order
- [x] Confirm mobile search works identically
- [x] Confirm actor/crew search in criteria form still works