### PR TITLE
Make whole card clickable for voting in Pick Together

### DIFF
--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -106,9 +106,7 @@ window.addEventListener('beforeunload', () => {
 
 // ── Card tap — single tap on poster = vote ────────────────────────────
 document.getElementById('collab-grid').addEventListener('click', (e) => {
-    const target = e.target.closest('.vote-target');
-    if (!target) return;
-    const card = target.closest('.collab-card');
+    const card = e.target.closest('.collab-card');
     if (!card) return;
     castVote(parseInt(card.dataset.id), 'veto');
 });

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -74,7 +74,7 @@
             $itemUrl = ($isTv ? '/tv/' : '/movie/') . $movie['id'];
             $title   = $movie['title'] ?? $movie['name'] ?? '';
         @endphp
-        <div class="collab-card relative select-none" data-id="{{ $movie['id'] }}">
+        <div class="collab-card relative select-none cursor-pointer" data-id="{{ $movie['id'] }}">
             <div class="card overflow-hidden">
                 {{-- Poster — tap to vote --}}
                 <div class="vote-target aspect-[2/3] bg-white/[0.03] overflow-hidden relative cursor-pointer">


### PR DESCRIPTION
After removing the link from the card info area, only the poster region registered clicks for voting. Changed the click handler to listen on the whole card element instead, and added `cursor-pointer` to the Blade template card so the cursor correctly indicates the entire card is interactive.