### PR TITLE
Add user reviews to movie and TV detail pages

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -111,8 +111,8 @@ class MovieController extends Controller
         $reviews    = collect($tmdbInfo->reviews->results ?? [])
             ->map(fn($r) => (array) $r)
             ->sortBy([
-                fn($r) => isset($r['author_details']['rating']) ? abs((float) $r['author_details']['rating'] - $refScore) : PHP_INT_MAX,
-                fn($r) => -(float) ($r['author_details']['rating'] ?? 0),
+                fn($r) => isset($r['author_details']->rating) ? abs((float) $r['author_details']->rating - $refScore) : PHP_INT_MAX,
+                fn($r) => -(float) ($r['author_details']->rating ?? 0),
                 fn($r) => -mb_strlen($r['content'] ?? ''),
             ])
             ->take(5)

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -105,7 +105,19 @@ class MovieController extends Controller
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
-        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 5);
+        $refScore   = (isset($omdbInfo->imdbRating) && $omdbInfo->imdbRating !== 'N/A')
+            ? (float) $omdbInfo->imdbRating
+            : (float) ($tmdbInfo->vote_average ?? 5.0);
+        $reviews    = collect($tmdbInfo->reviews->results ?? [])
+            ->map(fn($r) => (array) $r)
+            ->sortBy([
+                fn($r) => isset($r['author_details']['rating']) ? abs((float) $r['author_details']['rating'] - $refScore) : PHP_INT_MAX,
+                fn($r) => -(float) ($r['author_details']['rating'] ?? 0),
+                fn($r) => -mb_strlen($r['content'] ?? ''),
+            ])
+            ->take(5)
+            ->values()
+            ->all();
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -105,11 +105,12 @@ class MovieController extends Controller
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
+        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 2);
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',
             'trailer', 'user_input', 'all_genres', 'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country',
-            'collection'
+            'collection', 'reviews'
         ));
     }
 }

--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -105,7 +105,7 @@ class MovieController extends Controller
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
-        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 2);
+        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 5);
 
         return view('movie', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'similarMovies', 'similarTitle', 'linkSuffix', 'genres',

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -79,8 +79,8 @@ class TvShowController extends Controller
         $reviews    = collect($tmdbInfo->reviews->results ?? [])
             ->map(fn($r) => (array) $r)
             ->sortBy([
-                fn($r) => isset($r['author_details']['rating']) ? abs((float) $r['author_details']['rating'] - $refScore) : PHP_INT_MAX,
-                fn($r) => -(float) ($r['author_details']['rating'] ?? 0),
+                fn($r) => isset($r['author_details']->rating) ? abs((float) $r['author_details']->rating - $refScore) : PHP_INT_MAX,
+                fn($r) => -(float) ($r['author_details']->rating ?? 0),
                 fn($r) => -mb_strlen($r['content'] ?? ''),
             ])
             ->take(5)

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -73,7 +73,19 @@ class TvShowController extends Controller
         $all_genres = $movieService->genres($tmdb, 'tv');
         $user_input = session('tvInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
-        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 5);
+        $refScore   = (isset($omdbInfo->imdbRating) && $omdbInfo->imdbRating !== 'N/A')
+            ? (float) $omdbInfo->imdbRating
+            : (float) ($tmdbInfo->vote_average ?? 5.0);
+        $reviews    = collect($tmdbInfo->reviews->results ?? [])
+            ->map(fn($r) => (array) $r)
+            ->sortBy([
+                fn($r) => isset($r['author_details']['rating']) ? abs((float) $r['author_details']['rating'] - $refScore) : PHP_INT_MAX,
+                fn($r) => -(float) ($r['author_details']['rating'] ?? 0),
+                fn($r) => -mb_strlen($r['content'] ?? ''),
+            ])
+            ->take(5)
+            ->values()
+            ->all();
 
         return view('tv.show', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'genres', 'trailer', 'user_input', 'all_genres',

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -73,7 +73,7 @@ class TvShowController extends Controller
         $all_genres = $movieService->genres($tmdb, 'tv');
         $user_input = session('tvInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
-        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 2);
+        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 5);
 
         return view('tv.show', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'genres', 'trailer', 'user_input', 'all_genres',

--- a/app/Http/Controllers/TvShowController.php
+++ b/app/Http/Controllers/TvShowController.php
@@ -73,11 +73,12 @@ class TvShowController extends Controller
         $all_genres = $movieService->genres($tmdb, 'tv');
         $user_input = session('tvInput', 'default');
         $savedIds   = $this->savedWatchlistIds();
+        $reviews    = array_slice((array) ($tmdbInfo->reviews->results ?? []), 0, 2);
 
         return view('tv.show', compact(
             'tmdbInfo', 'omdbInfo', 'urls', 'genres', 'trailer', 'user_input', 'all_genres',
             'watchProviders', 'providersArray', 'batchUrl', 'savedIds', 'country',
-            'similarShows', 'similarTitle'
+            'similarShows', 'similarTitle', 'reviews'
         ));
     }
 

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -97,7 +97,7 @@ class TmdbClient implements ApiMovie
     {
         return Cache::remember('tmdb_movie_' . $movieId, now()->addHours(6), function () use ($movieId) {
             $url = 'https://api.themoviedb.org/3/movie/' . $movieId . '?'
-                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,watch/providers']);
+                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,reviews,watch/providers']);
 
             $response = $this->client->get($url);
             return json_decode($response->getBody()->getContents());
@@ -328,7 +328,7 @@ class TmdbClient implements ApiMovie
     {
         return Cache::remember('tmdb_tv_' . $id, now()->addHours(6), function () use ($id) {
             $url = 'https://api.themoviedb.org/3/tv/' . $id . '?'
-                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,watch/providers,external_ids']);
+                . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,reviews,watch/providers,external_ids']);
 
             $response = $this->client->get($url);
             return json_decode($response->getBody()->getContents());

--- a/resources/views/includes/reviews.blade.php
+++ b/resources/views/includes/reviews.blade.php
@@ -24,7 +24,14 @@
                 ? \Carbon\Carbon::parse($review->created_at)->format('M Y')
                 : null;
         @endphp
-        <div class="card p-4{{ $i >= 2 ? ' review-extra hidden' : '' }}">
+        @if($i === 2)
+        {{-- Animated wrapper for extra reviews --}}
+        <div id="reviews-extra-wrapper" style="display:grid;grid-template-rows:0fr;overflow:hidden;transition:grid-template-rows 0.3s ease">
+            <div style="overflow:hidden">
+                <div class="flex flex-col gap-4">
+        @endif
+
+        <div class="card p-4{{ $i >= 2 ? ' pt-0 mt-0' : '' }}" @if($i === 2) style="margin-top:0" @endif>
             <div class="flex items-center gap-3 mb-3">
                 @if($avatarUrl)
                     <img src="{{ $avatarUrl }}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" alt="">
@@ -51,6 +58,13 @@
                 </a>
             @endif
         </div>
+
+        @if($i === count($reviews) - 1 && count($reviews) > 2)
+                </div>
+            </div>
+        </div>
+        @endif
+
         @endforeach
     </div>
 
@@ -61,12 +75,12 @@
     </button>
     <script>
     (function () {
-        const btn   = document.getElementById('reviews-toggle');
-        const extra = document.querySelectorAll('.review-extra');
-        let open    = false;
+        const btn     = document.getElementById('reviews-toggle');
+        const wrapper = document.getElementById('reviews-extra-wrapper');
+        let open      = false;
         btn.addEventListener('click', function () {
             open = !open;
-            extra.forEach(function (el) { el.classList.toggle('hidden', !open); });
+            wrapper.style.gridTemplateRows = open ? '1fr' : '0fr';
             btn.textContent = open
                 ? 'Show fewer reviews ↑'
                 : 'Show {{ count($reviews) - 2 }} more reviews ↓';

--- a/resources/views/includes/reviews.blade.php
+++ b/resources/views/includes/reviews.blade.php
@@ -5,7 +5,7 @@
         <div class="section-divider"></div>
     </div>
     <div class="flex flex-col gap-4 mt-4">
-        @foreach($reviews as $review)
+        @foreach($reviews as $i => $review)
         @php
             $review    = (object) $review;
             $details   = (object) ($review->author_details ?? []);
@@ -24,7 +24,7 @@
                 ? \Carbon\Carbon::parse($review->created_at)->format('M Y')
                 : null;
         @endphp
-        <div class="card p-4">
+        <div class="card p-4{{ $i >= 2 ? ' review-extra hidden' : '' }}">
             <div class="flex items-center gap-3 mb-3">
                 @if($avatarUrl)
                     <img src="{{ $avatarUrl }}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" alt="">
@@ -53,5 +53,26 @@
         </div>
         @endforeach
     </div>
+
+    @if(count($reviews) > 2)
+    <button type="button" id="reviews-toggle"
+            class="mt-3 text-sm text-gray-500 hover:text-white transition-colors">
+        Show {{ count($reviews) - 2 }} more reviews ↓
+    </button>
+    <script>
+    (function () {
+        const btn   = document.getElementById('reviews-toggle');
+        const extra = document.querySelectorAll('.review-extra');
+        let open    = false;
+        btn.addEventListener('click', function () {
+            open = !open;
+            extra.forEach(function (el) { el.classList.toggle('hidden', !open); });
+            btn.textContent = open
+                ? 'Show fewer reviews ↑'
+                : 'Show {{ count($reviews) - 2 }} more reviews ↓';
+        });
+    })();
+    </script>
+    @endif
 </div>
 @endif

--- a/resources/views/includes/reviews.blade.php
+++ b/resources/views/includes/reviews.blade.php
@@ -24,14 +24,14 @@
                 ? \Carbon\Carbon::parse($review->created_at)->format('M Y')
                 : null;
         @endphp
-        @if($i === 2)
+        @if($i === 1)
         {{-- Animated wrapper for extra reviews --}}
         <div id="reviews-extra-wrapper" style="display:grid;grid-template-rows:0fr;overflow:hidden;transition:grid-template-rows 0.3s ease">
             <div style="overflow:hidden">
                 <div class="flex flex-col gap-4">
         @endif
 
-        <div class="card p-4{{ $i >= 2 ? ' pt-0 mt-0' : '' }}" @if($i === 2) style="margin-top:0" @endif>
+        <div class="card p-4">
             <div class="flex items-center gap-3 mb-3">
                 @if($avatarUrl)
                     <img src="{{ $avatarUrl }}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" alt="">
@@ -59,7 +59,7 @@
             @endif
         </div>
 
-        @if($i === count($reviews) - 1 && count($reviews) > 2)
+        @if($i === count($reviews) - 1 && count($reviews) > 1)
                 </div>
             </div>
         </div>
@@ -68,10 +68,10 @@
         @endforeach
     </div>
 
-    @if(count($reviews) > 2)
+    @if(count($reviews) > 1)
     <button type="button" id="reviews-toggle"
             class="mt-3 text-sm text-gray-500 hover:text-white transition-colors">
-        Show {{ count($reviews) - 2 }} more reviews ↓
+        Show {{ count($reviews) - 1 }} more {{ Str::plural('review', count($reviews) - 1) }} ↓
     </button>
     <script>
     (function () {
@@ -83,7 +83,7 @@
             wrapper.style.gridTemplateRows = open ? '1fr' : '0fr';
             btn.textContent = open
                 ? 'Show fewer reviews ↑'
-                : 'Show {{ count($reviews) - 2 }} more reviews ↓';
+                : 'Show {{ count($reviews) - 1 }} more {{ Str::plural('review', count($reviews) - 1) }} ↓';
         });
     })();
     </script>

--- a/resources/views/includes/reviews.blade.php
+++ b/resources/views/includes/reviews.blade.php
@@ -1,0 +1,57 @@
+@if(!empty($reviews) && count($reviews) > 0)
+<div class="mb-10">
+    <div class="section-header">
+        <h2 class="text-xl font-bold text-white mb-3">Reviews</h2>
+        <div class="section-divider"></div>
+    </div>
+    <div class="flex flex-col gap-4 mt-4">
+        @foreach($reviews as $review)
+        @php
+            $review    = (object) $review;
+            $details   = (object) ($review->author_details ?? []);
+            $rating    = $details->rating ?? null;
+            $avatar    = $details->avatar_path ?? null;
+            $avatarUrl = null;
+            if ($avatar) {
+                $avatarUrl = str_starts_with($avatar, '/https')
+                    ? ltrim($avatar, '/')
+                    : 'https://image.tmdb.org/t/p/w45' . $avatar;
+            }
+            $body     = $review->content ?? '';
+            $truncate = mb_strlen($body) > 280;
+            $excerpt  = $truncate ? mb_substr($body, 0, 280) . '…' : $body;
+            $date     = !empty($review->created_at)
+                ? \Carbon\Carbon::parse($review->created_at)->format('M Y')
+                : null;
+        @endphp
+        <div class="card p-4">
+            <div class="flex items-center gap-3 mb-3">
+                @if($avatarUrl)
+                    <img src="{{ $avatarUrl }}" class="w-8 h-8 rounded-full object-cover flex-shrink-0" alt="">
+                @else
+                    <div class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-xs font-bold text-gray-400 flex-shrink-0">
+                        {{ strtoupper(substr($review->author ?? '?', 0, 1)) }}
+                    </div>
+                @endif
+                <div class="flex-1 min-w-0">
+                    <span class="text-sm font-medium text-white">{{ $review->author ?? 'Anonymous' }}</span>
+                    @if($date)
+                        <span class="text-xs text-gray-600 ml-2">{{ $date }}</span>
+                    @endif
+                </div>
+                @if($rating)
+                    <span class="text-xs font-semibold text-accent flex-shrink-0">{{ $rating }}/10</span>
+                @endif
+            </div>
+            <p class="text-sm text-gray-300 leading-relaxed">{{ $excerpt }}</p>
+            @if($truncate)
+                <a href="{{ $review->url ?? '#' }}" target="_blank"
+                   class="text-xs text-gray-500 hover:text-accent transition-colors mt-2 inline-block">
+                    Read full review →
+                </a>
+            @endif
+        </div>
+        @endforeach
+    </div>
+</div>
+@endif

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -324,6 +324,8 @@
     </div>
     @endif
 
+    @include('includes.reviews')
+
     {{-- Similar movies --}}
     @if ($similarMovies != null)
     <div>
@@ -334,8 +336,6 @@
         @include('includes.carousel', ['allMovies' => $similarMovies, 'name' => 'swiper-similar', 'genres' => [], 'linkSuffix' => $linkSuffix, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
     </div>
     @endif
-
-    @include('includes.reviews')
 
 </div>
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -324,6 +324,8 @@
     </div>
     @endif
 
+    @include('includes.reviews')
+
     {{-- Similar movies --}}
     @if ($similarMovies != null)
     <div>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -324,8 +324,6 @@
     </div>
     @endif
 
-    @include('includes.reviews')
-
     {{-- Similar movies --}}
     @if ($similarMovies != null)
     <div>
@@ -336,6 +334,8 @@
         @include('includes.carousel', ['allMovies' => $similarMovies, 'name' => 'swiper-similar', 'genres' => [], 'linkSuffix' => $linkSuffix, 'showScore' => true, 'showSave' => true, 'savedIds' => $savedIds])
     </div>
     @endif
+
+    @include('includes.reviews')
 
 </div>
 

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -417,6 +417,8 @@
     </div>
     @endif
 
+    @include('includes.reviews')
+
     {{-- Similar shows --}}
     @if ($similarShows != null)
     <div>

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -417,6 +417,8 @@
     </div>
     @endif
 
+    @include('includes.reviews')
+
     {{-- Similar shows --}}
     @if ($similarShows != null)
     <div>
@@ -436,8 +438,6 @@
         ])
     </div>
     @endif
-
-    @include('includes.reviews')
 
 </div>
 

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -417,8 +417,6 @@
     </div>
     @endif
 
-    @include('includes.reviews')
-
     {{-- Similar shows --}}
     @if ($similarShows != null)
     <div>
@@ -438,6 +436,8 @@
         ])
     </div>
     @endif
+
+    @include('includes.reviews')
 
 </div>
 


### PR DESCRIPTION
## Summary

- Adds `reviews` to `append_to_response` on both `TmdbClient::movie()` and `TmdbClient::tvShow()` — zero extra API calls
- Fetches up to 5 reviews, shows 2 by default with a "Show X more reviews" toggle to expand/collapse the rest
- Each review card shows: author avatar (TMDB or Gravatar), author name, date, rating /10 (if provided), body truncated at 280 chars with "Read full review →" link
- Section hidden entirely when no reviews exist

## Test plan
- [ ] Visit a popular movie — 2 reviews visible, toggle shows/hides the rest
- [ ] Visit a TV show — same behaviour
- [ ] Movie with fewer than 3 reviews — no toggle shown
- [ ] Movie with no reviews — section not shown
- [ ] Long review truncated with "Read full review →" link to TMDB