### PR TITLE
Fix mobile filters modal: clipping, iOS scroll-through, compact layout

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -221,6 +221,9 @@ html[data-theme="light"] {
         transition: border-color 0.2s, box-shadow 0.2s;
         outline: none;
     }
+    @media (max-width: 639px) {
+        .modal-box .input-dark { padding-top: 0.4rem; padding-bottom: 0.4rem; font-size: 0.8125rem; }
+    }
     .input-dark::placeholder { color: var(--text-faint); }
     .input-dark:focus {
         border-color: rgba(192,57,58,0.5);
@@ -336,6 +339,8 @@ html[data-theme="light"] {
         display: flex;
         align-items: center;
         justify-content: center;
+        padding: max(0.5rem, env(safe-area-inset-top)) max(0.5rem, env(safe-area-inset-right)) max(0.5rem, env(safe-area-inset-bottom)) max(0.5rem, env(safe-area-inset-left));
+        box-sizing: border-box;
     }
     .modal-wrap.hidden { display: none !important; }
     .modal-backdrop {
@@ -352,15 +357,18 @@ html[data-theme="light"] {
         border-radius: 1rem;
         width: 100%;
         max-width: 680px;
-        margin: 0.5rem;
-        max-height: 96vh;
+        margin: 0;
+        max-height: 100%;
         overflow-y: auto;
         overflow-x: hidden;
+        overscroll-behavior: contain;
         box-shadow: 0 24px 80px rgba(0,0,0,0.7);
     }
     @media (min-width: 640px) {
+        .modal-wrap {
+            padding: 1rem;
+        }
         .modal-box {
-            margin: 1rem;
             max-height: 92vh;
         }
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -38,10 +38,26 @@ $(document).ready(function () {
     });
 
     /* ── Custom modals ─────────────────────────────────────────────────── */
+    let _modalScrollY = 0;
+    function lockBodyScroll() {
+        _modalScrollY = window.scrollY;
+        document.body.style.overflow = 'hidden';
+        document.body.style.position = 'fixed';
+        document.body.style.top = '-' + _modalScrollY + 'px';
+        document.body.style.width = '100%';
+    }
+    function unlockBodyScroll() {
+        document.body.style.overflow = '';
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.width = '';
+        window.scrollTo(0, _modalScrollY);
+    }
+
     $(document).on('click', '[data-modal-open]', function () {
         const id = $(this).data('modal-open');
         $('#' + id).removeClass('hidden');
-        $('body').css('overflow', 'hidden');
+        lockBodyScroll();
         if (id === 'trailer-modal' && typeof gtag !== 'undefined') {
             gtag('event', 'trailer_opened');
         }
@@ -49,13 +65,13 @@ $(document).ready(function () {
 
     $(document).on('click', '[data-modal-close], .modal-backdrop', function () {
         $(this).closest('.modal-wrap').addClass('hidden');
-        $('body').css('overflow', '');
+        unlockBodyScroll();
     });
 
     $(document).on('keydown', function (e) {
         if (e.key === 'Escape') {
             $('.modal-wrap').addClass('hidden');
-            $('body').css('overflow', '');
+            unlockBodyScroll();
             stopTrailer();
         }
     });
@@ -68,7 +84,7 @@ $(document).ready(function () {
     $(document).on('click', '#trailer-modal-close, #trailer-modal .modal-backdrop', function () {
         stopTrailer();
         $('#trailer-modal').addClass('hidden');
-        $('body').css('overflow', '');
+        unlockBodyScroll();
     });
 
     /* ── Progress bar ───────────────────────────────────────────────────── */

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -24,7 +24,7 @@
 
                 {{-- Years --}}
                 <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Release Year</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -44,7 +44,7 @@
 
                 {{-- Genres --}}
                 <div class="accordion-section border-t border-white/5 {{ $openGenres ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Genres</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -78,7 +78,7 @@
 
                 {{-- Language & Country --}}
                 <div class="accordion-section border-t border-white/5 {{ $openLanguage ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language & Country</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -98,7 +98,7 @@
 
                 {{-- Streaming --}}
                 <div class="accordion-section border-t border-white/5 {{ $openStreaming ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Streaming</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -119,7 +119,7 @@
 
                 {{-- People --}}
                 <div class="accordion-section border-t border-white/5 {{ $openPeople ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">People</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -141,7 +141,7 @@
 
                 {{-- Scores --}}
                 <div class="accordion-section border-t border-white/5 {{ $openScores ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Scores</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -24,7 +24,7 @@
 
                 {{-- First Air Date --}}
                 <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">First Air Date</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -44,7 +44,7 @@
 
                 {{-- Genres --}}
                 <div class="accordion-section border-t border-white/5 {{ $openGenres ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Genres</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -78,7 +78,7 @@
 
                 {{-- Language & Country --}}
                 <div class="accordion-section border-t border-white/5 {{ $openLanguage ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Language & Country</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -98,7 +98,7 @@
 
                 {{-- Streaming --}}
                 <div class="accordion-section border-t border-white/5 {{ $openStreaming ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Streaming</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -119,7 +119,7 @@
 
                 {{-- People --}}
                 <div class="accordion-section border-t border-white/5 {{ $openPeople ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">People</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
@@ -147,7 +147,7 @@
 
                 {{-- Scores --}}
                 <div class="accordion-section border-t border-white/5 {{ $openScores ? 'accordion-open' : '' }}">
-                    <button type="button" class="accordion-header w-full flex items-center justify-between py-3.5 text-left">
+                    <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
                         <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Scores</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>


### PR DESCRIPTION
## Summary
- Fix iOS Safari background page scroll while modal is open — `overflow:hidden` on body doesn't work on Safari; replaced with `position:fixed` + saved scroll position pattern
- Fix modal content clipped under notch/home bar — replaced `96vh` height with safe-area-aware padding on the modal wrapper using `env(safe-area-inset-*)` with `max()` fallback
- Compact the filters modal on mobile — accordion headers use less vertical padding (`py-2.5` on mobile, `py-3.5` on sm+), and inputs inside the modal get slightly reduced padding/font size

## Test plan
- [x] Open filters modal on iPhone Safari — modal should not clip under status bar or home indicator at top/bottom
- [x] Scroll the page while modal is open — background should not scroll
- [x] Close modal — page should return to original scroll position
- [x] Check desktop — modal sizing and input appearance unchanged