### PR TITLE
Add GDPR cookie consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
-                "jquery-flexdatalist": "^2.3.0"
+                "jquery-flexdatalist": "^2.3.0",
+                "vanilla-cookieconsent": "^3.1.0"
             },
             "devDependencies": {
                 "@rollup/plugin-inject": "^5.0",
@@ -2136,6 +2137,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/tom-select"
             }
+        },
+        "node_modules/vanilla-cookieconsent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+            "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
+            "license": "MIT"
         },
         "node_modules/vite": {
             "version": "6.4.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "vite": "^6.4.2"
     },
     "dependencies": {
-        "jquery-flexdatalist": "^2.3.0"
+        "jquery-flexdatalist": "^2.3.0",
+        "vanilla-cookieconsent": "^3.1.0"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -579,18 +579,47 @@ html[data-theme="light"] .bg-white\/\[0\.02\] { background-color: rgba(0,0,0,0.0
     --cc-bg: #1a1a1a;
     --cc-primary-color: #f5f5f5;
     --cc-secondary-color: #9ca3af;
-    --cc-btn-primary-bg: #c0393a;
-    --cc-btn-primary-color: #fff;
-    --cc-btn-primary-hover-bg: #a83031;
-    --cc-btn-secondary-bg: rgba(255,255,255,0.08);
-    --cc-btn-secondary-color: #f5f5f5;
-    --cc-btn-secondary-hover-bg: rgba(255,255,255,0.13);
+    --cc-link-color: #c0393a;
     --cc-separator-border-color: rgba(255,255,255,0.08);
-    --cc-toggle-on-bg: #c0393a;
-    --cc-toggle-off-bg: rgba(255,255,255,0.15);
-    --cc-overlay-bg: rgba(0,0,0,0.6);
     --cc-modal-border-radius: 12px;
     --cc-btn-border-radius: 8px;
     --cc-z-index: 9999;
+    --cc-overlay-bg: rgba(0,0,0,0.6);
+
+    --cc-btn-primary-bg: #c0393a;
+    --cc-btn-primary-color: #fff;
+    --cc-btn-primary-hover-bg: #a83031;
+    --cc-btn-primary-border-color: transparent;
+    --cc-btn-primary-hover-border-color: transparent;
+    --cc-btn-secondary-bg: rgba(255,255,255,0.08);
+    --cc-btn-secondary-color: #f5f5f5;
+    --cc-btn-secondary-hover-bg: rgba(255,255,255,0.13);
+    --cc-btn-secondary-border-color: transparent;
+    --cc-btn-secondary-hover-border-color: transparent;
+
+    --cc-cookie-category-block-bg: rgba(255,255,255,0.05);
+    --cc-cookie-category-block-border: rgba(255,255,255,0.08);
+    --cc-cookie-category-block-hover-bg: rgba(255,255,255,0.08);
+    --cc-cookie-category-block-hover-border: rgba(255,255,255,0.12);
+    --cc-cookie-category-expanded-block-bg: rgba(255,255,255,0.03);
+    --cc-cookie-category-expanded-block-hover-bg: rgba(255,255,255,0.05);
+    --cc-section-category-border: rgba(255,255,255,0.06);
+
+    --cc-footer-bg: #141414;
+    --cc-footer-border-color: rgba(255,255,255,0.08);
+    --cc-footer-color: #9ca3af;
+
+    --cc-toggle-on-bg: #c0393a;
+    --cc-toggle-off-bg: rgba(255,255,255,0.15);
+    --cc-toggle-on-knob-bg: #fff;
+    --cc-toggle-off-knob-bg: #fff;
+    --cc-toggle-readonly-bg: rgba(255,255,255,0.08);
+    --cc-toggle-readonly-knob-bg: rgba(255,255,255,0.4);
+    --cc-toggle-readonly-knob-icon-color: rgba(255,255,255,0.3);
+    --cc-toggle-enabled-icon-color: #fff;
+    --cc-toggle-disabled-icon-color: rgba(255,255,255,0.4);
+
+    --cc-webkit-scrollbar-bg: rgba(255,255,255,0.05);
+    --cc-webkit-scrollbar-hover-bg: rgba(255,255,255,0.1);
 }
 html[data-theme="light"] .bg-white\/\[0\.03\] { background-color: rgba(0,0,0,0.03) !important; }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -4,6 +4,7 @@
 @source "../js";
 
 @import "tom-select/dist/css/tom-select.default.css";
+@import "vanilla-cookieconsent/dist/cookieconsent.css";
 
 /* ─── Design tokens ─────────────────────────────────────────── */
 @theme {
@@ -571,4 +572,25 @@ html[data-theme="light"] footer {
 html[data-theme="light"] .border-white\/5  { border-color: var(--border-faint) !important; }
 html[data-theme="light"] .border-white\/10 { border-color: var(--border) !important; }
 html[data-theme="light"] .bg-white\/\[0\.02\] { background-color: rgba(0,0,0,0.02) !important; }
+
+/* ─── Cookie Consent theme ───────────────────────────────────── */
+#cc-main {
+    --cc-font-family: 'Inter', system-ui, sans-serif;
+    --cc-bg: #1a1a1a;
+    --cc-primary-color: #f5f5f5;
+    --cc-secondary-color: #9ca3af;
+    --cc-btn-primary-bg: #c0393a;
+    --cc-btn-primary-color: #fff;
+    --cc-btn-primary-hover-bg: #a83031;
+    --cc-btn-secondary-bg: rgba(255,255,255,0.08);
+    --cc-btn-secondary-color: #f5f5f5;
+    --cc-btn-secondary-hover-bg: rgba(255,255,255,0.13);
+    --cc-separator-border-color: rgba(255,255,255,0.08);
+    --cc-toggle-on-bg: #c0393a;
+    --cc-toggle-off-bg: rgba(255,255,255,0.15);
+    --cc-overlay-bg: rgba(0,0,0,0.6);
+    --cc-modal-border-radius: 12px;
+    --cc-btn-border-radius: 8px;
+    --cc-z-index: 9999;
+}
 html[data-theme="light"] .bg-white\/\[0\.03\] { background-color: rgba(0,0,0,0.03) !important; }

--- a/resources/js/custom/cookieConsent.js
+++ b/resources/js/custom/cookieConsent.js
@@ -1,0 +1,79 @@
+import * as CookieConsent from 'vanilla-cookieconsent';
+
+CookieConsent.run({
+    guiOptions: {
+        consentModal: {
+            layout: 'bar',
+            position: 'bottom',
+            equalWeightButtons: true,
+        },
+        preferencesModal: {
+            layout: 'box',
+        },
+    },
+
+    onConsent: ({ cookie }) => {
+        if (CookieConsent.acceptedCategory('analytics')) {
+            gtag('consent', 'update', { analytics_storage: 'granted' });
+        }
+    },
+
+    onChange: ({ changedCategories }) => {
+        if (changedCategories.includes('analytics')) {
+            if (CookieConsent.acceptedCategory('analytics')) {
+                gtag('consent', 'update', { analytics_storage: 'granted' });
+            } else {
+                gtag('consent', 'update', { analytics_storage: 'denied' });
+            }
+        }
+    },
+
+    categories: {
+        necessary: {
+            enabled: true,
+            readOnly: true,
+        },
+        analytics: {
+            enabled: false,
+            autoClear: {
+                cookies: [
+                    { name: /^_ga/ },
+                    { name: '_gid' },
+                ],
+            },
+        },
+    },
+
+    language: {
+        default: 'en',
+        translations: {
+            en: {
+                consentModal: {
+                    title: 'We use cookies',
+                    description: 'We use analytics cookies to understand how people use MoviePickr and improve the experience. You can choose to decline if you prefer.',
+                    acceptAllBtn: 'Accept',
+                    acceptNecessaryBtn: 'Decline',
+                    showPreferencesBtn: 'Manage',
+                },
+                preferencesModal: {
+                    title: 'Cookie preferences',
+                    acceptAllBtn: 'Accept all',
+                    acceptNecessaryBtn: 'Decline all',
+                    savePreferencesBtn: 'Save',
+                    sections: [
+                        {
+                            title: 'Necessary cookies',
+                            description: 'Required for the site to work — login sessions, CSRF protection, and theme preference.',
+                            linkedCategory: 'necessary',
+                        },
+                        {
+                            title: 'Analytics cookies',
+                            description: 'Google Analytics (GA4) helps us understand which features are used and how people navigate the site. No personal data is sold or shared.',
+                            linkedCategory: 'analytics',
+                        },
+                    ],
+                },
+            },
+        },
+    },
+});

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,15 +18,16 @@
     <meta name="twitter:description" content="@yield('og_description', 'Pick a random movie or TV show filtered by genre, streaming service, or mood. Or just hit roll and let it decide.')">
     <meta name="twitter:image" content="@yield('og_image', URL::asset('/images/icon.png'))">
     <script>!function(){var m=document.cookie.match(/(?:^|; )theme=([^;]+)/);if(m)document.documentElement.dataset.theme=m[1]}()</script>
-    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js', 'resources/js/custom/search.js', 'resources/js/custom/roulettes.js'])
-    @yield('scripts', '')
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RH8D2TSYJJ"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', { analytics_storage: 'denied' });
         gtag('js', new Date());
         gtag('config', 'G-RH8D2TSYJJ');
     </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RH8D2TSYJJ"></script>
+    @vite(['resources/css/app.css', 'resources/js/app.js', 'resources/js/custom/watchlist.js', 'resources/js/custom/search.js', 'resources/js/custom/roulettes.js', 'resources/js/custom/cookieConsent.js'])
+    @yield('scripts', '')
 </head>
 <body>
 
@@ -239,6 +240,7 @@
             <span class="text-gray-700">This product uses the TMDB API but is not endorsed or certified by TMDB.</span>
             <span class="text-gray-700">Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.</span>
             <span class="text-gray-700">Ratings data by <a href="https://www.omdbapi.com" target="_blank" class="hover:text-gray-500 transition-colors">OMDb</a>.</span>
+            <button data-cc="show-preferencesModal" class="hover:text-gray-400 transition-colors">Cookie settings</button>
         </div>
     </footer>
     @endunless

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
                 'resources/js/custom/search.js',
                 'resources/js/custom/roulettes.js',
                 'resources/js/custom/rouletteForm.js',
+                'resources/js/custom/cookieConsent.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Summary
- Install vanilla-cookieconsent and wire up GA4 Consent Mode v2
- Analytics cookies default to denied until the user accepts
- Cookie settings link in footer lets users withdraw consent at any time
- Banner styled to match the dark theme

## Test plan
- [x] Banner appears on first visit
- [x] Accepting analytics fires GA4 (check Network tab for gtag requests)
- [x] Declining keeps GA4 silent
- [x] "Cookie settings" in footer reopens the preferences modal
- [x] Preference is remembered across page refreshes