### PR TITLE
Paginate TMDB recent requests in admin dashboard

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -84,8 +84,8 @@ class AdminController extends Controller
 
             $tmdb['recent'] = TmdbRequestLog::with('user')
                 ->orderByDesc('id')
-                ->limit(50)
-                ->get();
+                ->paginate(25)
+                ->appends(['tab' => 'tmdb']);
         }
 
         return view('admin.dashboard', compact('stats', 'rowOrder', 'activeTab', 'tmdb'));

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -360,6 +360,9 @@
             </table>
             @endif
         </div>
+        @if($tmdb['recent']->hasPages())
+            <div class="mt-4">{{ $tmdb['recent']->links() }}</div>
+        @endif
 
     @endif
 


### PR DESCRIPTION
The recent requests table was loading all 50 entries at once. Switched to 25 per page with Laravel pagination. The paginator appends `tab=tmdb` to page links so the active tab is preserved when navigating between pages.