### PR TITLE
Align default rating filters: vote_average 6, vote_count 50

### DIFF
--- a/app/Http/Controllers/MoviePickController.php
+++ b/app/Http/Controllers/MoviePickController.php
@@ -16,8 +16,8 @@ class MoviePickController extends PickController
     private const DEFAULTS = [
         'with_original_language'   => 'en',
         'primary_release_date_gte' => 1990,
-        'vote_average_gte'         => 7,
-        'vote_count_gte'           => 100,
+        'vote_average_gte'         => 6,
+        'vote_count_gte'           => 50,
     ];
 
     public function single(CriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): RedirectResponse
@@ -104,7 +104,7 @@ class MoviePickController extends PickController
         session([self::SESSION_KEY => self::DEFAULTS]);
 
         $country = $movieService->getUserCountry();
-        $filters = ['vote_count.gte' => 50, 'vote_average.gte' => 5, 'primary_release_date.gte' => '1990-01-01', 'with_original_language' => 'en'];
+        $filters = ['vote_count.gte' => 50, 'vote_average.gte' => 6, 'primary_release_date.gte' => '1990-01-01', 'with_original_language' => 'en'];
 
         $totalPages = Cache::remember('homepage_movie_roll_pages_v2_' . $country, now()->addDay(), function () use ($tmdb, $filters, $country) {
             $first = $tmdb->discover(array_merge($filters, ['page' => 1]), $country);

--- a/app/Http/Controllers/TvPickController.php
+++ b/app/Http/Controllers/TvPickController.php
@@ -17,8 +17,8 @@ class TvPickController extends PickController
     private const DEFAULTS    = [
         'with_original_language' => 'en',
         'first_air_date_gte'     => 1990,
-        'vote_average_gte'       => 7,
-        'vote_count_gte'         => 100,
+        'vote_average_gte'       => 6,
+        'vote_count_gte'         => 50,
     ];
 
     public function single(TvCriteriaRequest $request, MovieService $movieService, TmdbClient $tmdb): RedirectResponse
@@ -107,7 +107,7 @@ class TvPickController extends PickController
         session([self::SESSION_KEY => self::DEFAULTS]);
 
         $country = $movieService->getUserCountry();
-        $filters = ['vote_average.gte' => 5, 'vote_count.gte' => 20, 'first_air_date.gte' => '1990-01-01', 'with_original_language' => 'en'];
+        $filters = ['vote_average.gte' => 6, 'vote_count.gte' => 50, 'first_air_date.gte' => '1990-01-01', 'with_original_language' => 'en'];
 
         $totalPages = Cache::remember('homepage_tv_roll_pages_v2_' . $country, now()->addDay(), function () use ($tmdb, $filters, $country) {
             $first = $tmdb->discoverTv(array_merge($filters, ['page' => 1]), $country);


### PR DESCRIPTION
DEFAULTS and the hardcoded homepage roll filters were out of sync — DEFAULTS said vote_average ≥ 7 / vote_count ≥ 100 but homepageRoll() was discovering with vote_average ≥ 5 / vote_count ≥ 20 (TV: 20).

- Lowered both DEFAULTS to vote_average ≥ 6, vote_count ≥ 50
- Aligned the homepage roll filters to match, so what's stored in session matches what's actually queried