### PR TITLE
UI fixes — roulette pills, mobile footer, filters modal padding

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -352,10 +352,17 @@ html[data-theme="light"] {
         border-radius: 1rem;
         width: 100%;
         max-width: 680px;
-        margin: 1rem;
-        max-height: 92vh;
+        margin: 0.5rem;
+        max-height: 96vh;
         overflow-y: auto;
+        overflow-x: hidden;
         box-shadow: 0 24px 80px rgba(0,0,0,0.7);
+    }
+    @media (min-width: 640px) {
+        .modal-box {
+            margin: 1rem;
+            max-height: 92vh;
+        }
     }
     .modal-close {
         position: absolute;

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -15,7 +15,7 @@
 
         <form method="POST" autocomplete="off" action="/movie?a=true" id="modal-criteria">
             @csrf
-            <div class="p-5 pb-4 flex flex-col">
+            <div class="p-3 sm:p-5 pb-4 flex flex-col">
 
                 <div class="mb-2">
                     <h2 class="text-lg font-bold text-white">Adjust Filters</h2>

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -37,13 +37,6 @@
                         @endif
 
                         <div class="absolute bottom-0 left-0 right-0 p-3">
-                            @if($allTags->isNotEmpty())
-                                <div class="flex gap-1 mb-1.5 flex-wrap">
-                                    @foreach($allTags as $tag)
-                                        <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/10 text-gray-400 border border-white/10">{{ $tag }}</span>
-                                    @endforeach
-                                </div>
-                            @endif
                             <h3 class="text-sm font-semibold text-white leading-snug">{{ $roulette->name }}</h3>
                             <span class="text-xs text-accent font-medium mt-1 block group-hover:underline">Batch →</span>
                         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -240,10 +240,10 @@
             <a href="{{ route('privacy') }}" class="hover:text-gray-400 transition-colors">Privacy Policy</a>
             <button data-cc="show-preferencesModal" class="hover:text-gray-400 transition-colors">Cookie settings</button>
         </div>
-        <p class="hidden sm:block mt-2 text-gray-700">
-            This product uses the TMDB API but is not endorsed or certified by TMDB.
-            Watch provider data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.
-            Ratings data by <a href="https://www.omdbapi.com" target="_blank" class="hover:text-gray-500 transition-colors">OMDb</a>.
+        <p class="mt-2 text-gray-700 leading-relaxed max-w-sm mx-auto sm:max-w-none">
+            Not endorsed by TMDB.
+            Streaming data by <a href="https://www.justwatch.com" target="_blank" class="hover:text-gray-500 transition-colors">JustWatch</a>.
+            Ratings by <a href="https://www.omdbapi.com" target="_blank" class="hover:text-gray-500 transition-colors">OMDb</a>.
         </p>
     </footer>
     @endunless

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -15,7 +15,7 @@
 
         <form method="POST" autocomplete="off" action="/tv/pick?a=true" id="modal-criteria">
             @csrf
-            <div class="p-5 pb-4 flex flex-col">
+            <div class="p-3 sm:p-5 pb-4 flex flex-col">
 
                 <div class="mb-2">
                     <h2 class="text-lg font-bold text-white">Adjust Filters</h2>


### PR DESCRIPTION
## Summary
- Remove tag pills (genre/language/decade) from roulette cards — cards look cleaner
- Show all footer attribution text on mobile — shortened copy, centred, wraps cleanly
- Fix filters modal on mobile — smaller margin (0.5rem), responsive inner padding (p-3 on mobile, p-5 on desktop), overflow-x hidden to prevent content escape