### PR TITLE
Show genres on Pick Together collab cards

### DIFF
--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -276,6 +276,7 @@ function addCardToGrid(movie) {
             <div class="p-2">
                 <div class="text-xs font-medium text-white truncate">${esc(title)}</div>
                 ${movie.vote_average ? `<div class="text-xs text-gray-500 mt-0.5">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
+                ${movie.genres ? `<div class="text-xs text-gray-600 mt-0.5 truncate">${esc(movie.genres)}</div>` : ''}
             </div>
         </div>`;
 

--- a/resources/js/custom/roulettes.js
+++ b/resources/js/custom/roulettes.js
@@ -157,6 +157,7 @@ function getBatchCards(rowSelector) {
             title:      el.dataset.title,
             rating:     parseFloat(el.dataset.rating) || 0,
             media_type: el.dataset.mediaType || 'movie',
+            genres:     el.dataset.genres || '',
         });
     });
     return cards;
@@ -391,6 +392,7 @@ $(document).on('click', '#collab-start-btn', function () {
             name:         c.title,
             vote_average: c.rating,
             media_type:   c.media_type,
+            genres:       c.genres || '',
         };
     }).filter(m => m.id > 0);
 

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -324,6 +324,7 @@ $(document).ready(function () {
             const mediaType  = ($(this).data('type') || 'movie') === 'tv' ? 'tv' : 'movie';
             const year       = parseInt($(this).data('year')) || 2000;
             const dateStr    = year + '-01-01';
+            const genres     = $(this).data('genres') || '';
             movies.push({
                 id,
                 poster_path:    posterPath,
@@ -334,6 +335,7 @@ $(document).ready(function () {
                 release_date:   mediaType === 'movie' ? dateStr : null,
                 first_air_date: mediaType === 'tv'    ? dateStr : null,
                 genre_ids:      [],
+                genres,
             });
         });
 

--- a/resources/views/includes/carousel.blade.php
+++ b/resources/views/includes/carousel.blade.php
@@ -11,6 +11,7 @@
              data-title="{{ $title }}"
              data-rating="{{ $result['vote_average'] ?? 0 }}"
              data-poster="{{ $result['poster_path'] ?? '' }}"
+             data-genres="{{ $genres[$result['id']] ?? '' }}"
              data-media-type="{{ $itemBase === 'tv' ? 'tv' : 'movie' }}"
              data-url="{{ url($itemBase.'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : ($linkSuffix ?? '') }}">
             <a href="{{ url($itemBase.'/'.$result['id']) }}{{ !empty($clearCriteria) ? '?i=new' : (!empty($linkSuffix ?? '') ? $linkSuffix : '') }}"


### PR DESCRIPTION
Adds genre labels to cards in the Pick Together (collab batch) session.

## Changes

- **`carousel.blade.php`** — expose `data-genres` on each batch card so JavaScript can read the pre-formatted genre string (e.g. "Action, Drama")
- **`roulettes.js`** — `getBatchCards()` now picks up the `genres` attribute; the collab session payload includes it when creating a session from a batch page
- **`watchlist.js`** — collab session payload includes genres from each watchlist card
- **`collabBatch.js`** — `addCardToGrid()` renders a small grey genre line below the rating when genres are available

No backend changes needed — genres are stored as part of the movie JSON object in the `collab_batches` table.