### PR TITLE
Show genres on initial collab card render

### DIFF
--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -109,6 +109,9 @@
                     @if(!empty($movie['vote_average']) && $movie['vote_average'] > 0)
                         <div class="text-xs text-gray-500 mt-0.5">★ {{ number_format($movie['vote_average'], 1) }}</div>
                     @endif
+                    @if(!empty($movie['genres']))
+                        <div class="text-xs text-gray-600 mt-0.5 truncate">{{ $movie['genres'] }}</div>
+                    @endif
                 </a>
             </div>
         </div>


### PR DESCRIPTION
The previous commit only handled dynamically added cards (via JS).
Initial cards are server-rendered by the Blade template and also
need the genres line.

https://claude.ai/code/session_01EWsegyfcL4jhprqw6BZcgZ