### PR TITLE
Ensure storage directories exist on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,8 @@ jobs:
           port: 2244
           script: |
             cd /var/www/moviepicker
+            mkdir -p storage/framework/cache/data storage/framework/sessions storage/framework/views storage/logs
+            chmod -R 775 storage
             php artisan migrate --force
             php artisan config:cache
             php artisan route:cache


### PR DESCRIPTION
Laravel's file cache driver writes to `storage/framework/cache/data/` with hashed subdirectories. If those directories don't exist, cache writes fail with "Failed to open stream: No such file or directory". Added `mkdir -p` for all framework storage directories at the start of the post-deploy script so they're always present regardless of server state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWsegyfcL4jhprqw6BZcgZ)_