### PR TITLE
Add disabled visual styles to btn-accent and btn-secondary

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -105,6 +105,11 @@ html[data-theme="light"] {
     }
     .btn-accent:hover { background-color: #d44445; color: #fff; }
     .btn-accent:active { transform: scale(0.97); }
+    .btn-accent:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
 
     .btn-secondary {
         display: inline-flex;
@@ -126,6 +131,11 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
     .btn-secondary:active { transform: scale(0.97); }
+    .btn-secondary:disabled {
+        opacity: 0.35;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
     .btn-secondary.active {
         background-color: var(--bg-surface-hover);
         border-color: var(--border-hover);


### PR DESCRIPTION
Disabled buttons are dimmed to 35% opacity with a not-allowed cursor.
pointer-events: none prevents hover effects from showing on disabled state.