### PR TITLE
Fix 500 on movie pages with missing TMDB fields

### DIFF
--- a/app/Http/Controllers/MovieController.php
+++ b/app/Http/Controllers/MovieController.php
@@ -81,7 +81,7 @@ class MovieController extends Controller
         }
 
         if ($similarMovies === null) {
-            $recommendations = $tmdbInfo->recommendations->results ?? [];
+            $recommendations = $tmdbInfo->recommendations?->results ?? [];
             if (count($recommendations) >= 4) {
                 $similarMovies = ['results' => array_map(fn($r) => (array) $r, array_slice($recommendations, 0, 20))];
                 $similarTitle  = 'You Might Also Like';
@@ -99,10 +99,10 @@ class MovieController extends Controller
             }
         }
 
-        $keywords   = array_slice((array) ($tmdbInfo->keywords->keywords ?? []), 0, 5);
+        $keywords   = array_slice((array) ($tmdbInfo->keywords?->keywords ?? []), 0, 5);
         $genres     = $movieService->genresString($tmdbInfo);
         $urls       = $link->links($omdbInfo);
-        $trailer    = $movieService->getTrailer($tmdbInfo->videos->results ?? []);
+        $trailer    = $movieService->getTrailer($tmdbInfo->videos?->results ?? []);
         $all_genres = $movieService->genres($tmdb);
         $user_input = $request->session()->get('userInput', 'default');
         $savedIds   = $this->savedWatchlistIds();

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -110,11 +110,11 @@ class TmdbClient implements ApiMovie
      */
     public function similarMovies(object $movieObj): ?array
     {
-        if ($movieObj->similar->total_results == 0) {
+        if (($movieObj->similar?->total_results ?? 0) == 0) {
             return null;
         }
 
-        $maxPage = min($movieObj->similar->total_pages, 20);
+        $maxPage = min($movieObj->similar->total_pages ?? 1, 20);
         $url     = 'https://api.themoviedb.org/3/movie/' . $movieObj->id . '/similar?'
             . http_build_query(['language' => 'en-US', 'page' => rand(1, $maxPage)]);
 


### PR DESCRIPTION
Some movies return null for `keywords`, `videos`, `recommendations`, or `similar` in the TMDB API response. Accessing a nested property on null throws a fatal TypeError in PHP 8 — the `??` operator at the end of the chain cannot catch it. Switched to the null-safe `?->` operator on all affected chains so missing fields fall back to empty arrays instead of 500ing.