### PR TITLE
Add sharing — movie/TV detail, batch, and roulettes

### DIFF
--- a/app/Http/Controllers/BatchShareController.php
+++ b/app/Http/Controllers/BatchShareController.php
@@ -29,6 +29,10 @@ class BatchShareController extends Controller
             default  => 'Shared Movie Batch',
         };
 
+        $titles   = collect($results)->pluck('title')->filter()->take(4)->implode(', ');
+        $ogImage  = collect($results)->first(fn($m) => !empty($m['poster_path']));
+        $ogImage  = $ogImage ? 'https://image.tmdb.org/t/p/w500' . $ogImage['poster_path'] : null;
+
         return view('batch', [
             'movies'         => ['results' => $results],
             'all_genres'     => [],
@@ -42,6 +46,9 @@ class BatchShareController extends Controller
             'mediaType'      => $isMixed ? 'mixed' : ($isTv ? 'tv' : 'movie'),
             'isShared'       => true,
             'shareToken'     => self::encode($results, $type),
+            'ogTitle'        => $tags . ' — MoviePickr',
+            'ogDescription'  => $titles ? 'Includes: ' . $titles . '...' : $tags,
+            'ogImage'        => $ogImage,
         ]);
     }
 

--- a/app/Http/Controllers/BatchShareController.php
+++ b/app/Http/Controllers/BatchShareController.php
@@ -18,21 +18,30 @@ class BatchShareController extends Controller
             abort(404);
         }
 
-        $isTv    = $data['type'] === 'tv';
+        $type    = $data['type'];
+        $isTv    = $type === 'tv';
+        $isMixed = $type === 'mixed';
         $results = $data['movies'];
 
+        $tags = match(true) {
+            $isMixed => 'Shared Watchlist',
+            $isTv    => 'Shared TV Batch',
+            default  => 'Shared Movie Batch',
+        };
+
         return view('batch', [
-            'movies'      => ['results' => $results],
-            'all_genres'  => [],
-            'movie_genres'=> [],
+            'movies'         => ['results' => $results],
+            'all_genres'     => [],
+            'movie_genres'   => [],
             'providersArray' => [],
-            'user_input'  => [],
-            'tag'         => $isTv ? 'Shared TV Batch' : 'Shared Movie Batch',
-            'savedIds'    => auth()->check()
+            'user_input'     => [],
+            'tag'            => $tags,
+            'savedIds'       => auth()->check()
                 ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
                 : [],
-            'mediaType'   => $isTv ? 'tv' : 'movie',
-            'isShared'    => true,
+            'mediaType'      => $isMixed ? 'mixed' : ($isTv ? 'tv' : 'movie'),
+            'isShared'       => true,
+            'shareToken'     => self::encode($results, $type),
         ]);
     }
 
@@ -58,7 +67,9 @@ class BatchShareController extends Controller
     private static function decode(string $token): ?array
     {
         try {
-            $json = base64_decode(strtr($token, '-_', '+/') . str_repeat('=', strlen($token) % 4));
+            $padded = strtr($token, '-_', '+/');
+            $padded .= str_repeat('=', (4 - strlen($padded) % 4) % 4);
+            $json   = base64_decode($padded, strict: true) ?: base64_decode($padded);
             $data = json_decode($json, true);
             if (!isset($data['type'], $data['movies']) || !is_array($data['movies'])) {
                 return null;

--- a/app/Http/Controllers/BatchShareController.php
+++ b/app/Http/Controllers/BatchShareController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Cache;
+
+class BatchShareController extends Controller
+{
+    public function show(string $token)
+    {
+        $cacheKey = 'batch_share_' . substr(hash('sha256', $token), 0, 24);
+
+        $data = Cache::remember($cacheKey, now()->addDays(30), function () use ($token) {
+            return self::decode($token);
+        });
+
+        if (!$data) {
+            abort(404);
+        }
+
+        $isTv    = $data['type'] === 'tv';
+        $results = $data['movies'];
+
+        return view('batch', [
+            'movies'      => ['results' => $results],
+            'all_genres'  => [],
+            'movie_genres'=> [],
+            'providersArray' => [],
+            'user_input'  => [],
+            'tag'         => $isTv ? 'Shared TV Batch' : 'Shared Movie Batch',
+            'savedIds'    => auth()->check()
+                ? auth()->user()->watchlist()->pluck('tmdb_id')->toArray()
+                : [],
+            'mediaType'   => $isTv ? 'tv' : 'movie',
+            'isShared'    => true,
+        ]);
+    }
+
+    public static function encode(array $results, string $type): string
+    {
+        $data = [
+            'type'   => $type,
+            'movies' => array_map(fn($m) => [
+                'id'           => $m['id'],
+                'poster_path'  => $m['poster_path'] ?? null,
+                'title'        => $m['title'] ?? $m['name'] ?? '',
+                'name'         => $m['name'] ?? $m['title'] ?? '',
+                'vote_average' => $m['vote_average'] ?? 0,
+                'release_date' => $m['release_date'] ?? $m['first_air_date'] ?? null,
+                'first_air_date' => $m['first_air_date'] ?? null,
+                'genre_ids'    => $m['genre_ids'] ?? [],
+            ], array_values($results)),
+        ];
+
+        return rtrim(strtr(base64_encode(json_encode($data)), '+/', '-_'), '=');
+    }
+
+    private static function decode(string $token): ?array
+    {
+        try {
+            $json = base64_decode(strtr($token, '-_', '+/') . str_repeat('=', strlen($token) % 4));
+            $data = json_decode($json, true);
+            if (!isset($data['type'], $data['movies']) || !is_array($data['movies'])) {
+                return null;
+            }
+            return $data;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -73,6 +73,7 @@ class MoviePickController extends PickController
             'providersArray' => $movieService->buildProvidersArray($tmdb),
             'tag'            => 'Movies picked for you',
             'savedIds'       => $this->savedWatchlistIds(),
+            'shareToken'     => BatchShareController::encode($movies['results'], 'movie'),
         ]);
     }
 

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -163,6 +163,7 @@ class RouletteController extends Controller
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
                 'mediaType'    => $isTv ? 'tv' : null,
+                'shareToken'   => BatchShareController::encode($results, $isTv ? 'tv' : 'movie'),
             ]));
         }
 
@@ -184,6 +185,7 @@ class RouletteController extends Controller
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
                 'mediaType'    => 'tv',
+                'shareToken'   => BatchShareController::encode($shows['results'], 'tv'),
             ]);
         }
 
@@ -202,6 +204,7 @@ class RouletteController extends Controller
             'tag'          => $roulette->name,
             'title'        => $roulette->name . ' — MoviePickr',
             'savedIds'     => $savedIds,
+            'shareToken'   => BatchShareController::encode($movies['results'], 'movie'),
         ]);
     }
 

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -76,6 +76,7 @@ class TvPickController extends PickController
             'tag'            => 'TV Shows picked for you',
             'savedIds'       => $this->savedWatchlistIds(),
             'mediaType'      => 'tv',
+            'shareToken'     => BatchShareController::encode($shows['results'], 'tv'),
         ]);
     }
 

--- a/docs/collaborative-batch.md
+++ b/docs/collaborative-batch.md
@@ -1,0 +1,281 @@
+# Collaborative Batch — Real-Time Movie Selection
+
+A shared batch session where a group of people eliminate movies in real time until one is left. Everyone who has the link open sees removals happen live with animations.
+
+---
+
+## Concept
+
+1. User rolls a batch → gets a shareable link with a short room token (e.g. `/batch/collab/abc123`)
+2. Friends open the link → everyone joins the same "room"
+3. Anyone can veto a movie → it animates off everyone's screen simultaneously with "[Name] vetoed this"
+4. Last movie standing → celebration animation → everyone sees the winner
+
+---
+
+## Architecture Decisions
+
+### Token
+- Short random ID (8 chars, e.g. `Str::random(8)`) — NOT base64-encoded content
+- Stored in DB, URL is just a reference
+- Replaces the current base64 URL approach for collaborative batches
+- Keep the existing `/batch/share/{token}` for non-collaborative shares (read-only, no DB)
+
+### Real-Time
+- **Laravel Reverb** — free, open source, runs on your own server
+- No external service, no cost beyond server resources
+- Each room = one Reverb channel: `batch.{token}`
+- Events broadcast: `MovieVetoed`, `BatchComplete`
+
+### State Storage
+- DB table `collab_batches` stores current movie list as JSON
+- Each veto updates the JSON in DB and broadcasts to channel
+- Expires after 24 hours (or when session ends)
+
+---
+
+## Database
+
+```php
+Schema::create('collab_batches', function (Blueprint $table) {
+    $table->string('token', 8)->primary();
+    $table->json('movies');            // current remaining movies
+    $table->string('media_type', 10)->default('movie');
+    $table->unsignedBigInteger('created_by')->nullable(); // user_id
+    $table->timestamp('expires_at');
+    $table->timestamps();
+
+    $table->index('expires_at');       // for cleanup job
+});
+```
+
+---
+
+## User Identity
+
+| Situation | Display |
+|-----------|---------|
+| Logged in | Their name from `auth()->user()->name` |
+| Anonymous | Fun random name generated once per session, stored in `localStorage` (e.g. "Blue Fox", "Red Panda") — pick from a list of colors + animals |
+
+Store anonymous identity: `localStorage.setItem('collab_identity', 'Blue Fox')`
+
+---
+
+## Reverb Setup
+
+```bash
+composer require laravel/reverb
+php artisan reverb:install
+```
+
+Add to `.env`:
+```
+REVERB_APP_ID=your-app-id
+REVERB_APP_KEY=your-app-key
+REVERB_APP_SECRET=your-app-secret
+REVERB_HOST=localhost
+REVERB_PORT=8080
+```
+
+Run the WebSocket server:
+```bash
+php artisan reverb:start
+```
+
+On production — run as a background process via supervisor:
+```ini
+[program:reverb]
+command=php /var/www/moviepicker/artisan reverb:start
+autostart=true
+autorestart=true
+```
+
+---
+
+## Events
+
+### `MovieVetoed`
+Broadcast on channel `batch.{token}` when a movie is removed.
+
+```php
+class MovieVetoed implements ShouldBroadcast
+{
+    public function __construct(
+        public string $token,
+        public int    $movieId,
+        public string $vetoedBy,   // display name
+        public array  $remaining,  // movies left after veto
+    ) {}
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel('batch.' . $this->token);
+    }
+}
+```
+
+### `BatchComplete`
+Broadcast when only one movie remains.
+
+```php
+class BatchComplete implements ShouldBroadcast
+{
+    public function __construct(
+        public string $token,
+        public array  $winner,     // the last movie
+        public string $decidedBy,
+    ) {}
+}
+```
+
+---
+
+## Routes
+
+```php
+Route::get('/batch/collab/{token}',          [CollabBatchController::class, 'show']);
+Route::post('/batch/collab',                  [CollabBatchController::class, 'create']);
+Route::delete('/batch/collab/{token}/{id}',   [CollabBatchController::class, 'veto']);
+```
+
+---
+
+## Controller Sketch
+
+```php
+class CollabBatchController extends Controller
+{
+    public function create(Request $request)
+    {
+        // Called when user clicks "Collaborative Share" on a batch page
+        // $request->movies = array from current batch
+        $batch = CollabBatch::create([
+            'token'      => Str::random(8),
+            'movies'     => $request->movies,
+            'media_type' => $request->media_type ?? 'movie',
+            'created_by' => auth()->id(),
+            'expires_at' => now()->addHours(24),
+        ]);
+
+        return response()->json(['token' => $batch->token]);
+    }
+
+    public function show(string $token)
+    {
+        $batch = CollabBatch::where('token', $token)
+            ->where('expires_at', '>', now())
+            ->firstOrFail();
+
+        return view('batch.collab', compact('batch'));
+    }
+
+    public function veto(string $token, int $movieId, Request $request)
+    {
+        $batch = CollabBatch::where('token', $token)->firstOrFail();
+
+        $movies = collect($batch->movies)->reject(fn($m) => $m['id'] === $movieId)->values()->all();
+        $batch->update(['movies' => $movies]);
+
+        $vetoedBy = auth()->user()?->name ?? $request->input('identity', 'Someone');
+
+        if (count($movies) === 1) {
+            broadcast(new BatchComplete($token, $movies[0], $vetoedBy));
+        } else {
+            broadcast(new MovieVetoed($token, $movieId, $vetoedBy, $movies));
+        }
+
+        return response()->json(['remaining' => count($movies)]);
+    }
+}
+```
+
+---
+
+## Frontend
+
+### JS — Joining a channel
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+window.Echo = new Echo({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT,
+    forceTLS: false,
+    enabledTransports: ['ws', 'wss'],
+});
+
+Echo.channel(`batch.${token}`)
+    .listen('MovieVetoed', (e) => {
+        animateVeto(e.movieId, e.vetoedBy);
+        updateRemainingCards(e.remaining);
+    })
+    .listen('BatchComplete', (e) => {
+        animateWinner(e.winner, e.decidedBy);
+    });
+```
+
+### Veto Animation Ideas
+- Card shakes briefly, then slides/fades out
+- Small toast appears: *"Red Panda vetoed Inception"*
+- If you're the one vetoing: instant feedback, card disappears immediately
+- For others: 300ms delay then same animation (feels live)
+
+### Winner Animation
+- Confetti burst
+- Card scales up to center of screen
+- *"You all picked [Movie]! 🎉"*
+- Button to navigate to the movie detail page
+
+---
+
+## UI Changes Needed
+
+1. **Batch page** — add a "Collaborative Share" button alongside the existing share button
+   - Regular share = current base64 URL (read-only, works forever)
+   - Collaborative share = creates a DB session, gives a room link
+2. **Collab batch page** — show participant count ("3 people in this session")
+3. **Each movie card** — ✕ veto button (visible to all, any participant can use it)
+4. **Veto counter** — optional: show how many movies have been eliminated ("7 of 10 eliminated")
+
+---
+
+## Cleanup
+
+Add a scheduled command to delete expired sessions:
+
+```php
+// In routes/console.php or a command
+Schedule::command('collab:cleanup')->daily();
+
+// Command:
+CollabBatch::where('expires_at', '<', now())->delete();
+```
+
+---
+
+## Implementation Order
+
+1. Install and configure Reverb
+2. Create `collab_batches` migration and model
+3. Create `CollabBatchController`
+4. Create broadcast events (`MovieVetoed`, `BatchComplete`)
+5. Add route for collab batch page
+6. Build `batch/collab.blade.php` view (can reuse batch layout)
+7. Write JS for Echo channel + veto animation
+8. Add "Collaborative Share" button to batch page
+9. Test with two browser tabs
+10. Deploy Reverb as a supervisor process on production
+
+---
+
+## Notes
+
+- Keep existing `/batch/share/{token}` (base64, read-only) as-is — it requires no server state and links never expire. Collaborative batches are a separate flow.
+- The room expires after 24h. After expiry, the link shows a "session ended" page.
+- Anonymous identity (fun names) makes it feel playful — don't force login to participate.
+- Consider a "lock" feature later: creator can prevent new people from joining mid-session.

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,13 @@
+window.showSuccessToast = function (msg) {
+    const el = document.createElement('div');
+    el.className = 'fixed top-20 left-1/2 z-50 bg-green-900/80 border border-green-700/50 text-green-300 text-sm px-5 py-3 rounded-lg backdrop-blur-sm cursor-pointer whitespace-nowrap';
+    el.style.transform = 'translateX(-50%)';
+    el.textContent = msg;
+    el.onclick = () => el.remove();
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3000);
+};
+
 window.showErrorToast = function (msg) {
     const el = document.createElement('div');
     el.className = 'fixed top-20 left-1/2 z-50 bg-red-900/80 border border-red-700/50 text-red-300 text-sm px-5 py-3 rounded-lg backdrop-blur-sm cursor-pointer whitespace-nowrap';
@@ -70,6 +80,33 @@ $(document).ready(function () {
         lockBodyScroll();
         if (id === 'trailer-modal' && typeof gtag !== 'undefined') {
             gtag('event', 'trailer_opened');
+        }
+    });
+
+    $(document).on('click', '[data-share]', function () {
+        const url   = $(this).data('share-url') || window.location.href;
+        const title = $(this).data('share-title') || document.title;
+        if (navigator.share) {
+            navigator.share({ title, url }).catch(() => {});
+        } else if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(() => {
+                window.showSuccessToast('Link copied!');
+            }).catch(() => {
+                window.showErrorToast('Could not copy link.');
+            });
+        } else {
+            const ta = document.createElement('textarea');
+            ta.value = url;
+            ta.style.cssText = 'position:fixed;opacity:0';
+            document.body.appendChild(ta);
+            ta.select();
+            try {
+                document.execCommand('copy');
+                window.showSuccessToast('Link copied!');
+            } catch {
+                window.showErrorToast('Could not copy link.');
+            }
+            document.body.removeChild(ta);
         }
     });
 

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -61,18 +61,88 @@ document.addEventListener('DOMContentLoaded', function () {
         sessionStorage.removeItem('rollSource');
         sessionStorage.removeItem('rollBackUrl');
         sessionStorage.removeItem('rollBackLabel');
+        sessionStorage.removeItem('sharedBatchCards');
     }
 
     const rollSource = sessionStorage.getItem('rollSource');
-    if (rollSource === 'person') {
+    if (rollSource === 'person' || rollSource === 'shared_batch') {
         document.querySelectorAll('.js-criteria-btn').forEach(el => el.classList.add('hidden'));
     }
     const backUrl   = sessionStorage.getItem('rollBackUrl');
     const backLabel = sessionStorage.getItem('rollBackLabel');
     document.querySelectorAll('.js-back-roulettes').forEach(el => {
-        if (backUrl)   el.href        = backUrl;
+        if (backUrl) {
+            el.href = backUrl;
+            el.classList.remove('hidden');
+        }
         if (backLabel) el.textContent = backLabel;
     });
+
+    // On shared batch pages, set context on any card click so direct clicks
+    // (not just roll animation) carry the ← Shared Batch back button
+    if (window.location.pathname.startsWith('/batch/share/')) {
+        document.addEventListener('click', function (e) {
+            if (e.target.closest('[data-batch-card]')) {
+                const cards = getBatchCards('.swiper-multiple');
+                sessionStorage.setItem('sharedBatchCards', JSON.stringify(cards));
+                setRollContext('shared_batch', window.location.href, '← Shared Batch');
+                sessionStorage.setItem('rollSource', 'shared_batch');
+            }
+        });
+    }
+
+    // On movie/TV detail pages reached from a shared batch — replace similar section
+    // and override Roll to pick from the same batch
+    if (rollSource === 'shared_batch') {
+        const storedCards = JSON.parse(sessionStorage.getItem('sharedBatchCards') || '[]');
+        const currentPath = window.location.pathname;
+        const otherCards  = storedCards.filter(c => {
+            try { return new URL(c.url, location.origin).pathname !== currentPath; }
+            catch { return true; }
+        });
+
+        if (otherCards.length) {
+            const section = document.getElementById('similar-section');
+            if (section) {
+                const esc = s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+                const items = otherCards.map(c => `
+                    <div class="relative flex-shrink-0 w-44 sm:w-52"
+                         data-batch-card data-title="${esc(c.title)}" data-rating="${c.rating}"
+                         data-poster="${c.poster ? c.poster.replace('https://image.tmdb.org/t/p/w342','') : ''}"
+                         data-media-type="${c.media_type}" data-url="${esc(c.url)}">
+                        <a href="${esc(c.url)}" class="block group long-movie" data-name="${esc(c.title)}">
+                            <div class="card card-hover overflow-hidden">
+                                <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden">
+                                    ${c.poster ? `<img src="${esc(c.poster)}" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" loading="lazy" alt="${esc(c.title)}">` : '<div class="w-full h-full"></div>'}
+                                </div>
+                                <div class="p-2">
+                                    <div class="text-xs font-medium text-white truncate">${esc(c.title)}</div>
+                                    ${c.rating ? `<div class="text-xs text-gray-500 mt-0.5">★ ${Number(c.rating).toFixed(1)}</div>` : ''}
+                                </div>
+                            </div>
+                        </a>
+                    </div>`).join('');
+
+                section.innerHTML = `
+                    <div class="section-header">
+                        <h2 class="text-xl font-bold text-white mb-3">From This Batch</h2>
+                        <div class="section-divider"></div>
+                    </div>
+                    <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">${items}</div>`;
+            }
+
+            // Override Roll button to re-roll from the shared batch
+            document.querySelectorAll('[data-roll="movie-criteria"],[data-roll="tv-criteria"]').forEach(btn => {
+                btn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    setRollContext('shared_batch', sessionStorage.getItem('rollBackUrl'), '← Shared Batch');
+                    rollCards(otherCards.length ? otherCards : storedCards, 'shared_batch');
+                });
+            });
+        }
+    }
+
 });
 
 // ── Core roll function ────────────────────────────────────────────────
@@ -232,6 +302,18 @@ document.addEventListener('click', function (e) {
                 if (err && err.throttled) { window.showErrorToast('Rolling too fast — slow down a bit and try again.'); return; }
                 window.location.href = fallback;
             });
+        return;
+    }
+
+    // Shared batch Roll — picks from cards already on the page, back goes to shared batch URL
+    const sharedRollBtn = e.target.closest('#shared-batch-roll-btn');
+    if (sharedRollBtn) {
+        e.preventDefault();
+        const cards = getBatchCards('.swiper-multiple');
+        if (!cards.length) return;
+        sessionStorage.setItem('sharedBatchCards', JSON.stringify(cards));
+        setRollContext('shared_batch', window.location.href, '← Shared Batch');
+        rollCards(cards, 'shared_batch');
         return;
     }
 

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -238,4 +238,57 @@ $(document).ready(function () {
         }
     });
 
+    /* ── Share visible watchlist as a batch ───────────────────────── */
+    $('#watchlist-share').on('click', function () {
+        const movies = [];
+        $('.watchlist-card:visible').each(function () {
+            const link      = $(this).find('a[href]').first();
+            const img       = $(this).find('img').first();
+            const href      = link.attr('href') || '';
+            const idMatch   = href.match(/\/(?:movie|tv)\/(\d+)/);
+            const id        = idMatch ? parseInt(idMatch[1]) : 0;
+            if (!id) return;
+            const posterSrc  = (img.attr('src') || '').replace('w500', 'w342');
+            const posterPath = posterSrc.replace(/https:\/\/image\.tmdb\.org\/t\/p\/w\d+/, '');
+            const title      = $(this).data('title') || '';
+            const rating     = parseFloat($(this).data('rating')) || 0;
+            const mediaType  = ($(this).data('type') || 'movie') === 'tv' ? 'tv' : 'movie';
+            const year       = parseInt($(this).data('year')) || 2000;
+            const dateStr    = year + '-01-01';
+            movies.push({
+                id,
+                poster_path:    posterPath,
+                title,
+                name:           title,
+                vote_average:   rating,
+                media_type:     mediaType,
+                release_date:   mediaType === 'movie' ? dateStr : null,
+                first_air_date: mediaType === 'tv'    ? dateStr : null,
+                genre_ids:      [],
+            });
+        });
+
+        if (!movies.length) { window.showErrorToast('Nothing to share.'); return; }
+
+        const hasTV  = movies.some(m => m.media_type === 'tv');
+        const hasMov = movies.some(m => m.media_type === 'movie');
+        const type   = hasTV && hasMov ? 'mixed' : (hasTV ? 'tv' : 'movie');
+
+        const token = btoa(unescape(encodeURIComponent(JSON.stringify({ type, movies })))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+        const url   = window.location.origin + '/batch/share/' + token;
+        const title = 'My Watchlist — MoviePickr';
+
+        if (navigator.share) {
+            navigator.share({ title, url }).catch(() => {});
+        } else if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(() => window.showSuccessToast('Link copied!'));
+        } else {
+            const ta = document.createElement('textarea');
+            ta.value = url; ta.style.cssText = 'position:fixed;opacity:0';
+            document.body.appendChild(ta); ta.select();
+            try { document.execCommand('copy'); window.showSuccessToast('Link copied!'); } catch {}
+            document.body.removeChild(ta);
+        }
+    });
+
 });

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -1,5 +1,12 @@
 @extends('layouts.app')
 @section('page_title', $title ?? (($mediaType ?? 'movie') === 'tv' ? 'TV Batch — MoviePickr' : 'Batch — MoviePickr'))
+@if(!empty($ogTitle))
+@section('og_title', $ogTitle)
+@section('og_description', $ogDescription)
+@if(!empty($ogImage))
+@section('og_image', $ogImage)
+@endif
+@endif
 @section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js', 'resources/js/custom/watchlist.js'])

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -107,6 +107,8 @@
             @if(empty($isShared))
                 <a href="{{ Request::url() }}" class="btn-secondary flex-none text-center long-single">New Batch</a>
                 <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>
+            @else
+                <button id="shared-batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>
             @endif
         </div>
     </div>

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -89,13 +89,25 @@
 {{-- Sticky bottom bar --}}
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
-        <div class="flex-shrink-0"></div>
+        <div class="flex-shrink-0">
+            @if(isset($shareToken))
+            <button type="button" class="btn-secondary text-sm"
+                data-share
+                data-share-url="{{ url('/batch/share/'.$shareToken) }}"
+                data-share-title="{{ $tag ?? 'Shared Batch' }} — MoviePickr"
+                title="Share this batch">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+            </button>
+            @endif
+        </div>
         <div class="flex items-center gap-3">
-            @if(isset($providersArray) && isset($all_genres))
+            @if(isset($providersArray) && isset($all_genres) && empty($isShared))
                 <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Filters</button>
             @endif
-            <a href="{{ Request::url() }}" class="btn-secondary flex-none text-center long-single">New Batch</a>
-            <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>
+            @if(empty($isShared))
+                <a href="{{ Request::url() }}" class="btn-secondary flex-none text-center long-single">New Batch</a>
+                <button id="batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>
+            @endif
         </div>
     </div>
 </div>

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -1,8 +1,9 @@
 <div class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide carousel-row {{ $name ?? '' }}">
     @foreach ($allMovies['results'] as $result)
         @php
-            $date  = $result['release_date'] ?? $result['first_air_date'] ?? null;
-            $title = $result['title'] ?? $result['name'] ?? '';
+            $date      = $result['release_date'] ?? $result['first_air_date'] ?? null;
+            $title     = $result['title'] ?? $result['name'] ?? '';
+            $itemBase  = $result['media_type'] ?? $linkBase ?? 'movie';
         @endphp
         @if($date)
         <div class="relative flex-shrink-0 w-44 sm:w-52 lg:w-56"
@@ -10,9 +11,9 @@
              data-title="{{ $title }}"
              data-rating="{{ $result['vote_average'] ?? 0 }}"
              data-poster="{{ $result['poster_path'] ?? '' }}"
-             data-media-type="{{ ($linkBase ?? 'movie') === 'tv' ? 'tv' : 'movie' }}"
-             data-url="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : ($linkSuffix ?? '') }}">
-            <a href="{{ url(($linkBase ?? 'movie').'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}"
+             data-media-type="{{ $itemBase === 'tv' ? 'tv' : 'movie' }}"
+             data-url="{{ url($itemBase.'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : ($linkSuffix ?? '') }}">
+            <a href="{{ url($itemBase.'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}"
                class="block h-full group long-movie" data-name="{{ $title }}">
                 <div class="card card-hover h-full flex flex-col overflow-hidden">
                     <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden">

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -43,6 +43,13 @@
         {{-- Save buttons --}}
         <div class="flex flex-col items-end gap-2 flex-shrink-0">
             <div class="flex items-center gap-2">
+                <button type="button" class="btn-secondary flex-shrink-0 text-sm"
+                    data-share
+                    data-share-url="{{ url()->current() }}"
+                    data-share-title="{{ $tmdbInfo->title ?? '' }} — MoviePickr"
+                    title="Share">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+                </button>
                 @auth
                     <button type="button" id="title-save-roulette-btn"
                             class="btn-secondary text-sm flex items-center gap-1.5">

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -344,7 +344,7 @@
 
     {{-- Similar movies --}}
     @if ($similarMovies != null)
-    <div>
+    <div id="similar-section">
         <div class="section-header">
             <h2 class="text-xl font-bold text-white mb-3">{{ $similarTitle }}</h2>
             <div class="section-divider"></div>
@@ -362,8 +362,8 @@
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
-            @elseif($batchUrl)
-                <a href="{{ $batchUrl }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
+            @else
+                <a href="{{ $batchUrl ?? '#' }}" class="btn-secondary text-center js-back-roulettes {{ $batchUrl ? '' : 'hidden' }}">← Batch</a>
             @endif
         </div>
         {{-- Right --}}

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -2,7 +2,7 @@
 @section('page_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
 @section('og_title', ($tmdbInfo->title ?? $omdbInfo->Title ?? 'Movie').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this movie picked by MoviePickr.', 200))
-@section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
+@section('og_image', $tmdbInfo->backdrop_path ? 'https://image.tmdb.org/t/p/w1280'.$tmdbInfo->backdrop_path : ($tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : ''))
 @section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])

--- a/resources/views/my-roulettes/manage.blade.php
+++ b/resources/views/my-roulettes/manage.blade.php
@@ -124,6 +124,22 @@
                                         </button>
                                     </form>
 
+                                    {{-- Share --}}
+                                    @if($roulette->is_public)
+                                    <button type="button"
+                                        class="p-2 text-gray-500 hover:text-white transition-colors"
+                                        data-share
+                                        data-share-url="{{ url('/roulettes/'.$roulette->slug) }}"
+                                        data-share-title="{{ $roulette->name }} — MoviePickr"
+                                        title="Share">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+                                    </button>
+                                    @else
+                                    <span class="p-2 text-gray-700 cursor-not-allowed" title="Make public to share">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+                                    </span>
+                                    @endif
+
                                     {{-- Roll --}}
                                     <a href="/roulettes/{{ $roulette->slug }}" target="_blank"
                                        class="p-2 text-gray-500 hover:text-white transition-colors" title="Roll">

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -437,7 +437,7 @@
 
     {{-- Similar shows --}}
     @if ($similarShows != null)
-    <div>
+    <div id="similar-section">
         <div class="section-header">
             <h2 class="text-xl font-bold text-white mb-3">{{ $similarTitle }}</h2>
             <div class="section-divider"></div>
@@ -464,8 +464,8 @@
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
-            @elseif($batchUrl)
-                <a href="{{ $batchUrl }}" class="btn-secondary text-center js-back-roulettes">← Batch</a>
+            @else
+                <a href="{{ $batchUrl ?? '#' }}" class="btn-secondary text-center js-back-roulettes {{ $batchUrl ? '' : 'hidden' }}">← Batch</a>
             @endif
         </div>
         {{-- Right actions --}}

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -43,6 +43,13 @@
         {{-- Save buttons --}}
         <div class="flex flex-col items-end gap-2 flex-shrink-0">
             <div class="flex items-center gap-2">
+                <button type="button" class="btn-secondary flex-shrink-0 text-sm"
+                    data-share
+                    data-share-url="{{ url()->current() }}"
+                    data-share-title="{{ $tmdbInfo->name ?? '' }} — MoviePickr"
+                    title="Share">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+                </button>
                 @auth
                     @php $isSaved = auth()->user()->watchlist()->where('tmdb_id', $tmdbInfo->id)->exists(); @endphp
                     <button type="button" id="title-save-roulette-btn"

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -2,7 +2,7 @@
 @section('page_title', ($tmdbInfo->name ?? 'TV Show').' — MoviePickr')
 @section('og_title', ($tmdbInfo->name ?? 'TV Show').' — MoviePickr')
 @section('og_description', Str::limit($tmdbInfo->overview ?? 'Watch this TV show picked by MoviePickr.', 200))
-@section('og_image', $tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : '')
+@section('og_image', $tmdbInfo->backdrop_path ? 'https://image.tmdb.org/t/p/w1280'.$tmdbInfo->backdrop_path : ($tmdbInfo->poster_path ? 'https://image.tmdb.org/t/p/w500'.$tmdbInfo->poster_path : ''))
 @section('footer_pb', 'pb-32')
 @section('scripts')
     @vite(['resources/js/custom/showMore.js', 'resources/js/custom/carousel.js', 'resources/js/custom/trailerModal.js', 'resources/js/custom/criteriaForm.js'])

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -145,7 +145,11 @@
 @if($items->isNotEmpty())
 <div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
     <div class="max-w-7xl mx-auto flex items-center justify-between py-1">
-        <div class="flex-shrink-0"></div>
+        <div class="flex-shrink-0">
+            <button id="watchlist-share" class="btn-secondary text-sm" title="Share visible list">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+            </button>
+        </div>
         <div class="flex items-center gap-3">
             <button id="watchlist-roll" class="btn-accent px-8">Roll</button>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,6 +114,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
     Route::delete('users/{user}/roulettes/{roulette}',         [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
 });
 
+Route::get('/batch/share/{token}',      [\App\Http\Controllers\BatchShareController::class, 'show'])->name('batch.share');
 Route::get('/roulettes',                [RouletteController::class, 'index']);
 Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'moviesJson']);
 Route::get('/roulettes/{slug}',         [RouletteController::class, 'show']);


### PR DESCRIPTION
## Summary
- Share button on movie and TV detail pages — native share sheet on mobile, copies link on desktop with toast confirmation
- Batch sharing via base64 URL (`/batch/share/{token}`) — all movie data encoded in the URL so links never expire; cached for 30 days on first visit, re-decoded from URL if cache is cleared
- Share button added to batch bottom bar — works for movie batch, TV batch, and roulette batches
- Roulette manage page — share icon next to each roulette; active when public, greyed out with tooltip when private
- Clipboard fallback using `execCommand` for non-HTTPS local dev environments

## Test plan
- [x] Movie/TV detail share button — mobile: share sheet, desktop: link copied toast
- [x] Roll a batch → share icon in bottom-left → open shared link in incognito → same movies, no Roll/Filters buttons
- [x] Roll a roulette → share button appears
- [x] Roulette manage → public roulette has active share icon, private is greyed out