### PR TITLE
Add recommendations to movie and TV detail pages

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -83,7 +83,7 @@ class MovieController extends Controller
         if ($similarMovies === null) {
             $recommendations = $tmdbInfo->recommendations->results ?? [];
             if (count($recommendations) >= 4) {
-                $similarMovies = ['results' => array_slice($recommendations, 0, 20)];
+                $similarMovies = ['results' => array_map(fn($r) => (array) $r, array_slice($recommendations, 0, 20))];
                 $similarTitle  = 'You Might Also Like';
             } else {
                 $similarMovies = $tmdb->similarMovies($tmdbInfo);

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -71,7 +71,7 @@ class MovieController extends Controller
                 ])->values()->all()];
                 $similarTitle = 'More from Your Watchlist';
             }
-        } elseif (!empty($movieCriteria)) {
+        } elseif (!empty($movieCriteria) && session('roll_source') === 'criteria') {
             $movieCriteria['page'] = rand(1, min($movieCriteria['total_pages'] ?? 500, 500));
             $discovered = $tmdb->discover($movieCriteria, $country);
             if (count($discovered['results']) >= 4) {
@@ -81,7 +81,13 @@ class MovieController extends Controller
         }
 
         if ($similarMovies === null) {
-            $similarMovies = $tmdb->similarMovies($tmdbInfo);
+            $recommendations = $tmdbInfo->recommendations->results ?? [];
+            if (count($recommendations) >= 4) {
+                $similarMovies = ['results' => array_slice($recommendations, 0, 20)];
+                $similarTitle  = 'You Might Also Like';
+            } else {
+                $similarMovies = $tmdb->similarMovies($tmdbInfo);
+            }
         }
 
         $collection = null;

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -41,6 +41,7 @@ class MoviePickController extends PickController
             return redirect('/criteria');
         }
 
+        session(['roll_source' => 'criteria']);
         return redirect()->route('movie', [$movieService->pickRandom($results['results'])['id']]);
     }
 
@@ -91,6 +92,7 @@ class MoviePickController extends PickController
             'batchUrl'          => url('/multiple'),
             'savedBatchUrl'     => url('/multiple'),
             'savedBatchResults' => $picked,
+            'roll_source'       => 'criteria',
         ]);
 
         return response()->json($this->toRollCards($picked));
@@ -118,6 +120,7 @@ class MoviePickController extends PickController
             'batchUrl'          => url('/multiple'),
             'savedBatchUrl'     => url('/multiple'),
             'savedBatchResults' => $picked,
+            'roll_source'       => 'other',
         ]);
 
         return response()->json($this->toRollCards($picked));

--- a/app/Http/Controllers/PersonRollController.php
+++ b/app/Http/Controllers/PersonRollController.php
@@ -16,7 +16,7 @@ class PersonRollController extends Controller
         $type     = $request->query('type', 'cast');
         $criteria = $type === 'crew' ? ['with_crew' => [$id]] : ['with_cast' => [$id]];
 
-        session(['userInput' => $criteria + ['vote_count_gte' => 10]]);
+        session(['userInput' => $criteria + ['vote_count_gte' => 10], 'roll_source' => 'other']);
 
         $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
         $results = $tmdb->discover($criteria, $country);
@@ -60,6 +60,7 @@ class PersonRollController extends Controller
                 $personKey . '_names'   => [(string)($person->name ?? '')],
                 'vote_count_gte'        => 10,
             ],
+            'roll_source' => 'other',
         ]);
 
         return redirect()->route('tv.show', [$shows->random()->id]);
@@ -71,7 +72,7 @@ class PersonRollController extends Controller
         $type     = $request->query('type', 'cast');
         $criteria = $type === 'crew' ? ['with_crew' => [$id]] : ['with_cast' => [$id]];
 
-        session(['userInput' => $criteria + ['vote_count_gte' => 10]]);
+        session(['userInput' => $criteria + ['vote_count_gte' => 10], 'roll_source' => 'other']);
         session()->forget('batchUrl');
 
         $criteria['page'] = $movieService->resolvePage($tmdb, $criteria, $country);
@@ -108,6 +109,7 @@ class PersonRollController extends Controller
                 $personKey . '_names' => [(string)($person->name ?? '')],
                 'vote_count_gte'      => 10,
             ],
+            'roll_source' => 'other',
         ]);
         session()->forget('batchUrl');
 

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -112,6 +112,7 @@ class RouletteController extends Controller
                 'savedBatchUrl'     => $batchUrl,
                 'savedBatchResults' => $picked,
                 'tvInput'           => $this->criteriaForSession($criteria, $response['total_pages'] ?? 500),
+                'roll_source'       => 'other',
             ]);
 
             return response()->json($this->toRollCards($picked, 'tv'));
@@ -127,6 +128,7 @@ class RouletteController extends Controller
             'savedBatchUrl'     => $batchUrl,
             'savedBatchResults' => $picked,
             'userInput'         => $this->criteriaForSession($criteria, $response['total_pages'] ?? 500),
+            'roll_source'       => 'other',
         ]);
 
         return response()->json($this->toRollCards($picked));

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -42,6 +42,7 @@ class TvPickController extends PickController
             return redirect('/tv/criteria');
         }
 
+        session(['roll_source' => 'criteria']);
         return redirect()->route('tv.show', [$movieService->pickRandom($results['results'])['id']]);
     }
 
@@ -94,6 +95,7 @@ class TvPickController extends PickController
             'batchUrl'          => url('/tv/multiple'),
             'savedBatchUrl'     => url('/tv/multiple'),
             'savedBatchResults' => $picked,
+            'roll_source'       => 'criteria',
         ]);
 
         return response()->json($this->toRollCards($picked, 'tv'));
@@ -121,6 +123,7 @@ class TvPickController extends PickController
             'batchUrl'          => url('/tv/multiple'),
             'savedBatchUrl'     => url('/tv/multiple'),
             'savedBatchResults' => $picked,
+            'roll_source'       => 'other',
         ]);
 
         return response()->json($this->toRollCards($picked, 'tv'));

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -43,7 +43,7 @@ class TvShowController extends Controller
         $similarShows = null;
         $similarTitle = 'Similar Shows';
 
-        if (!empty($showCriteria)) {
+        if (!empty($showCriteria) && session('roll_source') === 'criteria') {
             $showCriteria['page'] = rand(1, min($showCriteria['total_pages'] ?? 500, 500));
             $discovered = $tmdb->discoverTv($showCriteria, $country);
             if (count($discovered['results']) >= 4) {
@@ -54,10 +54,17 @@ class TvShowController extends Controller
         }
 
         if ($similarShows === null) {
-            $raw = $tmdb->similarShows($tmdbInfo);
-            if ($raw) {
-                $raw['results'] = $movieService->normaliseShows($raw['results']);
-                $similarShows   = $raw;
+            $recommendations = array_values((array) ($tmdbInfo->recommendations->results ?? []));
+            if (count($recommendations) >= 4) {
+                $recommendations = $movieService->normaliseShows(array_map(fn($r) => (array) $r, array_slice($recommendations, 0, 20)));
+                $similarShows    = ['results' => $recommendations];
+                $similarTitle    = 'You Might Also Like';
+            } else {
+                $raw = $tmdb->similarShows($tmdbInfo);
+                if ($raw) {
+                    $raw['results'] = $movieService->normaliseShows($raw['results']);
+                    $similarShows   = $raw;
+                }
             }
         }
 

--- a/app/Http/Controllers/WatchlistController.php
+++ b/app/Http/Controllers/WatchlistController.php
@@ -174,6 +174,7 @@ class WatchlistController extends Controller
             return redirect()->route('watchlist');
         }
 
+        session(['roll_source' => 'other']);
         $picked = $items->random();
 
         $base = $picked->type === 'tv'

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -97,7 +97,7 @@ class TmdbClient implements ApiMovie
     {
         return Cache::remember('tmdb_movie_' . $movieId, now()->addHours(6), function () use ($movieId) {
             $url = 'https://api.themoviedb.org/3/movie/' . $movieId . '?'
-                . http_build_query(['append_to_response' => 'videos,credits,similar,watch/providers']);
+                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,watch/providers']);
 
             $response = $this->client->get($url);
             return json_decode($response->getBody()->getContents());
@@ -328,7 +328,7 @@ class TmdbClient implements ApiMovie
     {
         return Cache::remember('tmdb_tv_' . $id, now()->addHours(6), function () use ($id) {
             $url = 'https://api.themoviedb.org/3/tv/' . $id . '?'
-                . http_build_query(['append_to_response' => 'videos,credits,similar,watch/providers,external_ids']);
+                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,watch/providers,external_ids']);
 
             $response = $this->client->get($url);
             return json_decode($response->getBody()->getContents());


### PR DESCRIPTION
## Summary

Implements the roll-source aware similar content section on movie and TV detail pages.

**New `roll_source` session flag** — set at the point of rolling so the detail page knows where the user came from:
- Criteria form rolls (`single()`, `criteriaRoll()`) → `roll_source = 'criteria'`
- Everything else (homepage, roulette, person page, watchlist) → `roll_source = 'other'`

**Detail page logic:**
1. Watchlist context → "More from Your Watchlist" (unchanged, highest priority)
2. `roll_source === 'criteria'` → "More with Same Criteria" (existing behaviour)
3. Otherwise → "You Might Also Like" from recommendations endpoint (≥4 results)
4. Fallback → Similar (if recommendations returns fewer than 4)

**API changes:**
- Added `recommendations` to `append_to_response` on `TmdbClient::movie()` and `TmdbClient::tvShow()` — zero extra API calls, bundled with the existing detail request

## Test plan
- [x] Roll from criteria page → detail page shows "More with Same Criteria"
- [x] Roll from homepage → detail page shows "You Might Also Like"
- [x] Roll from a roulette → detail page shows "You Might Also Like"
- [x] Roll from a person page → detail page shows "You Might Also Like"
- [x] Roll from watchlist → detail page shows "More from Your Watchlist"
- [x] Confirm TV show detail page behaves the same way
- [x] Confirm fallback to Similar works when recommendations returns < 4 results