### PR TITLE
Accent color for active filter toggles on watchlist page

### DIFF
--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -142,14 +142,14 @@ $(document).ready(function () {
     }
 
     $(document).on('click', '.watchlist-filter', function () {
-        $('.watchlist-filter').removeClass('active');
-        $(this).addClass('active');
+        $('.watchlist-filter').removeClass('active').removeClass('text-accent').addClass('text-gray-400');
+        $(this).addClass('active').addClass('text-accent').removeClass('text-gray-400');
         applyFilters();
     });
 
     $(document).on('click', '.type-filter', function () {
-        $('.type-filter').removeClass('active').addClass('text-gray-400');
-        $(this).addClass('active').removeClass('text-gray-400');
+        $('.type-filter').removeClass('active').removeClass('text-accent').addClass('text-gray-400');
+        $(this).addClass('active').addClass('text-accent').removeClass('text-gray-400');
         applyFilters();
     });
 

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -12,12 +12,12 @@
                 {{-- Status + type filters --}}
                 <div class="flex flex-wrap gap-2">
                     <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all" data-filter="all">All</button>
+                        <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-filter="all">All</button>
                         <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="saved">To Watch</button>
                         <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="watched">Watched</button>
                     </div>
                     <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="type-filter active text-xs px-3 py-1.5 rounded-md transition-all" data-type="all">All</button>
+                        <button class="type-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-type="all">All</button>
                         <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="movie">Films</button>
                         <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="tv">TV</button>
                     </div>


### PR DESCRIPTION
Active status and type filter buttons now show in accent color instead of the default text color. Inactive buttons remain gray. Both the initial Blade template state and the JS click handlers are updated to stay in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWsegyfcL4jhprqw6BZcgZ)_