### PR TITLE
Add TMDB request logging and admin stats dashboard

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -50,6 +51,14 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
+        if ($exception instanceof ThrottleRequestsException) {
+            if ($request->wantsJson() || $request->ajax()) {
+                return response()->json(['error' => 'Rolling too fast — slow down a bit and try again.'], 429);
+            }
+            $destination = str_contains($request->path(), 'tv') ? '/tv/criteria' : '/criteria';
+            return redirect($destination)->with('error', 'You\'re rolling too fast — wait a moment and try again.');
+        }
+
         return parent::render($request, $exception);
     }
 }

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Roulette;
 use App\Models\Setting;
+use App\Models\TmdbRequestLog;
 
 class AdminController extends Controller
 {
@@ -17,8 +18,76 @@ class AdminController extends Controller
             'community' => Roulette::where('is_system', false)->count(),
         ];
 
-        $rowOrder = Setting::get('roulette_row_order', []);
+        $rowOrder   = Setting::get('roulette_row_order', []);
+        $activeTab  = request('tab', 'overview');
+        $tmdb       = [];
 
-        return view('admin.dashboard', compact('stats', 'rowOrder'));
+        if ($activeTab === 'tmdb') {
+            $today     = now()->toDateString();
+            $sevenDays = now()->subDays(6)->startOfDay();
+
+            $tmdb['today'] = TmdbRequestLog::selectRaw('
+                COUNT(*) as total,
+                SUM(CASE WHEN cached = 0 THEN 1 ELSE 0 END) as live,
+                SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) as hits,
+                AVG(CASE WHEN cached = 0 THEN response_time_ms ELSE NULL END) as avg_ms,
+                SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END) as rate_limited
+            ')->whereDate('created_at', $today)->first();
+
+            // Short-window live request counts for rate limit monitoring
+            $tmdb['last_60s']  = TmdbRequestLog::where('cached', false)
+                ->where('created_at', '>=', now()->subSeconds(60))->count();
+
+            $tmdb['last_5min'] = TmdbRequestLog::where('cached', false)
+                ->where('created_at', '>=', now()->subMinutes(5))->count();
+
+            // Current avg req/sec (live only, over last 60s) vs TMDB limit of 40/s
+            $tmdb['req_per_sec']    = round($tmdb['last_60s'] / 60, 2);
+            $tmdb['rate_limit_max'] = 40;
+            $tmdb['rate_pct']       = min(100, round(($tmdb['req_per_sec'] / 40) * 100));
+
+            // Per-minute breakdown for last 30 minutes (live requests only)
+            $tmdb['per_minute'] = TmdbRequestLog::selectRaw("
+                DATE_FORMAT(created_at, '%H:%i') as minute,
+                COUNT(*) as live
+            ")->where('cached', false)
+              ->where('created_at', '>=', now()->subMinutes(30))
+              ->groupByRaw("DATE_FORMAT(created_at, '%H:%i')")
+              ->orderByDesc('minute')
+              ->get();
+
+            // Peak req/sec in last 30 min (max live requests in any single minute / 60)
+            $tmdb['peak_req_per_sec'] = $tmdb['per_minute']->max('live')
+                ? round($tmdb['per_minute']->max('live') / 60, 2)
+                : 0;
+
+            $tmdb['by_endpoint'] = TmdbRequestLog::selectRaw('
+                endpoint,
+                COUNT(*) as total,
+                SUM(CASE WHEN cached = 0 THEN 1 ELSE 0 END) as live,
+                SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) as hits,
+                AVG(CASE WHEN cached = 0 THEN response_time_ms ELSE NULL END) as avg_ms
+            ')->whereDate('created_at', $today)
+              ->groupBy('endpoint')
+              ->orderByDesc('total')
+              ->get();
+
+            $tmdb['daily'] = TmdbRequestLog::selectRaw('
+                DATE(created_at) as date,
+                COUNT(*) as total,
+                SUM(CASE WHEN cached = 0 THEN 1 ELSE 0 END) as live,
+                SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) as hits
+            ')->where('created_at', '>=', $sevenDays)
+              ->groupByRaw('DATE(created_at)')
+              ->orderByDesc('date')
+              ->get();
+
+            $tmdb['recent'] = TmdbRequestLog::with('user')
+                ->orderByDesc('id')
+                ->limit(50)
+                ->get();
+        }
+
+        return view('admin.dashboard', compact('stats', 'rowOrder', 'activeTab', 'tmdb'));
     }
 }

--- a/app/Models/TmdbRequestLog.php
+++ b/app/Models/TmdbRequestLog.php
@@ -10,6 +10,7 @@ class TmdbRequestLog extends Model
 
     protected $fillable = [
         'endpoint',
+        'route',
         'cached',
         'status_code',
         'response_time_ms',

--- a/app/Models/TmdbRequestLog.php
+++ b/app/Models/TmdbRequestLog.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TmdbRequestLog extends Model
+{
+    const UPDATED_AT = null;
+
+    protected $fillable = [
+        'endpoint',
+        'cached',
+        'status_code',
+        'response_time_ms',
+        'user_id',
+        'visitor_hash',
+    ];
+
+    protected $casts = [
+        'cached' => 'boolean',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -447,6 +447,7 @@ class TmdbClient implements ApiMovie
         try {
             TmdbRequestLog::create([
                 'endpoint'         => $endpoint,
+                'route'            => $this->currentRoute(),
                 'cached'           => $cached,
                 'status_code'      => $statusCode,
                 'response_time_ms' => $ms,
@@ -455,6 +456,16 @@ class TmdbClient implements ApiMovie
             ]);
         } catch (\Throwable) {
             // Never let logging break a request
+        }
+    }
+
+    private function currentRoute(): string
+    {
+        try {
+            $req = request();
+            return strtoupper($req->method()) . ' /' . ltrim($req->path(), '/');
+        } catch (\Throwable) {
+            return '';
         }
     }
 

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -3,8 +3,10 @@
 namespace App\Services;
 
 use App\Interfaces\MovieApiInterface as ApiMovie;
+use App\Models\TmdbRequestLog;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Cache;
 
 class TmdbClient implements ApiMovie
@@ -84,9 +86,8 @@ class TmdbClient implements ApiMovie
             $input['watch_region'] = $country;
         }
 
-        $response = $this->client->get('https://api.themoviedb.org/3/discover/movie?' . http_build_query($input));
-
-        return json_decode($response->getBody()->getContents(), true);
+        $url = 'https://api.themoviedb.org/3/discover/movie?' . http_build_query($input);
+        return json_decode($this->fetch($url, 'discover_movie'), true);
     }
 
     /**
@@ -95,12 +96,10 @@ class TmdbClient implements ApiMovie
      */
     public function movie($movieId): object
     {
-        return Cache::remember('tmdb_movie_' . $movieId, now()->addHours(6), function () use ($movieId) {
+        return $this->cached('tmdb_movie_' . $movieId, now()->addHours(6), 'movie_detail', function () use ($movieId) {
             $url = 'https://api.themoviedb.org/3/movie/' . $movieId . '?'
                 . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,keywords,watch/providers']);
-
-            $response = $this->client->get($url);
-            return json_decode($response->getBody()->getContents());
+            return json_decode($this->fetch($url, 'movie_detail'));
         });
     }
 
@@ -119,8 +118,7 @@ class TmdbClient implements ApiMovie
         $url     = 'https://api.themoviedb.org/3/movie/' . $movieObj->id . '/similar?'
             . http_build_query(['language' => 'en-US', 'page' => rand(1, $maxPage)]);
 
-        $response = $this->client->get($url);
-        return json_decode($response->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'movie_similar'), true);
     }
 
     /**
@@ -133,9 +131,8 @@ class TmdbClient implements ApiMovie
             ? now('UTC')->diffInSeconds(\Carbon\Carbon::tomorrow('UTC'))
             : now('UTC')->diffInSeconds(\Carbon\Carbon::now('UTC')->startOfWeek(\Carbon\Carbon::MONDAY)->addWeek());
 
-        return Cache::remember("tmdb_trending_{$period}", $ttl, function () use ($period) {
-            $response = $this->client->get("https://api.themoviedb.org/3/trending/movie/{$period}");
-            return json_decode($response->getBody()->getContents(), true);
+        return $this->cached("tmdb_trending_{$period}", $ttl, 'trending_movie', function () use ($period) {
+            return json_decode($this->fetch("https://api.themoviedb.org/3/trending/movie/{$period}", 'trending_movie'), true);
         });
     }
 
@@ -146,9 +143,8 @@ class TmdbClient implements ApiMovie
             ? now('UTC')->diffInSeconds(\Carbon\Carbon::tomorrow('UTC'))
             : now('UTC')->diffInSeconds(\Carbon\Carbon::now('UTC')->startOfWeek(\Carbon\Carbon::MONDAY)->addWeek());
 
-        return Cache::remember("tmdb_trending_tv_{$period}", $ttl, function () use ($period) {
-            $response = $this->client->get("https://api.themoviedb.org/3/trending/tv/{$period}");
-            return json_decode($response->getBody()->getContents(), true);
+        return $this->cached("tmdb_trending_tv_{$period}", $ttl, 'trending_tv', function () use ($period) {
+            return json_decode($this->fetch("https://api.themoviedb.org/3/trending/tv/{$period}", 'trending_tv'), true);
         });
     }
 
@@ -160,7 +156,7 @@ class TmdbClient implements ApiMovie
             'page'          => 1,
             'include_adult' => 'false',
         ]);
-        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'search_movie'), true);
     }
 
     public function searchPeople(string $query): array
@@ -171,14 +167,14 @@ class TmdbClient implements ApiMovie
             'page'          => 1,
             'include_adult' => 'false',
         ]);
-        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'search_people'), true);
     }
 
     public function person(int $id): object
     {
-        return Cache::remember('tmdb_person_' . $id, now()->addHour(), function () use ($id) {
+        return $this->cached('tmdb_person_' . $id, now()->addHour(), 'person', function () use ($id) {
             $url = 'https://api.themoviedb.org/3/person/' . $id . '?' . http_build_query(['language' => 'en-US']);
-            return json_decode($this->client->get($url)->getBody()->getContents());
+            return json_decode($this->fetch($url, 'person'));
         });
     }
 
@@ -187,18 +183,18 @@ class TmdbClient implements ApiMovie
      */
     public function personDetail(int $id): object
     {
-        return Cache::remember('tmdb_person_detail_' . $id, now()->addHours(6), function () use ($id) {
+        return $this->cached('tmdb_person_detail_' . $id, now()->addHours(6), 'person_detail', function () use ($id) {
             $url = 'https://api.themoviedb.org/3/person/' . $id . '?'
                 . http_build_query(['language' => 'en-US', 'append_to_response' => 'combined_credits,images']);
-            return json_decode($this->client->get($url)->getBody()->getContents());
+            return json_decode($this->fetch($url, 'person_detail'));
         });
     }
 
     public function collection(int $id): object
     {
-        return Cache::remember('tmdb_collection_' . $id, now()->addWeek(), function () use ($id) {
+        return $this->cached('tmdb_collection_' . $id, now()->addWeek(), 'collection', function () use ($id) {
             $url = 'https://api.themoviedb.org/3/collection/' . $id . '?' . http_build_query(['language' => 'en-US']);
-            return json_decode($this->client->get($url)->getBody()->getContents());
+            return json_decode($this->fetch($url, 'collection'));
         });
     }
 
@@ -208,8 +204,7 @@ class TmdbClient implements ApiMovie
     public function genres(): string
     {
         $url = 'https://api.themoviedb.org/3/genre/movie/list?' . http_build_query(['language' => 'en-US']);
-        $response = $this->client->get($url);
-        return $response->getBody()->getContents();
+        return $this->fetch($url, 'genre_movie');
     }
 
     // ── TV Shows ─────────────────────────────────────────────────────────────
@@ -276,9 +271,8 @@ class TmdbClient implements ApiMovie
             $input['watch_region'] = $country;
         }
 
-        $response = $this->client->get('https://api.themoviedb.org/3/discover/tv?' . http_build_query($input));
-
-        return json_decode($response->getBody()->getContents(), true);
+        $url = 'https://api.themoviedb.org/3/discover/tv?' . http_build_query($input);
+        return json_decode($this->fetch($url, 'discover_tv'), true);
     }
 
     /**
@@ -286,9 +280,9 @@ class TmdbClient implements ApiMovie
      */
     public function tvStatus(int $id): array
     {
-        return Cache::remember('tmdb_tv_status_' . $id, now()->addHours(24), function () use ($id) {
+        return $this->cached('tmdb_tv_status_' . $id, now()->addHours(24), 'tv_status', function () use ($id) {
             $url  = 'https://api.themoviedb.org/3/tv/' . $id . '?' . http_build_query(['language' => 'en-US']);
-            $data = json_decode($this->client->get($url)->getBody()->getContents(), true);
+            $data = json_decode($this->fetch($url, 'tv_status'), true);
             return [
                 'status'        => $data['status'] ?? null,
                 'last_air_date' => $data['last_air_date'] ?? null,
@@ -301,10 +295,10 @@ class TmdbClient implements ApiMovie
      */
     public function tvEpisode(int $showId, int $seasonNumber, int $episodeNumber): object
     {
-        return Cache::remember("tmdb_tv_{$showId}_s{$seasonNumber}_e{$episodeNumber}", now()->addHours(6), function () use ($showId, $seasonNumber, $episodeNumber) {
+        return $this->cached("tmdb_tv_{$showId}_s{$seasonNumber}_e{$episodeNumber}", now()->addHours(6), 'tv_episode', function () use ($showId, $seasonNumber, $episodeNumber) {
             $url = "https://api.themoviedb.org/3/tv/{$showId}/season/{$seasonNumber}/episode/{$episodeNumber}?"
                 . http_build_query(['language' => 'en-US', 'append_to_response' => 'credits,images']);
-            return json_decode($this->client->get($url)->getBody()->getContents());
+            return json_decode($this->fetch($url, 'tv_episode'));
         });
     }
 
@@ -313,10 +307,10 @@ class TmdbClient implements ApiMovie
      */
     public function tvSeason(int $showId, int $seasonNumber): object
     {
-        return Cache::remember("tmdb_tv_{$showId}_season_{$seasonNumber}", now()->addHours(6), function () use ($showId, $seasonNumber) {
+        return $this->cached("tmdb_tv_{$showId}_season_{$seasonNumber}", now()->addHours(6), 'tv_season', function () use ($showId, $seasonNumber) {
             $url = "https://api.themoviedb.org/3/tv/{$showId}/season/{$seasonNumber}?"
                 . http_build_query(['language' => 'en-US', 'append_to_response' => 'credits']);
-            return json_decode($this->client->get($url)->getBody()->getContents());
+            return json_decode($this->fetch($url, 'tv_season'));
         });
     }
 
@@ -326,12 +320,10 @@ class TmdbClient implements ApiMovie
      */
     public function tvShow(int $id): object
     {
-        return Cache::remember('tmdb_tv_' . $id, now()->addHours(6), function () use ($id) {
+        return $this->cached('tmdb_tv_' . $id, now()->addHours(6), 'tv_detail', function () use ($id) {
             $url = 'https://api.themoviedb.org/3/tv/' . $id . '?'
                 . http_build_query(['append_to_response' => 'videos,credits,similar,recommendations,keywords,watch/providers,external_ids']);
-
-            $response = $this->client->get($url);
-            return json_decode($response->getBody()->getContents());
+            return json_decode($this->fetch($url, 'tv_detail'));
         });
     }
 
@@ -350,15 +342,14 @@ class TmdbClient implements ApiMovie
         $url     = 'https://api.themoviedb.org/3/tv/' . $showObj->id . '/similar?'
             . http_build_query(['language' => 'en-US', 'page' => rand(1, $maxPage)]);
 
-        $response = $this->client->get($url);
-        return json_decode($response->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'tv_similar'), true);
     }
 
     /** TV genre list — use MovieService::genres($tmdb, 'tv') which caches the result. */
     public function tvGenres(): string
     {
         $url = 'https://api.themoviedb.org/3/genre/tv/list?' . http_build_query(['language' => 'en-US']);
-        return $this->client->get($url)->getBody()->getContents();
+        return $this->fetch($url, 'genre_tv');
     }
 
     public function searchTv(string $query): array
@@ -369,7 +360,7 @@ class TmdbClient implements ApiMovie
             'page'          => 1,
             'include_adult' => 'false',
         ]);
-        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'search_tv'), true);
     }
 
     public function searchAll(string $query): array
@@ -379,7 +370,7 @@ class TmdbClient implements ApiMovie
             'language'      => 'en-US',
             'include_adult' => 'false',
         ]);
-        return json_decode($this->client->get($url)->getBody()->getContents(), true);
+        return json_decode($this->fetch($url, 'search_all'), true);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -409,5 +400,72 @@ class TmdbClient implements ApiMovie
     {
         $fields = ['popularity', 'first_air_date', 'vote_average', 'vote_count', 'name'];
         return $fields[array_rand($fields)] . (rand(0, 1) ? '.asc' : '.desc');
+    }
+
+    // ── Logging ──────────────────────────────────────────────────────────────
+
+    /**
+     * Make an HTTP GET request, log it, and return the response body string.
+     * Uses finally so the log is written even if the request throws.
+     */
+    private function fetch(string $url, string $endpoint): string
+    {
+        $start      = microtime(true);
+        $statusCode = 200;
+        try {
+            $response   = $this->client->get($url);
+            $statusCode = $response->getStatusCode();
+            return $response->getBody()->getContents();
+        } catch (RequestException $e) {
+            $statusCode = $e->hasResponse() ? $e->getResponse()->getStatusCode() : 0;
+            throw $e;
+        } finally {
+            $ms = (int) round((microtime(true) - $start) * 1000);
+            $this->log($endpoint, false, $statusCode, $ms);
+        }
+    }
+
+    /**
+     * Cache::remember wrapper that logs cache hits.
+     * Cache misses are logged inside the closure via fetch().
+     */
+    private function cached(string $key, mixed $ttl, string $endpoint, callable $fn): mixed
+    {
+        $called = false;
+        $result = Cache::remember($key, $ttl, function () use ($fn, &$called) {
+            $called = true;
+            return $fn();
+        });
+        if (!$called) {
+            $this->log($endpoint, true, null, null);
+        }
+        return $result;
+    }
+
+    private function log(string $endpoint, bool $cached, ?int $statusCode, ?int $ms): void
+    {
+        try {
+            TmdbRequestLog::create([
+                'endpoint'         => $endpoint,
+                'cached'           => $cached,
+                'status_code'      => $statusCode,
+                'response_time_ms' => $ms,
+                'user_id'          => auth()->id(),
+                'visitor_hash'     => $this->visitorHash(),
+            ]);
+        } catch (\Throwable) {
+            // Never let logging break a request
+        }
+    }
+
+    private function visitorHash(): string
+    {
+        try {
+            $ip = request()->ip() ?? '';
+            $ua = request()->userAgent() ?? '';
+            return substr(hash('sha256', $ip . $ua), 0, 16);
+        } catch (\Throwable) {
+            return '';
+        }
     }
 }

--- a/database/migrations/2026_05_29_090244_add_route_to_tmdb_request_logs_table.php
+++ b/database/migrations/2026_05_29_090244_add_route_to_tmdb_request_logs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->string('route', 60)->nullable()->after('endpoint');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->dropColumn('route');
+        });
+    }
+};

--- a/database/migrations/2026_05_29_100000_create_tmdb_request_logs_table.php
+++ b/database/migrations/2026_05_29_100000_create_tmdb_request_logs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tmdb_request_logs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('endpoint', 80);
+            $table->boolean('cached');
+            $table->smallInteger('status_code')->nullable();
+            $table->smallInteger('response_time_ms')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('visitor_hash', 16)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index('created_at');
+            $table->index(['created_at', 'endpoint']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tmdb_request_logs');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,13 @@
+window.showErrorToast = function (msg) {
+    const el = document.createElement('div');
+    el.className = 'fixed top-20 left-1/2 z-50 bg-red-900/80 border border-red-700/50 text-red-300 text-sm px-5 py-3 rounded-lg backdrop-blur-sm cursor-pointer whitespace-nowrap';
+    el.style.transform = 'translateX(-50%)';
+    el.textContent = msg;
+    el.onclick = () => el.remove();
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 5000);
+};
+
 $(document).ready(function () {
 
     /* ── Nav hamburger ─────────────────────────────────────────────────── */

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -142,13 +142,23 @@ document.addEventListener('submit', function (e) {
     const body = new FormData(form);
     if (btn) { btn.textContent = 'Loading…'; btn.disabled = true; }
 
-    fetch(endpoint, { method: 'POST', body })
-        .then(r => r.json())
+    fetch(endpoint, { method: 'POST', body, headers: { 'Accept': 'application/json' } })
+        .then(r => {
+            if (r.status === 429) throw { throttled: true };
+            return r.json();
+        })
         .then(movies => {
             if (btn) { btn.textContent = isMovie ? 'Find Movie' : 'Find Show'; btn.disabled = false; }
             if (!rollCards(toCards(movies))) window.location.href = fallback;
         })
-        .catch(() => { window.location.href = fallback; });
+        .catch(err => {
+            if (err && err.throttled) {
+                if (btn) { btn.textContent = isMovie ? 'Find Movie' : 'Find Show'; btn.disabled = false; }
+                window.showErrorToast('Rolling too fast — slow down a bit and try again.');
+                return;
+            }
+            window.location.href = fallback;
+        });
 });
 
 // ── Click delegation ──────────────────────────────────────────────────
@@ -180,8 +190,11 @@ document.addEventListener('click', function (e) {
         rouletteBtn.textContent = 'Loading…';
         rouletteBtn.disabled = true;
 
-        fetch(`/roulettes/${slug}/movies`)
-            .then(r => r.json())
+        fetch(`/roulettes/${slug}/movies`, { headers: { 'Accept': 'application/json' } })
+            .then(r => {
+                if (r.status === 429) throw { throttled: true };
+                return r.json();
+            })
             .then(movies => {
                 rouletteBtn.textContent = orig;
                 rouletteBtn.disabled = false;
@@ -189,7 +202,15 @@ document.addEventListener('click', function (e) {
                 if (typeof gtag !== 'undefined') gtag('event', 'roulette_rolled', { roulette_slug: slug });
                 if (!rollCards(toCards(movies))) window.location.href = `/roulettes/${slug}`;
             })
-            .catch(() => { window.location.href = `/roulettes/${slug}`; });
+            .catch(err => {
+                if (err && err.throttled) {
+                    rouletteBtn.textContent = orig;
+                    rouletteBtn.disabled = false;
+                    window.showErrorToast('Rolling too fast — slow down a bit and try again.');
+                    return;
+                }
+                window.location.href = `/roulettes/${slug}`;
+            });
         return;
     }
 
@@ -201,10 +222,16 @@ document.addEventListener('click', function (e) {
         const endpoint = isTv ? '/tv/roll/criteria' : '/movie/roll/criteria';
         const fallback = isTv ? '/tv/pick' : '/movie';
         setRollContext('batch', window.location.pathname + '?from=roll', '← Batch');
-        fetch(endpoint)
-            .then(r => r.json())
+        fetch(endpoint, { headers: { 'Accept': 'application/json' } })
+            .then(r => {
+                if (r.status === 429) throw { throttled: true };
+                return r.json();
+            })
             .then(movies => { if (!rollCards(toCards(movies))) window.location.href = fallback; })
-            .catch(() => { window.location.href = fallback; });
+            .catch(err => {
+                if (err && err.throttled) { window.showErrorToast('Rolling too fast — slow down a bit and try again.'); return; }
+                window.location.href = fallback;
+            });
         return;
     }
 
@@ -240,13 +267,23 @@ document.addEventListener('click', function (e) {
         const origText = link.textContent;
         link.textContent = 'Loading…';
 
-        fetch(jsonUrl)
-            .then(r => r.json())
+        fetch(jsonUrl, { headers: { 'Accept': 'application/json' } })
+            .then(r => {
+                if (r.status === 429) throw { throttled: true };
+                return r.json();
+            })
             .then(movies => {
                 link.textContent = origText;
                 if (!rollCards(toCards(movies))) window.location.href = fallback;
             })
-            .catch(() => { window.location.href = fallback; });
+            .catch(err => {
+                if (err && err.throttled) {
+                    link.textContent = origText;
+                    window.showErrorToast('Rolling too fast — slow down a bit and try again.');
+                    return;
+                }
+                window.location.href = fallback;
+            });
         return;
     }
 });

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -10,56 +10,356 @@
 
     @include('admin._nav')
 
-    {{-- Stats --}}
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
-            <div class="text-3xl font-bold text-white mb-1">{{ $stats['total'] }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-widest">Total Roulettes</div>
-        </div>
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
-            <div class="text-3xl font-bold text-accent mb-1">{{ $stats['public'] }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-widest">Public</div>
-        </div>
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
-            <div class="text-3xl font-bold text-blue-400 mb-1">{{ $stats['system'] }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-widest">System</div>
-        </div>
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
-            <div class="text-3xl font-bold text-purple-400 mb-1">{{ $stats['community'] }}</div>
-            <div class="text-xs text-gray-500 uppercase tracking-widest">Community</div>
-        </div>
+    {{-- Tabs --}}
+    <div class="flex gap-1 mb-8 border-b border-white/5 pb-0">
+        <a href="{{ route('admin.dashboard') }}"
+           class="px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors -mb-px
+                  {{ $activeTab === 'overview' ? 'border-accent text-white' : 'border-transparent text-gray-500 hover:text-white' }}">
+            Overview
+        </a>
+        <a href="{{ route('admin.dashboard', ['tab' => 'tmdb']) }}"
+           class="px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors -mb-px
+                  {{ $activeTab === 'tmdb' ? 'border-accent text-white' : 'border-transparent text-gray-500 hover:text-white' }}">
+            TMDB
+        </a>
     </div>
 
-    {{-- Quick links --}}
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <a href="{{ route('admin.roulettes.index') }}"
-           class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
-            <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">Manage Roulettes →</div>
-            <div class="text-sm text-gray-500">Edit, reorder, publish or hide roulettes by group.</div>
-        </a>
-        <a href="{{ route('admin.rows.index') }}"
-           class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
-            <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">Row Order →</div>
-            <div class="text-sm text-gray-500">Drag to reorder how rows appear on the /roulettes page.</div>
-            @if(count($rowOrder))
-            <div class="mt-3 flex flex-wrap gap-1">
-                @foreach($rowOrder as $row)
-                    <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">{{ $row }}</span>
+    @if($activeTab === 'overview')
+
+        {{-- Stats --}}
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
+            <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+                <div class="text-3xl font-bold text-white mb-1">{{ $stats['total'] }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Total Roulettes</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+                <div class="text-3xl font-bold text-accent mb-1">{{ $stats['public'] }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Public</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+                <div class="text-3xl font-bold text-blue-400 mb-1">{{ $stats['system'] }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">System</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+                <div class="text-3xl font-bold text-purple-400 mb-1">{{ $stats['community'] }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Community</div>
+            </div>
+        </div>
+
+        {{-- Quick links --}}
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <a href="{{ route('admin.roulettes.index') }}"
+               class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
+                <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">Manage Roulettes →</div>
+                <div class="text-sm text-gray-500">Edit, reorder, publish or hide roulettes by group.</div>
+            </a>
+            <a href="{{ route('admin.rows.index') }}"
+               class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
+                <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">Row Order →</div>
+                <div class="text-sm text-gray-500">Drag to reorder how rows appear on the /roulettes page.</div>
+                @if(count($rowOrder))
+                <div class="mt-3 flex flex-wrap gap-1">
+                    @foreach($rowOrder as $row)
+                        <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">{{ $row }}</span>
+                    @endforeach
+                </div>
+                @endif
+            </a>
+            <a href="{{ route('admin.roulettes.create') }}"
+               class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
+                <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">+ New Roulette →</div>
+                <div class="text-sm text-gray-500">Create a new curated collection.</div>
+            </a>
+            <a href="/roulettes" target="_blank"
+               class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
+                <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">View /roulettes ↗</div>
+                <div class="text-sm text-gray-500">See the public-facing roulettes page.</div>
+            </a>
+        </div>
+
+    @else
+
+        @php
+            $today   = $tmdb['today'];
+            $hitRate = $today->total > 0 ? round(($today->hits / $today->total) * 100) : 0;
+            $rps     = $tmdb['req_per_sec'];
+            $pct     = $tmdb['rate_pct'];
+            $barColor = $pct >= 75 ? '#ef4444' : ($pct >= 40 ? '#f59e0b' : '#22c55e');
+            $labelColor = $pct >= 75 ? 'text-red-400' : ($pct >= 40 ? 'text-yellow-400' : 'text-green-400');
+            $status = $pct >= 75 ? 'High' : ($pct >= 40 ? 'Moderate' : 'Safe');
+        @endphp
+
+        {{-- 429 warning --}}
+        @if($today->rate_limited > 0)
+        <div class="mb-6 flex items-center gap-3 bg-red-500/10 border border-red-500/30 rounded-xl px-5 py-4">
+            <span class="text-red-400 text-xl">⚠</span>
+            <div>
+                <div class="text-sm font-semibold text-red-400">Rate limit hit today</div>
+                <div class="text-xs text-red-400/70 mt-0.5">{{ $today->rate_limited }} request{{ $today->rate_limited > 1 ? 's' : '' }} returned 429. TMDB allows ~40 req/sec.</div>
+            </div>
+        </div>
+        @endif
+
+        {{-- Rate limit gauge --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Rate Limit</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-6">
+            <div class="flex items-end justify-between mb-2">
+                <div>
+                    <span class="text-3xl font-bold {{ $labelColor }}">{{ $rps }}</span>
+                    <span class="text-sm text-gray-500 ml-1">req/sec</span>
+                    <span class="ml-3 text-xs font-medium px-2 py-0.5 rounded-full {{ $pct >= 75 ? 'bg-red-500/15 text-red-400 border border-red-500/20' : ($pct >= 40 ? 'bg-yellow-500/15 text-yellow-400 border border-yellow-500/20' : 'bg-green-500/15 text-green-400 border border-green-500/20') }}">{{ $status }}</span>
+                </div>
+                <div class="text-right">
+                    <div class="text-xs text-gray-500">Peak last 30 min</div>
+                    <div class="text-sm font-semibold text-gray-300">{{ $tmdb['peak_req_per_sec'] }} req/sec</div>
+                </div>
+            </div>
+            <div class="relative h-2.5 bg-white/5 rounded-full overflow-hidden">
+                <div class="absolute inset-y-0 left-0 rounded-full transition-all" style="width: {{ $pct }}%; background: {{ $barColor }}"></div>
+                {{-- Danger marker at 75% (30 req/sec) --}}
+                <div class="absolute inset-y-0 w-px bg-red-500/40" style="left: 75%"></div>
+            </div>
+            <div class="flex justify-between mt-1.5 text-xs text-gray-600">
+                <span>0</span>
+                <span class="text-red-500/50">30/s danger zone</span>
+                <span>40/s limit</span>
+            </div>
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4 pt-4 border-t border-white/5">
+                <div>
+                    <div class="text-lg font-bold text-white">{{ $tmdb['last_60s'] }}</div>
+                    <div class="text-xs text-gray-500">Live last 60s</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold text-white">{{ $tmdb['last_5min'] }}</div>
+                    <div class="text-xs text-gray-500">Live last 5 min</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold text-white">{{ round($tmdb['last_5min'] / 5, 1) }}</div>
+                    <div class="text-xs text-gray-500">Avg/min (5 min)</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold {{ ($today->rate_limited ?? 0) > 0 ? 'text-red-400' : 'text-white' }}">{{ $today->rate_limited ?? 0 }}</div>
+                    <div class="text-xs text-gray-500">429s today</div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Today's summary --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-10">
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-white mb-1">{{ number_format($today->total ?? 0) }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Total</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-blue-400 mb-1">{{ number_format($today->live ?? 0) }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Live</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-green-400 mb-1">{{ number_format($today->hits ?? 0) }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Cached</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-purple-400 mb-1">{{ $hitRate }}%</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Hit Rate</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-yellow-400 mb-1">{{ $today->avg_ms ? round($today->avg_ms) . 'ms' : '—' }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-10">
+
+            {{-- By endpoint --}}
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                    @if($tmdb['by_endpoint']->isEmpty())
+                        <div class="px-5 py-6 text-sm text-gray-500">No requests yet today.</div>
+                    @else
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Total</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Live</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Avg ms</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['by_endpoint'] as $row)
+                            <tr>
+                                <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
+                                <td class="px-4 py-2.5 text-right text-white">{{ $row->total }}</td>
+                                <td class="px-4 py-2.5 text-right text-blue-400">{{ $row->live }}</td>
+                                <td class="px-4 py-2.5 text-right text-green-400">{{ $row->hits }}</td>
+                                <td class="px-4 py-2.5 text-right text-gray-400">{{ $row->avg_ms ? round($row->avg_ms) : '—' }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @endif
+                </div>
+            </div>
+
+            {{-- Last 7 days --}}
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Last 7 Days</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                    @if($tmdb['daily']->isEmpty())
+                        <div class="px-5 py-6 text-sm text-gray-500">No data yet.</div>
+                    @else
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Date</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Total</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Live</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Hit %</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['daily'] as $row)
+                            @php $pct = $row->total > 0 ? round(($row->hits / $row->total) * 100) : 0; @endphp
+                            <tr>
+                                <td class="px-4 py-2.5 text-gray-300">{{ \Carbon\Carbon::parse($row->date)->format('M j') }}</td>
+                                <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->total) }}</td>
+                                <td class="px-4 py-2.5 text-right text-blue-400">{{ number_format($row->live) }}</td>
+                                <td class="px-4 py-2.5 text-right text-green-400">{{ number_format($row->hits) }}</td>
+                                <td class="px-4 py-2.5 text-right text-purple-400">{{ $pct }}%</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @endif
+                </div>
+            </div>
+
+        </div>
+
+        {{-- Per-minute activity (last 30 min) --}}
+        @if($tmdb['per_minute']->isNotEmpty())
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3 mt-8">Activity — Last 30 Minutes <span class="normal-case font-normal text-gray-600">(live requests only)</span></h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-8">
+            @php
+                $sorted  = $tmdb['per_minute']->sortBy('minute')->values();
+                $maxLive = $sorted->max('live') ?: 1;
+            @endphp
+
+            {{-- Bar chart --}}
+            <div class="flex items-end gap-1" style="height: 80px">
+                @foreach($sorted as $m)
+                @php
+                    $barH  = max(4, round(($m->live / $maxLive) * 72));
+                    $rateM = $m->live / 60;
+                    $barC  = $rateM >= 30 ? '#ef4444' : ($rateM >= 15 ? '#f59e0b' : '#3b82f6');
+                @endphp
+                <div class="flex-1 flex flex-col items-center justify-end gap-0.5 group relative" style="height: 80px">
+                    <span class="text-[9px] text-gray-500 group-hover:text-white transition-colors leading-none">{{ $m->live }}</span>
+                    <div class="w-full rounded-sm opacity-60 group-hover:opacity-100 transition-opacity"
+                         style="height: {{ $barH }}px; background: {{ $barC }}">
+                    </div>
+                </div>
                 @endforeach
             </div>
+
+            {{-- Time labels — show every ~5th to avoid crowding --}}
+            @php $total = $sorted->count(); @endphp
+            <div class="flex gap-1 mt-1">
+                @foreach($sorted as $i => $m)
+                <div class="flex-1 text-center">
+                    @if($i === 0 || $i === $total - 1 || $i % 5 === 0)
+                        <span class="text-[9px] text-gray-600">{{ $m->minute }}</span>
+                    @endif
+                </div>
+                @endforeach
+            </div>
+
+            {{-- Legend --}}
+            <div class="flex items-center gap-4 mt-3 pt-3 border-t border-white/5 text-xs text-gray-500">
+                <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#3b82f6"></span> Safe (&lt;15/min)</span>
+                <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#f59e0b"></span> Moderate (15–30/min)</span>
+                <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#ef4444"></span> High (&gt;30/min = &gt;0.5/sec)</span>
+            </div>
+
+            {{-- Mini table --}}
+            <div class="mt-4 overflow-x-auto">
+                <table class="w-full text-xs">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left py-1.5 pr-4 text-gray-500 font-medium">Time</th>
+                            <th class="text-right py-1.5 pr-4 text-gray-500 font-medium">Req</th>
+                            <th class="text-right py-1.5 text-gray-500 font-medium">Req/sec avg</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($sorted->sortByDesc('minute') as $m)
+                        @php $rs = round($m->live / 60, 2); @endphp
+                        <tr>
+                            <td class="py-1.5 pr-4 font-mono text-gray-400">{{ $m->minute }}</td>
+                            <td class="py-1.5 pr-4 text-right text-white">{{ $m->live }}</td>
+                            <td class="py-1.5 text-right {{ $rs >= 0.5 ? 'text-yellow-400' : 'text-gray-400' }}">{{ $rs }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+        {{-- Recent requests --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Recent Requests</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden overflow-x-auto">
+            @if($tmdb['recent']->isEmpty())
+                <div class="px-5 py-6 text-sm text-gray-500">No requests logged yet.</div>
+            @else
+            <table class="w-full text-sm min-w-[640px]">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Status</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">User</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdb['recent'] as $log)
+                    <tr>
+                        <td class="px-4 py-2 text-gray-500 text-xs whitespace-nowrap">{{ $log->created_at->format('H:i:s') }}</td>
+                        <td class="px-4 py-2 font-mono text-xs text-gray-300">{{ str_replace('_', '/', $log->endpoint) }}</td>
+                        <td class="px-4 py-2">
+                            @if($log->cached)
+                                <span class="text-xs px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">cache</span>
+                            @else
+                                <span class="text-xs px-1.5 py-0.5 rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/20">live</span>
+                            @endif
+                        </td>
+                        <td class="px-4 py-2 text-right">
+                            @if($log->status_code)
+                                <span class="text-xs font-mono {{ $log->status_code === 429 ? 'text-red-400' : ($log->status_code >= 400 ? 'text-orange-400' : 'text-gray-500') }}">
+                                    {{ $log->status_code }}
+                                </span>
+                            @else
+                                <span class="text-gray-600">—</span>
+                            @endif
+                        </td>
+                        <td class="px-4 py-2 text-right text-xs text-gray-500">{{ $log->response_time_ms ?? '—' }}</td>
+                        <td class="px-4 py-2 text-xs text-gray-400">
+                            {{ $log->user?->name ?? $log->visitor_hash ?? '—' }}
+                        </td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
             @endif
-        </a>
-        <a href="{{ route('admin.roulettes.create') }}"
-           class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
-            <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">+ New Roulette →</div>
-            <div class="text-sm text-gray-500">Create a new curated collection.</div>
-        </a>
-        <a href="/roulettes" target="_blank"
-           class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
-            <div class="text-lg font-semibold text-white mb-1 group-hover:text-accent transition-colors">View /roulettes ↗</div>
-            <div class="text-sm text-gray-500">See the public-facing roulettes page.</div>
-        </a>
-    </div>
+        </div>
+
+    @endif
 
 </div>
 @endsection

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -174,11 +174,11 @@
             {{-- By endpoint --}}
             <div>
                 <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Today</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
                     @if($tmdb['by_endpoint']->isEmpty())
                         <div class="px-5 py-6 text-sm text-gray-500">No requests yet today.</div>
                     @else
-                    <table class="w-full text-sm">
+                    <table class="w-full text-sm min-w-[380px]">
                         <thead>
                             <tr class="border-b border-white/5">
                                 <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
@@ -207,11 +207,11 @@
             {{-- Last 7 days --}}
             <div>
                 <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Last 7 Days</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
                     @if($tmdb['daily']->isEmpty())
                         <div class="px-5 py-6 text-sm text-gray-500">No data yet.</div>
                     @else
-                    <table class="w-full text-sm">
+                    <table class="w-full text-sm min-w-[320px]">
                         <thead>
                             <tr class="border-b border-white/5">
                                 <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Date</th>
@@ -316,10 +316,11 @@
             @if($tmdb['recent']->isEmpty())
                 <div class="px-5 py-6 text-sm text-gray-500">No requests logged yet.</div>
             @else
-            <table class="w-full text-sm min-w-[640px]">
+            <table class="w-full text-sm min-w-[780px]">
                 <thead>
                     <tr class="border-b border-white/5">
                         <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Route</th>
                         <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
                         <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Status</th>
@@ -331,6 +332,7 @@
                     @foreach($tmdb['recent'] as $log)
                     <tr>
                         <td class="px-4 py-2 text-gray-500 text-xs whitespace-nowrap">{{ $log->created_at->format('H:i:s') }}</td>
+                        <td class="px-4 py-2 font-mono text-xs text-gray-500 whitespace-nowrap">{{ $log->route ?? '—' }}</td>
                         <td class="px-4 py-2 font-mono text-xs text-gray-300">{{ str_replace('_', '/', $log->endpoint) }}</td>
                         <td class="px-4 py-2">
                             @if($log->cached)

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,28 +56,33 @@ Route::prefix('tmdb')->group(function () {
 Route::get('/no-results', NoResultsController::class)->name('no-results');
 Route::get('/criteria',  CriteriaController::class);
 
-Route::match(['get', 'post'], '/movie',    [MoviePickController::class, 'single']);
-Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
-Route::get('/movie/roll',                       [MoviePickController::class, 'homepageRoll']);
-Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRoll']);
+Route::middleware('throttle:60,1')->group(function () {
+    Route::match(['get', 'post'], '/movie',               [MoviePickController::class, 'single']);
+    Route::match(['get', 'post'], '/multiple',            [MoviePickController::class, 'batch']);
+    Route::get('/movie/roll',                             [MoviePickController::class, 'homepageRoll']);
+    Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRoll']);
+
+    Route::match(['get', 'post'], '/tv/pick',             [TvPickController::class, 'single'])->name('tv.pick');
+    Route::match(['get', 'post'], '/tv/multiple',         [TvPickController::class, 'batch']);
+    Route::get('/tv/roll',                                [TvPickController::class, 'homepageRoll']);
+    Route::match(['get', 'post'], '/tv/roll/criteria',    [TvPickController::class, 'criteriaRoll']);
+
+    Route::get('/person/{id}/roll/movie',                 [PersonRollController::class, 'movie'])->name('person.roll.movie');
+    Route::get('/person/{id}/roll/tv',                    [PersonRollController::class, 'tv'])->name('person.roll.tv');
+    Route::get('/person/{id}/roll/movie/json',            [PersonRollController::class, 'movieRollJson']);
+    Route::get('/person/{id}/roll/tv/json',               [PersonRollController::class, 'tvRollJson']);
+});
+
 Route::get('/movie/{id}',          MovieController::class)->name('movie');
 
 // TV Shows
 Route::get('/tv/criteria',                     TvCriteriaController::class);
-Route::match(['get', 'post'], '/tv/pick',      [TvPickController::class, 'single'])->name('tv.pick');
-Route::match(['get', 'post'], '/tv/multiple',  [TvPickController::class, 'batch']);
-Route::get('/tv/roll',                          [TvPickController::class, 'homepageRoll']);
-Route::match(['get', 'post'], '/tv/roll/criteria',   [TvPickController::class, 'criteriaRoll']);
 Route::get('/tv/{id}',             TvShowController::class)->name('tv.show');
 Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
 Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
 
 Route::get('/person/roll/tv/next',    [PersonRollController::class, 'nextTvRoll'])->name('person.roll.tv.next');
 Route::get('/person/{id}',            PersonController::class)->name('person');
-Route::get('/person/{id}/roll/movie',      [PersonRollController::class, 'movie'])->name('person.roll.movie');
-Route::get('/person/{id}/roll/tv',         [PersonRollController::class, 'tv'])->name('person.roll.tv');
-Route::get('/person/{id}/roll/movie/json', [PersonRollController::class, 'movieRollJson']);
-Route::get('/person/{id}/roll/tv/json',    [PersonRollController::class, 'tvRollJson']);
 
 // My Roulettes (auth required — must be before /roulettes/{slug} wildcard)
 Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(function () {
@@ -130,15 +135,3 @@ if (app()->environment('local')) {
         return redirect('/');
     });
 }
-
-// Obfuscated utility routes (cache/config clear, scheduler trigger)
-Route::get('/fdsdfsds', function () {
-    Artisan::call('config:clear');
-    Artisan::call('view:clear');
-    Artisan::call('cache:clear');
-    Artisan::call('config:cache');
-});
-
-Route::get('/asdsadasdasdsadsaghfgh', function () {
-    Artisan::call('schedule:run');
-});


### PR DESCRIPTION
## Summary
- New `tmdb_request_logs` table (endpoint, cached, status_code, response_time_ms, user_id, visitor_hash) with indexes on created_at, (created_at, endpoint), and user_id
- `TmdbClient` now logs every interaction — real HTTP calls via `fetch()` wrapper (timing, status code, 429s), cache hits via `cached()` wrapper using a `$called` flag to avoid double lookups. Logging never breaks a request (catch-all in `log()`)
- Admin dashboard gets a TMDB tab (`?tab=tmdb`) with:
  - Rate limit gauge showing current avg req/sec vs TMDB's 40/sec limit, with safe/moderate/high thresholds
  - Short-window counters: live requests in last 60s and 5min
  - Per-minute activity bar chart (last 30 min) with counts, time labels, legend, and a breakdown table
  - Today's summary (total, live, cached, hit rate, avg response time)
  - Endpoint breakdown and 7-day history
  - Recent 50 requests with user identification

## Test plan
- [ ] Visit a few pages to generate requests, then check `/admin?tab=tmdb`
- [ ] Revisit the same movie page — should show cache hits
- [ ] Verify rate limit gauge, bar chart, and recent requests table all populate
- [ ] Confirm overview tab is unchanged