### PR TITLE
Fix genres disappearing after graveyard restore in Pick Together

### DIFF
--- a/app/Events/CollabStateUpdated.php
+++ b/app/Events/CollabStateUpdated.php
@@ -26,14 +26,15 @@ class CollabStateUpdated implements ShouldBroadcast
     )
     {
         $slim = fn(array $movies) => array_values(array_map(fn($m) => [
-            'id'           => $m['id'],
-            'poster_path'  => $m['poster_path'] ?? null,
-            'title'        => $m['title'] ?? $m['name'] ?? '',
-            'name'         => $m['name'] ?? $m['title'] ?? '',
-            'vote_average' => $m['vote_average'] ?? 0,
-            'media_type'   => $m['media_type'] ?? null,
-            'release_date' => $m['release_date'] ?? null,
+            'id'             => $m['id'],
+            'poster_path'    => $m['poster_path'] ?? null,
+            'title'          => $m['title'] ?? $m['name'] ?? '',
+            'name'           => $m['name'] ?? $m['title'] ?? '',
+            'vote_average'   => $m['vote_average'] ?? 0,
+            'media_type'     => $m['media_type'] ?? null,
+            'release_date'   => $m['release_date'] ?? null,
             'first_air_date' => $m['first_air_date'] ?? null,
+            'genres'         => $m['genres'] ?? '',
         ], $movies));
 
         $this->state = [


### PR DESCRIPTION
The `CollabStateUpdated` event uses a `$slim()` function to strip movie objects down to specific fields before broadcasting via WebSocket. `genres` wasn't included in that whitelist, so any card re-rendered by JS after a state change (e.g. restored from graveyard) lost its genre label.

Added `genres` to the slim mapping so it survives the broadcast and `addCardToGrid()` can display it correctly.