### PR TITLE
Prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -222,7 +222,7 @@ html[data-theme="light"] {
         outline: none;
     }
     @media (max-width: 639px) {
-        .modal-box .input-dark { padding-top: 0.4rem; padding-bottom: 0.4rem; font-size: 0.8125rem; }
+        .modal-box .input-dark { padding-top: 0.4rem; padding-bottom: 0.4rem; }
     }
     .input-dark::placeholder { color: var(--text-faint); }
     .input-dark:focus {
@@ -638,3 +638,8 @@ html[data-theme="light"] .bg-white\/\[0\.02\] { background-color: rgba(0,0,0,0.0
     --cc-webkit-scrollbar-hover-bg: rgba(255,255,255,0.1);
 }
 html[data-theme="light"] .bg-white\/\[0\.03\] { background-color: rgba(0,0,0,0.03) !important; }
+
+/* Prevent iOS Safari auto-zoom on input focus */
+@media (max-width: 639px) {
+    input, select, textarea, .ts-control input { font-size: 16px !important; }
+}


### PR DESCRIPTION
## Summary
- iOS Safari auto-zooms when an input is focused with `font-size < 16px` — sets all `input`, `select`, `textarea`, and TomSelect inner inputs to `16px` on mobile (`max-width: 639px`)
- Also removes the `0.8125rem` (13px) modal input override introduced in the previous fix, which was making the zoom worse

## Test plan
- [x] Tap any input on iPhone Safari — no zoom should occur
- [x] Check filters modal inputs, TomSelect dropdowns, search inputs
- [x] Verify desktop appearance is unchanged