### PR TITLE
Fix double winner popup in Pick Together

### DIFF
--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -34,6 +34,9 @@ const hasCriteria = window.collabHasCriteria;
 // ── Grace period for leave toasts ────────────────────────────────────
 const leavePending = new Map(); // userId → timeout
 
+// ── Roll guard (prevents double animation) ────────────────────────────
+let rollInProgress = false;
+
 // ── Local state ───────────────────────────────────────────────────────
 let state = {
     movies:       window.collabMovies       || [],
@@ -458,6 +461,8 @@ function updateProgress() {
 
 // ── Roll animation then winner overlay ───────────────────────────────
 function triggerRoll(winner) {
+    if (rollInProgress) return;
+    rollInProgress = true;
     const allCards = [...state.movies, winner].filter((m, i, arr) =>
         m.poster_path && arr.findIndex(x => x.id === m.id) === i
     );
@@ -497,7 +502,10 @@ function showWinner(movie) {
 
 document.getElementById('winner-dismiss').addEventListener('click', () => {
     document.getElementById('winner-overlay').classList.add('hidden');
-    api('ready'); // toggle ready off so session can continue
+    rollInProgress = false;
+    if (state.ready.includes(myId)) {
+        api('ready'); // toggle ready off so session can continue
+    }
 });
 
 // ── Toasts ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Pressing "Stay Here" on the winner overlay was showing a second winner popup.

Two causes fixed:

- Added a `rollInProgress` flag that blocks `triggerRoll` from running again while an animation is already in progress. This stops the double-trigger where the user who clicked Ready received both the HTTP response roll and the WebSocket broadcast roll.
- The "Stay Here" dismiss handler now only calls `api('ready')` to toggle ready off when the current user was actually in the ready array. Previously it called it unconditionally, which in the auto-roll case (last card left standing) would add the user to ready and potentially trigger another server-side roll.