### PR TITLE
Auto-show winner when last card remains in Pick Together

### DIFF
--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -216,6 +216,10 @@ function applyState(newState, eventType, byName = '', byId = '', movieTitle = ''
         setTimeout(() => triggerRoll(e_winner), 400);
     }
 
+    if (prevMovieIds.size > 1 && state.movies.length === 1 && eventType !== 'rolled' && eventType !== 'refreshed') {
+        setTimeout(() => triggerRoll(state.movies[0]), 600);
+    }
+
     if (eventType === 'refreshed') {
         // Full re-render — wipe grid and graveyard, add all new cards
         document.getElementById('collab-grid').innerHTML = '';


### PR DESCRIPTION
When all but one movie is vetoed out, automatically trigger the winner
animation instead of waiting for Ready to Roll. caseOpening skips the
strip animation for a single card and goes straight to the winner overlay.