### PR TITLE
UX fixes — Filters rename and scroll lock

### DIFF
--- a/resources/js/custom/caseOpening.js
+++ b/resources/js/custom/caseOpening.js
@@ -82,6 +82,7 @@ export function runCaseOpening(cards, winnerIdx, fullUrl, mediaType = 'movie') {
     });
 
     overlay.classList.remove('hidden');
+    document.body.style.overflow = 'hidden';
     titleEl.classList.add('opacity-0');
     tierEl.classList.add('opacity-0');
     titleEl.textContent  = '';
@@ -140,11 +141,12 @@ export function runCaseOpening(cards, winnerIdx, fullUrl, mediaType = 'movie') {
         titleEl.classList.remove('opacity-0');
     }, 7050);
 
-    setTimeout(() => { window.location.href = fullUrl; }, 8500);
+    setTimeout(() => { document.body.style.overflow = ''; window.location.href = fullUrl; }, 8500);
 
     document.addEventListener('keydown', function onEsc(e) {
         if (e.key === 'Escape') {
             overlay.classList.add('hidden');
+            document.body.style.overflow = '';
             document.removeEventListener('keydown', onEsc);
         }
     });

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -92,7 +92,7 @@
         <div class="flex-shrink-0"></div>
         <div class="flex items-center gap-3">
             @if(isset($providersArray) && isset($all_genres))
-                <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Criteria</button>
+                <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Filters</button>
             @endif
             <a href="{{ Request::url() }}" class="btn-secondary flex-none text-center long-single">New Batch</a>
             <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', $title ?? (($mediaType ?? 'movie') === 'tv' ? 'TV Batch — MoviePickr' : 'Batch — MoviePickr'))
-@section('footer_pb', 'pb-32')
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])
 @endsection

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('page_title', $title ?? (($mediaType ?? 'movie') === 'tv' ? 'TV Batch — MoviePickr' : 'Batch — MoviePickr'))
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])
 @endsection

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -9,7 +9,7 @@
 <div class="max-w-2xl mx-auto px-4 py-10 pb-24">
 
     <div class="mb-8">
-        <h1 class="text-3xl font-bold text-white">Movie Criteria</h1>
+        <h1 class="text-3xl font-bold text-white">Movie Filters</h1>
         <p class="text-gray-500 text-sm mt-1">Fill in what you want, leave the rest blank.</p>
     </div>
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -11,8 +11,8 @@
             <a href="/tv/pick?i=new" class="btn-accent">Random TV Show</a>
         </div>
         <div class="flex flex-wrap gap-3 justify-center">
-            <a href="/criteria" class="btn-secondary">Movie Criteria</a>
-            <a href="/tv/criteria" class="btn-secondary">TV Criteria</a>
+            <a href="/criteria" class="btn-secondary">Movie Filters</a>
+            <a href="/tv/criteria" class="btn-secondary">TV Filters</a>
             <a href="/" class="btn-secondary">Home</a>
         </div>
     </div>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -8,7 +8,7 @@
         <p class="text-gray-500 mb-8">A server error occurred. Try again in a moment.</p>
         <div class="flex flex-wrap gap-3 justify-center">
             <a href="/movie?i=new" class="btn-accent">Random Movie</a>
-            <a href="/criteria" class="btn-secondary">Set Criteria</a>
+            <a href="/criteria" class="btn-secondary">Set Filters</a>
         </div>
     </div>
 </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -10,11 +10,11 @@
         {{-- Poster collage background --}}
         @php $bgPosters = array_values(array_filter(array_slice($trendingDay['results'] ?? [], 0, 12), fn($m) => !empty($m['poster_path']))); @endphp
         @if(count($bgPosters) >= 3)
-            <div class="absolute inset-0 grid grid-cols-4 md:grid-cols-6 opacity-[0.18] pointer-events-none overflow-hidden" aria-hidden="true">
+            <div class="absolute inset-0 grid grid-cols-3 md:grid-cols-6 opacity-[0.18] pointer-events-none overflow-hidden" aria-hidden="true">
                 @foreach($bgPosters as $m)
                     <img src="https://image.tmdb.org/t/p/w342{{ $m['poster_path'] }}"
                          alt=""
-                         class="w-full h-full object-cover"
+                         class="w-full h-full object-cover {{ $loop->index >= 6 ? 'hidden md:block' : '' }}"
                          @if($loop->first) fetchpriority="high" @endif>
                 @endforeach
             </div>
@@ -343,6 +343,23 @@
         </div>
     </section>
 
+    {{-- About --}}
+    <section class="bg-white/[0.02] border-y border-white/5 py-10 sm:py-16">
+        <div class="max-w-2xl mx-auto px-4 text-center">
+            <h2 class="text-2xl font-bold text-white mb-3">About MoviePickr</h2>
+            <div class="section-divider mb-6"></div>
+            <p class="text-gray-400 leading-relaxed mb-8">
+                Sometimes the best movie is one you never would have chosen yourself.
+                Tell MoviePickr what you're in the mood for and it'll find something worth watching.
+                Filter by genre, decade, streaming service, or cast, or skip the filters entirely and let it surprise you.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-3 justify-center items-stretch sm:items-center">
+                <a href="/movie?i=new" class="btn-accent long-single text-center">Random Movie</a>
+                <a href="/criteria" class="btn-secondary text-center">Set Preferences</a>
+            </div>
+        </div>
+    </section>
+
     {{-- Featured Roulettes --}}
     @if($featuredRoulettes->isNotEmpty())
     @include('includes.roulette-labels')
@@ -424,23 +441,6 @@
         </div>
     </section>
     @endif
-
-    {{-- About --}}
-    <section class="bg-white/[0.02] border-y border-white/5 py-10 sm:py-16">
-        <div class="max-w-2xl mx-auto px-4 text-center">
-            <h2 class="text-2xl font-bold text-white mb-3">About MoviePickr</h2>
-            <div class="section-divider mb-6"></div>
-            <p class="text-gray-400 leading-relaxed mb-8">
-                Sometimes the best movie is one you never would have chosen yourself.
-                Tell MoviePickr what you're in the mood for and it'll find something worth watching.
-                Filter by genre, decade, streaming service, or cast, or skip the filters entirely and let it surprise you.
-            </p>
-            <div class="flex flex-col sm:flex-row gap-3 justify-center items-stretch sm:items-center">
-                <a href="/movie?i=new" class="btn-accent long-single text-center">Random Movie</a>
-                <a href="/criteria" class="btn-secondary text-center">Set Preferences</a>
-            </div>
-        </div>
-    </section>
 
 
     <script>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -372,7 +372,7 @@
             <a href="/roulettes" class="btn-secondary text-sm px-4 py-2 flex-shrink-0">Browse all roulettes →</a>
         </div>
         <div class="section-divider mb-5"></div>
-        <div class="flex gap-3 overflow-x-auto pb-2">
+        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
             @foreach($featuredRoulettes as $roulette)
                 @php
                     $tags     = $roulette->tags;

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -1,4 +1,4 @@
-<div class="flex gap-3 overflow-x-auto pb-2 carousel-row {{ $name ?? '' }}">
+<div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide carousel-row {{ $name ?? '' }}">
     @foreach ($allMovies['results'] as $result)
         @php
             $date  = $result['release_date'] ?? $result['first_air_date'] ?? null;

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -18,7 +18,7 @@
             <div class="p-5 pb-4 flex flex-col">
 
                 <div class="mb-2">
-                    <h2 class="text-lg font-bold text-white">Adjust Criteria</h2>
+                    <h2 class="text-lg font-bold text-white">Adjust Filters</h2>
                     <p class="text-xs text-gray-500 mt-0.5">Tap a section to expand. Leave anything blank to ignore it.</p>
                 </div>
 

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -1,7 +1,7 @@
 @foreach ($grouped as $groupName => $roulettes)
     <div class="mb-10">
         <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">{{ $groupName }}</h2>
-        <div class="flex gap-3 overflow-x-auto pb-2 roulette-row">
+        <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide roulette-row">
             @foreach ($roulettes as $roulette)
                 @php
                     $tags     = $roulette->tags;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -232,17 +232,19 @@
 
     @unless(View::hasSection('hide_footer'))
     <footer class="border-t border-white/5 mt-8 pt-6 @yield('footer_pb', 'pb-6') text-center text-xs text-gray-600">
-        © Martynas Jankauskas {{ date('Y') }}
-        <div class="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
+        <p>© Martynas Jankauskas {{ date('Y') }}</p>
+        <div class="mt-2 flex items-center justify-center gap-3">
             <a href="https://www.themoviedb.org" target="_blank" class="flex items-center gap-1.5 hover:opacity-80 transition-opacity">
                 <img src="https://www.themoviedb.org/assets/2/v4/logos/v2/blue_short-8e7b30f73a4020692ccca9c88bafe5dcb6f8a62a4c6bc55cd9ba82bb2cd95f6c.svg" alt="TMDB" class="h-3">
             </a>
-            <span class="text-gray-700">This product uses the TMDB API but is not endorsed or certified by TMDB.</span>
-            <span class="text-gray-700">Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.</span>
-            <span class="text-gray-700">Ratings data by <a href="https://www.omdbapi.com" target="_blank" class="hover:text-gray-500 transition-colors">OMDb</a>.</span>
             <a href="{{ route('privacy') }}" class="hover:text-gray-400 transition-colors">Privacy Policy</a>
             <button data-cc="show-preferencesModal" class="hover:text-gray-400 transition-colors">Cookie settings</button>
         </div>
+        <p class="hidden sm:block mt-2 text-gray-700">
+            This product uses the TMDB API but is not endorsed or certified by TMDB.
+            Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.
+            Ratings data by <a href="https://www.omdbapi.com" target="_blank" class="hover:text-gray-500 transition-colors">OMDb</a>.
+        </p>
     </footer>
     @endunless
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -130,7 +130,7 @@
                 <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
             </a>
             <a href="/criteria" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">
-                Movie Criteria
+                Movie Filters
             </a>
 
             {{-- TV Shows --}}
@@ -145,7 +145,7 @@
                 <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
             </a>
             <a href="/tv/criteria" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">
-                TV Criteria
+                TV Filters
             </a>
 
             {{-- Account --}}

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -3,12 +3,12 @@
 @section('og_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this movie picked by MoviePickr.', 200))
 @section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
-@section('footer_pb', 'pb-32')
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-20">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-4">
 
     @if (isset($trailer))
         @include('includes.trailer-modal')

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -364,7 +364,7 @@
             @if(request()->query('wl_status'))
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
             @else
-                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
+                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Filters</button>
                 <a href="/movie" class="btn-accent long-single text-center" data-roll="movie-criteria">Roll</a>
             @endif
         </div>

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -8,7 +8,7 @@
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-36 sm:pb-20">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-20">
 
     @if (isset($trailer))
         @include('includes.trailer-modal')

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -3,7 +3,7 @@
 @section('og_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this movie picked by MoviePickr.', 200))
 @section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection

--- a/resources/views/my-roulettes/index.blade.php
+++ b/resources/views/my-roulettes/index.blade.php
@@ -30,7 +30,7 @@
         <div class="mb-10">
             <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">{{ $groupName }}</h2>
 
-            <div class="flex gap-3 overflow-x-auto pb-2 roulette-row">
+            <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide roulette-row">
                 @foreach($roulettes as $roulette)
                     @php
                         $tags     = $roulette->tags;

--- a/resources/views/no-results.blade.php
+++ b/resources/views/no-results.blade.php
@@ -20,13 +20,13 @@
 
     <h1 class="text-2xl font-bold text-white mb-3">No results found</h1>
     <p class="text-gray-500 text-sm mb-10">
-        Nothing matched your current filters. Try adjusting your criteria, roll something completely random, or browse our curated roulettes.
+        Nothing matched your current filters. Try adjusting your filters, roll something completely random, or browse our curated roulettes.
     </p>
 
     <div class="flex flex-col gap-3">
 
         <button type="button" class="btn-accent py-3 js-criteria-btn" data-modal-open="modal-form">
-            Adjust Criteria
+            Adjust Filters
         </button>
 
         <a href="{{ $randomUrl }}" class="btn-secondary py-3 text-center">

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -18,7 +18,7 @@
             <div class="p-5 pb-4 flex flex-col">
 
                 <div class="mb-2">
-                    <h2 class="text-lg font-bold text-white">Adjust Criteria</h2>
+                    <h2 class="text-lg font-bold text-white">Adjust Filters</h2>
                     <p class="text-xs text-gray-500 mt-0.5">Tap a section to expand. Leave anything blank to ignore it.</p>
                 </div>
 

--- a/resources/views/tv/criteria.blade.php
+++ b/resources/views/tv/criteria.blade.php
@@ -9,7 +9,7 @@
 <div class="max-w-2xl mx-auto px-4 py-10 pb-24">
 
     <div class="mb-8">
-        <h1 class="text-3xl font-bold text-white">TV Show Criteria</h1>
+        <h1 class="text-3xl font-bold text-white">TV Show Filters</h1>
         <p class="text-gray-500 text-sm mt-1">Fill in what you want, leave the rest blank.</p>
     </div>
 

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -3,7 +3,7 @@
 @section('og_title', ($tmdbInfo->name ?? 'TV Show').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this TV show picked by MoviePickr.', 200))
 @section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
-@section('footer_pb', 'pb-24')
+@section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -3,12 +3,12 @@
 @section('og_title', ($tmdbInfo->name ?? 'TV Show').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this TV show picked by MoviePickr.', 200))
 @section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
-@section('footer_pb', 'pb-32')
+@section('footer_pb', 'pb-24')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-20">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-4">
 
     @if (isset($trailer))
         @include('includes.trailer-modal')

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -464,7 +464,7 @@
         {{-- Right actions --}}
         <div class="flex items-center gap-3">
             @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
-                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Criteria</button>
+                <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Filters</button>
             @endif
             @if(request()->query('wl_status'))
                 @php

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -8,7 +8,7 @@
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])
 @endsection
 @section('content')
-<div class="max-w-7xl mx-auto px-4 py-8 pb-36 sm:pb-20">
+<div class="max-w-7xl mx-auto px-4 py-8 pb-20">
 
     @if (isset($trailer))
         @include('includes.trailer-modal')


### PR DESCRIPTION
## Summary
- Replace all user-facing "Criteria" text with "Filters" for consistency (buttons, headings, modals, error pages, mobile nav)
- Disable page scroll during roulette animation overlay, restore on Escape or when navigation fires
- Swap About and Curated Roulettes order on homepage (About first, better for first-time visitors)
- Fix hero background poster grid on mobile — 3 columns instead of 4, hide images 6–11 so each poster is wider and less squished
- Fix excessive bottom gap on movie and TV show detail pages (pb-36 → pb-4)
- Improve footer mobile layout — clean two-row structure, hide long attribution text on small screens
- Hide scrollbars on all horizontal carousels and roulette rows (still scrollable, just no visible bar)