### PR TITLE
Improve filters modal UX: sticky header/footer, fix reset button

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -372,6 +372,41 @@ html[data-theme="light"] {
             max-height: 92vh;
         }
     }
+    .modal-sticky-header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: var(--bg-modal);
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.875rem 1rem;
+        border-bottom: 1px solid var(--border);
+    }
+    .modal-sticky-header .modal-close {
+        position: static;
+        flex-shrink: 0;
+        margin-top: 0.125rem;
+    }
+    @media (min-width: 640px) {
+        .modal-sticky-header { padding: 1rem 1.25rem; }
+    }
+    .modal-sticky-footer {
+        position: sticky;
+        bottom: 0;
+        z-index: 10;
+        background: var(--bg-modal);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        border-top: 1px solid var(--border);
+    }
+    @media (min-width: 640px) {
+        .modal-sticky-footer { padding: 1rem 1.25rem; }
+    }
     .modal-close {
         position: absolute;
         top: 1rem;

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -10,6 +10,7 @@ $(document).ready(function () {
 
         // Prevent double initialization
         if (el.tomselect) {
+            window['_ts_' + id] = el.tomselect;
             return el.tomselect;
         }
 

--- a/resources/js/custom/criteriaForm.js
+++ b/resources/js/custom/criteriaForm.js
@@ -141,7 +141,7 @@ $(document).ready(function () {
     /* ── Reset ──────────────────────────────────────────────────── */
     function resetForm(formId, prefix) {
         const $form = $(formId);
-        $form.find('.bg-input').val('');
+        $form.find('.input-dark').val('');
         ['with_genres', 'without_genres', 'with_watch_providers', 'with_cast', 'with_crew'].forEach(function (key) {
             const ts = window['_ts_' + prefix + key];
             if (ts) ts.clear(true);

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -11,16 +11,17 @@
 <div id="modal-form" class="modal-wrap hidden">
     <div class="modal-backdrop" data-modal-close></div>
     <div class="modal-box">
-        <button class="modal-close" data-modal-close aria-label="Close">✕</button>
-
         <form method="POST" autocomplete="off" action="/movie?a=true" id="modal-criteria">
             @csrf
-            <div class="p-3 sm:p-5 pb-4 flex flex-col">
-
-                <div class="mb-2">
+            <div class="modal-sticky-header">
+                <div>
                     <h2 class="text-lg font-bold text-white">Adjust Filters</h2>
                     <p class="text-xs text-gray-500 mt-0.5">Tap a section to expand. Leave anything blank to ignore it.</p>
                 </div>
+                <button type="button" class="modal-close" data-modal-close aria-label="Close">✕</button>
+            </div>
+
+            <div class="px-3 sm:px-5 flex flex-col">
 
                 {{-- Years --}}
                 <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
@@ -167,16 +168,17 @@
 
                 @include('errors.error')
 
-                {{-- Actions --}}
-                <div class="flex items-center justify-between gap-2 pt-4 border-t border-white/5">
-                    <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
-                    <div class="flex gap-2">
-                        <button type="submit" class="btn-secondary text-sm long-single" formaction="/multiple?a=true">Multiple</button>
-                        <button type="submit" class="btn-accent text-sm long-single" formaction="/movie?a=true">Find Movie</button>
-                    </div>
-                </div>
-
             </div>
+
+            {{-- Actions --}}
+            <div class="modal-sticky-footer">
+                <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                <div class="flex gap-2">
+                    <button type="submit" class="btn-secondary text-sm long-single" formaction="/multiple?a=true">Multiple</button>
+                    <button type="submit" class="btn-accent text-sm long-single" formaction="/movie?a=true">Find Movie</button>
+                </div>
+            </div>
+
         </form>
     </div>
 </div>

--- a/resources/views/tv/criteria-modal.blade.php
+++ b/resources/views/tv/criteria-modal.blade.php
@@ -11,16 +11,17 @@
 <div id="modal-form" class="modal-wrap hidden">
     <div class="modal-backdrop" data-modal-close></div>
     <div class="modal-box">
-        <button class="modal-close" data-modal-close aria-label="Close">✕</button>
-
         <form method="POST" autocomplete="off" action="/tv/pick?a=true" id="modal-criteria">
             @csrf
-            <div class="p-3 sm:p-5 pb-4 flex flex-col">
-
-                <div class="mb-2">
+            <div class="modal-sticky-header">
+                <div>
                     <h2 class="text-lg font-bold text-white">Adjust Filters</h2>
                     <p class="text-xs text-gray-500 mt-0.5">Tap a section to expand. Leave anything blank to ignore it.</p>
                 </div>
+                <button type="button" class="modal-close" data-modal-close aria-label="Close">✕</button>
+            </div>
+
+            <div class="px-3 sm:px-5 flex flex-col">
 
                 {{-- First Air Date --}}
                 <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
@@ -173,16 +174,17 @@
 
                 @include('errors.error')
 
-                {{-- Actions --}}
-                <div class="flex items-center justify-between gap-2 pt-4 border-t border-white/5">
-                    <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
-                    <div class="flex gap-2">
-                        <button type="submit" class="btn-secondary text-sm long-single" formaction="/tv/multiple?a=true">Multiple</button>
-                        <button type="submit" class="btn-accent text-sm long-single" formaction="/tv/pick?a=true">Find Show</button>
-                    </div>
-                </div>
-
             </div>
+
+            {{-- Actions --}}
+            <div class="modal-sticky-footer">
+                <button type="button" id="modal-btn-reset" class="btn-secondary text-sm">Reset</button>
+                <div class="flex gap-2">
+                    <button type="submit" class="btn-secondary text-sm long-single" formaction="/tv/multiple?a=true">Multiple</button>
+                    <button type="submit" class="btn-accent text-sm long-single" formaction="/tv/pick?a=true">Find Show</button>
+                </div>
+            </div>
+
         </form>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Sticky header — title and close button stay pinned at the top while scrolling, so the modal is always easy to dismiss
- Sticky footer — Reset/Multiple/Find buttons stay pinned at the bottom, no need to scroll to submit
- Fix reset button — was targeting `.bg-input` which doesn't exist; inputs use `.input-dark`, so year, score and vote count fields were never being cleared

## Test plan
- [x] Open filters modal, scroll down — close button should remain visible at top
- [x] Scroll down — action buttons should remain visible at bottom
- [x] Set some filters, hit Reset — all fields including year and score inputs should clear
- [x] Verify light mode looks correct