### PR TITLE
Add GA4 custom event tracking

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -42,6 +42,9 @@ $(document).ready(function () {
         const id = $(this).data('modal-open');
         $('#' + id).removeClass('hidden');
         $('body').css('overflow', 'hidden');
+        if (id === 'trailer-modal' && typeof gtag !== 'undefined') {
+            gtag('event', 'trailer_opened');
+        }
     });
 
     $(document).on('click', '[data-modal-close], .modal-backdrop', function () {

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -92,6 +92,11 @@ function getBatchCards(rowSelector) {
     return cards;
 }
 
+function trackRoll(mediaType, source, extra = {}) {
+    if (typeof gtag === 'undefined') return;
+    gtag('event', mediaType === 'tv' ? 'tv_rolled' : 'movie_rolled', { source, ...extra });
+}
+
 function rollCards(cards, source) {
     if (!cards.length) return false;
     document.querySelectorAll('.modal-wrap').forEach(m => m.classList.add('hidden'));
@@ -99,6 +104,7 @@ function rollCards(cards, source) {
     if (rollSource) sessionStorage.setItem('rollSource', rollSource);
     const winnerIdx  = Math.floor(Math.random() * cards.length);
     const mediaType  = cards[winnerIdx].media_type || 'movie';
+    trackRoll(mediaType, rollSource || 'unknown');
     if (localStorage.getItem('wl_animation') !== '0') {
         runCaseOpening(cards, winnerIdx, cards[winnerIdx].url, mediaType);
     } else {
@@ -121,9 +127,17 @@ document.addEventListener('submit', function (e) {
 
     e.preventDefault();
 
-    const endpoint = isMovie ? '/movie/roll/criteria' : '/tv/roll/criteria';
-    const fallback = formaction;
-    setRollContext('batch', isMovie ? '/multiple?from=roll' : '/tv/multiple?from=roll', '← Batch');
+    const endpoint  = isMovie ? '/movie/roll/criteria' : '/tv/roll/criteria';
+    const fallback  = formaction;
+    const moodName  = btn && btn.dataset.mood;
+    const rollSource = moodName ? 'mood' : 'criteria';
+    setRollContext(rollSource, isMovie ? '/multiple?from=roll' : '/tv/multiple?from=roll', '← Batch');
+
+    if (moodName && typeof gtag !== 'undefined') {
+        gtag('event', 'mood_selected', { mood: moodName, media_type: isMovie ? 'movie' : 'tv' });
+    } else if (!moodName && typeof gtag !== 'undefined') {
+        gtag('event', 'criteria_submitted', { media_type: isMovie ? 'movie' : 'tv' });
+    }
 
     const body = new FormData(form);
     if (btn) { btn.textContent = 'Loading…'; btn.disabled = true; }
@@ -172,6 +186,7 @@ document.addEventListener('click', function (e) {
                 rouletteBtn.textContent = orig;
                 rouletteBtn.disabled = false;
                 setRollContext('roulette', `/roulettes/${slug}?from=roll`, '← Batch');
+                if (typeof gtag !== 'undefined') gtag('event', 'roulette_rolled', { roulette_slug: slug });
                 if (!rollCards(toCards(movies))) window.location.href = `/roulettes/${slug}`;
             })
             .catch(() => { window.location.href = `/roulettes/${slug}`; });
@@ -218,7 +233,8 @@ document.addEventListener('click', function (e) {
             setRollContext('person', window.location.href, link.dataset.backLabel || '← Back');
         } else {
             const batchUrl = (rollType === 'tv' || rollType === 'tv-criteria') ? '/tv/multiple?from=roll' : '/multiple?from=roll';
-            setRollContext('batch', batchUrl, '← Batch');
+            const src = (rollType === 'movie' || rollType === 'tv') ? 'homepage' : 'batch';
+            setRollContext(src, batchUrl, '← Batch');
         }
 
         const origText = link.textContent;

--- a/resources/js/custom/search.js
+++ b/resources/js/custom/search.js
@@ -62,6 +62,7 @@ $(document).ready(function () {
                     const html = (resp || []).map(buildResult).join('');
                     if (!html) { $results.addClass('hidden').empty(); return; }
                     $results.html(html).removeClass('hidden');
+                    if (typeof gtag !== 'undefined') gtag('event', 'search_used');
                 });
             }, 300);
         });
@@ -76,6 +77,14 @@ $(document).ready(function () {
 
     initSearch('#desktop-search-input', '#desktop-search-results');
     initSearch('#mobile-search-input',  '#mobile-search-results');
+
+    // Track search result clicks
+    $(document).on('click', '.search-result-item', function () {
+        if (typeof gtag === 'undefined') return;
+        const href = $(this).attr('href') || '';
+        const type = href.startsWith('/person/') ? 'person' : href.startsWith('/tv/') ? 'tv' : 'movie';
+        gtag('event', 'search_result_clicked', { result_type: type });
+    });
 
     // Close desktop results when clicking outside
     $(document).on('click', function (e) {

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -42,6 +42,9 @@ $(document).ready(function () {
             type:         btn.data('media-type') || 'movie',
         })
         .done(function (res) {
+            if (typeof gtag !== 'undefined') {
+                gtag('event', 'watchlist_saved', { action: res.saved ? 'save' : 'remove', media_type: btn.data('media-type') || 'movie' });
+            }
             btn.data('saved', res.saved ? '1' : '0');
             const star = btn.data('format') === 'star';
             if (star) {
@@ -220,6 +223,8 @@ $(document).ready(function () {
         const picked    = visible.eq(pickedIdx);
         let url = picked.find('a').first().attr('href') + '?wl_status=' + status;
         if (genres) url += '&wl_genres=' + encodeURIComponent(genres);
+
+        if (typeof gtag !== 'undefined') gtag('event', 'watchlist_rolled');
 
         if (localStorage.getItem('wl_animation') !== '0') {
             const cards      = buildCards();

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -91,7 +91,7 @@
                 <input type="hidden" name="without_genres[]" value="53">
                 <input type="hidden" name="vote_average_gte" value="6.0">
                 <input type="hidden" name="vote_count_gte" value="200">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!" data-mood="funny">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
                         <path d="M8 13s1.5 3 4 3 4-3 4-3"/>
@@ -112,7 +112,7 @@
                 <input type="hidden" name="without_genres[]" value="10749">
                 <input type="hidden" name="vote_average_gte" value="6.5">
                 <input type="hidden" name="vote_count_gte" value="200">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!" data-mood="intense">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
                     </svg>
@@ -130,7 +130,7 @@
                 <input type="hidden" name="without_genres[]" value="27">
                 <input type="hidden" name="without_genres[]" value="53">
                 <input type="hidden" name="without_genres[]" value="80">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!" data-mood="feel-good">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"/>
                         <line x1="12" y1="1" x2="12" y2="3"/>
@@ -156,7 +156,7 @@
                 <input type="hidden" name="without_genres[]" value="10751">
                 <input type="hidden" name="vote_average_gte" value="6.0">
                 <input type="hidden" name="vote_count_gte" value="200">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!" data-mood="dark">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
                     </svg>
@@ -174,7 +174,7 @@
                 <input type="hidden" name="without_genres[]" value="28">
                 <input type="hidden" name="vote_average_gte" value="6.5">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!" data-mood="romantic">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
                     </svg>
@@ -191,7 +191,7 @@
                 <input type="hidden" name="without_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="6.0">
                 <input type="hidden" name="vote_count_gte" value="200">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!" data-mood="mindless">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
                         <polygon points="10 8 16 12 10 16 10 8"/>
@@ -214,7 +214,7 @@
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="vote_average_gte" value="7.0">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to laugh at!" data-mood="funny">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
                         <path d="M8 13s1.5 3 4 3 4-3 4-3"/>
@@ -235,7 +235,7 @@
                 <input type="hidden" name="without_genres[]" value="16">
                 <input type="hidden" name="vote_average_gte" value="7.0">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to keep you on edge!" data-mood="intense">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
                     </svg>
@@ -252,7 +252,7 @@
                 <input type="hidden" name="vote_count_gte" value="100">
                 <input type="hidden" name="without_genres[]" value="80">
                 <input type="hidden" name="without_genres[]" value="9648">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to warm your heart!" data-mood="feel-good">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"/>
                         <line x1="12" y1="1" x2="12" y2="3"/>
@@ -278,7 +278,7 @@
                 <input type="hidden" name="without_genres[]" value="10751">
                 <input type="hidden" name="vote_average_gte" value="7.0">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to haunt you!" data-mood="dark">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
                     </svg>
@@ -296,7 +296,7 @@
                 <input type="hidden" name="without_genres[]" value="10759">
                 <input type="hidden" name="vote_average_gte" value="7.0">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to fall in love with!" data-mood="romantic">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/>
                     </svg>
@@ -312,7 +312,7 @@
                 <input type="hidden" name="without_genres[]" value="18">
                 <input type="hidden" name="vote_average_gte" value="6.5">
                 <input type="hidden" name="vote_count_gte" value="100">
-                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!">
+                <button type="submit" class="mood-tile long-single" data-loading="Finding something to just enjoy!" data-mood="mindless">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10"/>
                         <polygon points="10 8 16 12 10 16 10 8"/>

--- a/resources/views/my-roulettes/manage.blade.php
+++ b/resources/views/my-roulettes/manage.blade.php
@@ -15,6 +15,9 @@
         <div class="mb-6 px-4 py-3 rounded-xl bg-green-500/10 border border-green-500/20 text-green-400 text-sm">
             {{ session('success') }}
         </div>
+        @if(session('success') === 'Roulette created.')
+            <script>if (typeof gtag !== 'undefined') gtag('event', 'roulette_created');</script>
+        @endif
     @endif
 
     @if($errors->any())

--- a/resources/views/no-results.blade.php
+++ b/resources/views/no-results.blade.php
@@ -4,6 +4,9 @@
     @vite(['resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
+@once
+<script>if (typeof gtag !== 'undefined') gtag('event', 'no_results_hit', { media_type: '{{ $isTv ? 'tv' : 'movie' }}' });</script>
+@endonce
 
 @if($isTv)
     @include('tv.criteria-modal')


### PR DESCRIPTION
## Summary
- Track core roll events: `movie_rolled`, `tv_rolled` with source (homepage / mood / criteria / roulette / batch / person)
- Track feature usage: `mood_selected`, `criteria_submitted`, `roulette_rolled`, `watchlist_rolled`, `watchlist_saved`, `trailer_opened`
- Track discovery: `search_used`, `search_result_clicked` (with result_type)
- Track friction: `no_results_hit` (with media_type)
- Track engagement: `roulette_created`

## Test plan
- [x] Roll a movie from homepage — check `movie_rolled` fires with `source: homepage`
- [x] Click a mood tile — check `mood_selected` fires with correct mood name
- [x] Roll from a roulette — check `roulette_rolled` and `movie_rolled` both fire
- [x] Use search and click a result — check `search_used` and `search_result_clicked` fire
- [x] Save a movie to watchlist — check `watchlist_saved` fires
- [x] Open a trailer — check `trailer_opened` fires
- [x] Verify all events in GA4 Realtime view after deploy