### PR TITLE
Move Share and Pick Together out of sticky bar into page header

### DIFF
--- a/app/Http/Controllers/BatchShareController.php
+++ b/app/Http/Controllers/BatchShareController.php
@@ -68,6 +68,18 @@ class BatchShareController extends Controller
         ]);
     }
 
+    public function create(\Illuminate\Http\Request $request): \Illuminate\Http\JsonResponse
+    {
+        $movies = $request->input('movies', []);
+        $type   = $request->input('type', 'movie');
+
+        if (empty($movies) || !is_array($movies)) {
+            return response()->json(['error' => 'No movies'], 422);
+        }
+
+        return response()->json(['token' => self::store($movies, $type)]);
+    }
+
     public static function store(array $results, string $type): string
     {
         $token = Str::random(8);

--- a/app/Http/Controllers/BatchShareController.php
+++ b/app/Http/Controllers/BatchShareController.php
@@ -3,19 +3,35 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class BatchShareController extends Controller
 {
     public function show(string $token)
     {
-        $cacheKey = 'batch_share_' . substr(hash('sha256', $token), 0, 24);
+        // Try DB first (new short tokens)
+        $share = DB::table('batch_shares')
+            ->where('token', $token)
+            ->where(fn($q) => $q->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+            ->first();
 
-        $data = Cache::remember($cacheKey, now()->addDays(30), function () use ($token) {
-            return self::decode($token);
-        });
+        if ($share) {
+            $data       = ['type' => $share->type, 'movies' => json_decode($share->movies, true)];
+            $shareToken = $token;
+        } else {
+            // Fall back to base64 decode for old long-form URLs
+            $cacheKey = 'batch_share_' . substr(hash('sha256', $token), 0, 24);
+            $data = Cache::remember($cacheKey, now()->addDays(30), function () use ($token) {
+                return self::decode($token);
+            });
 
-        if (!$data) {
-            abort(404);
+            if (!$data) {
+                abort(404);
+            }
+
+            // Persist so any re-share from this page uses a short URL
+            $shareToken = self::store($data['movies'], $data['type']);
         }
 
         $type    = $data['type'];
@@ -29,9 +45,9 @@ class BatchShareController extends Controller
             default  => 'Shared Movie Batch',
         };
 
-        $titles   = collect($results)->pluck('title')->filter()->take(4)->implode(', ');
-        $ogImage  = collect($results)->first(fn($m) => !empty($m['poster_path']));
-        $ogImage  = $ogImage ? 'https://image.tmdb.org/t/p/w500' . $ogImage['poster_path'] : null;
+        $titles  = collect($results)->pluck('title')->filter()->take(4)->implode(', ');
+        $ogImage = collect($results)->first(fn($m) => !empty($m['poster_path']));
+        $ogImage = $ogImage ? 'https://image.tmdb.org/t/p/w500' . $ogImage['poster_path'] : null;
 
         return view('batch', [
             'movies'         => ['results' => $results],
@@ -45,30 +61,36 @@ class BatchShareController extends Controller
                 : [],
             'mediaType'      => $isMixed ? 'mixed' : ($isTv ? 'tv' : 'movie'),
             'isShared'       => true,
-            'shareToken'     => self::encode($results, $type),
+            'shareToken'     => $shareToken,
             'ogTitle'        => $tags . ' — MoviePickr',
             'ogDescription'  => $titles ? 'Includes: ' . $titles . '...' : $tags,
             'ogImage'        => $ogImage,
         ]);
     }
 
-    public static function encode(array $results, string $type): string
+    public static function store(array $results, string $type): string
     {
-        $data = [
-            'type'   => $type,
-            'movies' => array_map(fn($m) => [
-                'id'           => $m['id'],
-                'poster_path'  => $m['poster_path'] ?? null,
-                'title'        => $m['title'] ?? $m['name'] ?? '',
-                'name'         => $m['name'] ?? $m['title'] ?? '',
-                'vote_average' => $m['vote_average'] ?? 0,
-                'release_date' => $m['release_date'] ?? $m['first_air_date'] ?? null,
-                'first_air_date' => $m['first_air_date'] ?? null,
-                'genre_ids'    => $m['genre_ids'] ?? [],
-            ], array_values($results)),
-        ];
+        $token = Str::random(8);
 
-        return rtrim(strtr(base64_encode(json_encode($data)), '+/', '-_'), '=');
+        DB::table('batch_shares')->insert([
+            'token'      => $token,
+            'movies'     => json_encode(array_values(array_map(fn($m) => [
+                'id'             => $m['id'],
+                'poster_path'    => $m['poster_path'] ?? null,
+                'title'          => $m['title'] ?? $m['name'] ?? '',
+                'name'           => $m['name'] ?? $m['title'] ?? '',
+                'vote_average'   => $m['vote_average'] ?? 0,
+                'release_date'   => $m['release_date'] ?? $m['first_air_date'] ?? null,
+                'first_air_date' => $m['first_air_date'] ?? null,
+                'genre_ids'      => $m['genre_ids'] ?? [],
+            ], $results))),
+            'type'       => $type,
+            'expires_at' => now()->addDays(30),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
     }
 
     private static function decode(string $token): ?array
@@ -77,7 +99,7 @@ class BatchShareController extends Controller
             $padded = strtr($token, '-_', '+/');
             $padded .= str_repeat('=', (4 - strlen($padded) % 4) % 4);
             $json   = base64_decode($padded, strict: true) ?: base64_decode($padded);
-            $data = json_decode($json, true);
+            $data   = json_decode($json, true);
             if (!isset($data['type'], $data['movies']) || !is_array($data['movies'])) {
                 return null;
             }

--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -73,7 +73,7 @@ class MoviePickController extends PickController
             'providersArray' => $movieService->buildProvidersArray($tmdb),
             'tag'            => 'Movies picked for you',
             'savedIds'       => $this->savedWatchlistIds(),
-            'shareToken'     => BatchShareController::encode($movies['results'], 'movie'),
+            'shareToken'     => BatchShareController::store($movies['results'], 'movie'),
         ]);
     }
 

--- a/app/Http/Controllers/RouletteController.php
+++ b/app/Http/Controllers/RouletteController.php
@@ -163,7 +163,7 @@ class RouletteController extends Controller
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
                 'mediaType'    => $isTv ? 'tv' : null,
-                'shareToken'   => BatchShareController::encode($results, $isTv ? 'tv' : 'movie'),
+                'shareToken'   => BatchShareController::store($results, $isTv ? 'tv' : 'movie'),
             ]));
         }
 
@@ -185,7 +185,7 @@ class RouletteController extends Controller
                 'title'        => $roulette->name . ' — MoviePickr',
                 'savedIds'     => $savedIds,
                 'mediaType'    => 'tv',
-                'shareToken'   => BatchShareController::encode($shows['results'], 'tv'),
+                'shareToken'   => BatchShareController::store($shows['results'], 'tv'),
             ]);
         }
 
@@ -204,7 +204,7 @@ class RouletteController extends Controller
             'tag'          => $roulette->name,
             'title'        => $roulette->name . ' — MoviePickr',
             'savedIds'     => $savedIds,
-            'shareToken'   => BatchShareController::encode($movies['results'], 'movie'),
+            'shareToken'   => BatchShareController::store($movies['results'], 'movie'),
         ]);
     }
 

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -76,7 +76,7 @@ class TvPickController extends PickController
             'tag'            => 'TV Shows picked for you',
             'savedIds'       => $this->savedWatchlistIds(),
             'mediaType'      => 'tv',
-            'shareToken'     => BatchShareController::encode($shows['results'], 'tv'),
+            'shareToken'     => BatchShareController::store($shows['results'], 'tv'),
         ]);
     }
 

--- a/database/migrations/2026_05_30_000001_create_batch_shares_table.php
+++ b/database/migrations/2026_05_30_000001_create_batch_shares_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('batch_shares', function (Blueprint $table) {
+            $table->string('token', 8)->primary();
+            $table->json('movies');
+            $table->string('type', 10)->default('movie');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('batch_shares');
+    }
+};

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -274,21 +274,30 @@ $(document).ready(function () {
         const hasMov = movies.some(m => m.media_type === 'movie');
         const type   = hasTV && hasMov ? 'mixed' : (hasTV ? 'tv' : 'movie');
 
-        const token = btoa(unescape(encodeURIComponent(JSON.stringify({ type, movies })))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-        const url   = window.location.origin + '/batch/share/' + token;
         const title = 'My Watchlist — MoviePickr';
+        const csrf  = document.querySelector('meta[name="csrf-token"]').content;
 
-        if (navigator.share) {
-            navigator.share({ title, url }).catch(() => {});
-        } else if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(url).then(() => window.showSuccessToast('Link copied!'));
-        } else {
-            const ta = document.createElement('textarea');
-            ta.value = url; ta.style.cssText = 'position:fixed;opacity:0';
-            document.body.appendChild(ta); ta.select();
-            try { document.execCommand('copy'); window.showSuccessToast('Link copied!'); } catch {}
-            document.body.removeChild(ta);
-        }
+        fetch('/batch/share', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrf },
+            body: JSON.stringify({ type, movies }),
+        })
+        .then(r => r.json())
+        .then(data => {
+            const url = window.location.origin + '/batch/share/' + data.token;
+            if (navigator.share) {
+                navigator.share({ title, url }).catch(() => {});
+            } else if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(url).then(() => window.showSuccessToast('Link copied!'));
+            } else {
+                const ta = document.createElement('textarea');
+                ta.value = url; ta.style.cssText = 'position:fixed;opacity:0';
+                document.body.appendChild(ta); ta.select();
+                try { document.execCommand('copy'); window.showSuccessToast('Link copied!'); } catch {}
+                document.body.removeChild(ta);
+            }
+        })
+        .catch(() => window.showErrorToast('Could not create share link.'));
     });
 
 });

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -34,14 +34,16 @@
                 title="Share this batch">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
             </button>
+            @endif
             @auth
+            @if(isset($shareToken))
             <button type="button" id="collab-start-btn" class="btn-secondary text-sm"
-                data-media-type="{{ $isTv ? 'tv' : 'movie' }}"
+                data-media-type="{{ $mediaType ?? 'movie' }}"
                 title="Pick together — veto movies in real time with friends">
                 Pick Together
             </button>
-            @endauth
             @endif
+            @endauth
             @auth
             <button type="button" id="save-roulette-btn"
                     class="btn-secondary text-sm flex items-center gap-1.5">

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,6 +115,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
 });
 
 Route::get('/batch/share/{token}',           [\App\Http\Controllers\BatchShareController::class,  'show'])->name('batch.share');
+Route::post('/batch/share',                  [\App\Http\Controllers\BatchShareController::class,  'create'])->name('batch.share.create');
 Route::post('/batch/collab',                           [\App\Http\Controllers\CollabBatchController::class, 'create'])->name('batch.collab.create')->middleware('auth');
 Route::get('/batch/collab/{token}',                    [\App\Http\Controllers\CollabBatchController::class, 'show'])->name('batch.collab.show');
 Route::post('/batch/collab/{token}/join',              [\App\Http\Controllers\CollabBatchController::class, 'join']);


### PR DESCRIPTION
The sticky bar had up to 5 buttons (Share, Pick Together, Filters,
New Batch, Roll) which overflowed on narrow mobile screens. Share and
Pick Together are batch-level actions, not navigation, so they belong
in the header alongside Save as Roulette. The sticky bar now has at
most 3 buttons (Filters, New Batch, Roll), which fit comfortably on
all screen sizes.