### PR TITLE
Add media type filter and exclude-current-item to watchlist roll

### DIFF
--- a/app/Http/Controllers/WatchlistController.php
+++ b/app/Http/Controllers/WatchlistController.php
@@ -151,6 +151,7 @@ class WatchlistController extends Controller
     public function roll(Request $request)
     {
         $status = $request->query('status', 'all');
+        $type   = $request->query('type', 'all');
         $genres = $request->query('genres', '');
 
         $query = Auth::user()->watchlist();
@@ -160,6 +161,10 @@ class WatchlistController extends Controller
         }
 
         $items = $query->get();
+
+        if ($type !== 'all') {
+            $items = $items->filter(fn($item) => ($item->type ?? 'movie') === $type);
+        }
 
         if ($genres) {
             $genreList = array_map('trim', explode(',', $genres));
@@ -174,17 +179,20 @@ class WatchlistController extends Controller
             return redirect()->route('watchlist');
         }
 
+        $exclude   = (int) $request->query('exclude', 0);
+        $pickFrom  = $exclude ? $items->filter(fn($i) => $i->tmdb_id !== $exclude) : $items;
+        if ($pickFrom->isEmpty()) $pickFrom = $items;
+
         session(['roll_source' => 'other']);
-        $picked = $items->random();
+        $picked = $pickFrom->random();
 
         $base = $picked->type === 'tv'
             ? url('tv/' . $picked->tmdb_id)
             : route('movie', $picked->tmdb_id);
 
         $url = $base . '?wl_status=' . urlencode($status);
-        if ($genres) {
-            $url .= '&wl_genres=' . urlencode($genres);
-        }
+        if ($genres) $url .= '&wl_genres=' . urlencode($genres);
+        if ($type !== 'all') $url .= '&wl_type=' . urlencode($type);
 
         return redirect($url);
     }

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -186,9 +186,59 @@ $(document).ready(function () {
     $('#sort-select').on('change', applySort);
 
     /* ── Auto-roll when returning from movie page ──────────────────── */
-    if (sessionStorage.getItem('wl_autoroll') === '1') {
-        sessionStorage.removeItem('wl_autoroll');
-        setTimeout(() => $('#watchlist-roll').trigger('click'), 120);
+    const _autoParams = new URLSearchParams(window.location.search);
+    if (_autoParams.get('autoroll') === '1') {
+        const _status    = _autoParams.get('wl_status') || 'all';
+        const _type      = _autoParams.get('wl_type') || 'all';
+        const _genres    = _autoParams.get('wl_genres') || '';
+        const _exclude   = _autoParams.get('wl_exclude') || '';
+        const _genreList = _genres ? _genres.split(',').map(g => g.trim()).filter(Boolean) : [];
+
+        const eligible = $('.watchlist-card').filter(function () {
+            const statusMatch = _status === 'all' || $(this).attr('data-status') === _status;
+            const typeMatch   = _type === 'all'   || $(this).attr('data-type')   === _type;
+            if (!statusMatch || !typeMatch) return false;
+            if (_genreList.length === 0) return true;
+            const cardGenres = ($(this).attr('data-genres') || '').split(',').map(g => g.trim()).filter(Boolean);
+            return _genreList.every(g => cardGenres.includes(g));
+        });
+
+        if (eligible.length) {
+            // Pick winner from non-excluded items; fall back to full pool if only 1 item
+            const winnerPool = _exclude
+                ? eligible.filter(function () {
+                    return !($(this).find('a[href]').first().attr('href') || '').includes('/' + _exclude);
+                })
+                : eligible;
+            const pickFrom   = winnerPool.length > 0 ? winnerPool : eligible;
+            const picked     = pickFrom.eq(Math.floor(Math.random() * pickFrom.length));
+            const winnerHref = picked.find('a[href]').first().attr('href');
+            let   rollUrl    = winnerHref + '?wl_status=' + encodeURIComponent(_status);
+            if (_genres) rollUrl += '&wl_genres=' + encodeURIComponent(_genres);
+            if (_type !== 'all') rollUrl += '&wl_type=' + encodeURIComponent(_type);
+
+            const rollCards = eligible.toArray().map(el => {
+                const $el  = $(el);
+                const img  = $el.find('img').first();
+                return {
+                    url:        $el.find('a[href]').first().attr('href'),
+                    poster:     img.length ? (img.attr('src') || '').replace('w500', 'w342') : '',
+                    title:      $el.data('title') || '',
+                    rating:     parseFloat($el.data('rating')) || 0,
+                    media_type: ($el.data('type') || 'movie') === 'tv' ? 'tv' : 'movie',
+                };
+            });
+
+            const winnerIdx = rollCards.findIndex(c => c.url === winnerHref);
+            setTimeout(() => {
+                if (localStorage.getItem('wl_animation') !== '0') {
+                    runCaseOpening(rollCards, winnerIdx >= 0 ? winnerIdx : 0, rollUrl, rollCards[0]?.media_type || 'movie');
+                } else {
+                    window.showProgress?.();
+                    window.location.href = rollUrl;
+                }
+            }, 120);
+        }
     }
 
     /* ── Case opening animation ────────────────────────────────────── */
@@ -200,10 +250,10 @@ $(document).ready(function () {
             const title     = $(this).data('title') || '';
             const rating    = parseFloat($(this).data('rating')) || 0;
             const mediaType = ($(this).data('type') || 'movie') === 'tv' ? 'tv' : 'movie';
-            if (link.length && img.length) {
+            if (link.length) {
                 cards.push({
                     url:        link.attr('href'),
-                    poster:     (img.attr('src') || '').replace('w500', 'w342'),
+                    poster:     img.length ? (img.attr('src') || '').replace('w500', 'w342') : '',
                     title,
                     rating,
                     media_type: mediaType,
@@ -225,11 +275,13 @@ $(document).ready(function () {
         }
 
         const status    = $('.watchlist-filter.active').data('filter') || 'all';
+        const type      = $('.type-filter.active').data('type') || 'all';
         const genres    = genreSelect ? genreSelect.getValue().join(',') : '';
         const pickedIdx = Math.floor(Math.random() * visible.length);
         const picked    = visible.eq(pickedIdx);
         let url = picked.find('a').first().attr('href') + '?wl_status=' + status;
         if (genres) url += '&wl_genres=' + encodeURIComponent(genres);
+        if (type !== 'all') url += '&wl_type=' + encodeURIComponent(type);
 
         if (typeof gtag !== 'undefined') gtag('event', 'watchlist_rolled');
 

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -381,8 +381,16 @@
 @if(request()->query('wl_status'))
 <script>
 document.getElementById('wl-roll-btn').addEventListener('click', function () {
-    sessionStorage.setItem('wl_autoroll', '1');
-    window.location.href = '{{ route('watchlist') }}';
+    const params  = new URLSearchParams(window.location.search);
+    const status  = params.get('wl_status') || 'all';
+    const type    = params.get('wl_type') || 'all';
+    const genres  = params.get('wl_genres') || '';
+    const exclude = (window.location.pathname.match(/\/movie\/(\d+)/) || [])[1] || '';
+    let url = '{{ route('watchlist') }}?autoroll=1&wl_status=' + encodeURIComponent(status);
+    if (genres)  url += '&wl_genres='  + encodeURIComponent(genres);
+    if (type !== 'all') url += '&wl_type=' + encodeURIComponent(type);
+    if (exclude) url += '&wl_exclude=' + exclude;
+    window.location.href = url;
 });
 </script>
 @endif

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -474,11 +474,7 @@
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Filters</button>
             @endif
             @if(request()->query('wl_status'))
-                @php
-                    $wlParams = ['status' => request()->query('wl_status')];
-                    if (request()->query('wl_genres')) $wlParams['genres'] = request()->query('wl_genres');
-                @endphp
-                <a href="{{ route('watchlist.roll', $wlParams) }}" class="btn-accent long-single text-center">Roll</a>
+                <button id="wl-roll-btn" class="btn-accent long-single">Roll</button>
             @elseif(session('tvPersonRollIds'))
                 <a href="{{ route('person.roll.tv.next') }}" class="btn-accent long-single text-center">Roll</a>
             @else
@@ -487,5 +483,22 @@
         </div>
     </div>
 </div>
+
+@if(request()->query('wl_status'))
+<script>
+document.getElementById('wl-roll-btn').addEventListener('click', function () {
+    const params  = new URLSearchParams(window.location.search);
+    const status  = params.get('wl_status') || 'all';
+    const type    = params.get('wl_type') || 'all';
+    const genres  = params.get('wl_genres') || '';
+    const exclude = (window.location.pathname.match(/\/tv\/(\d+)/) || [])[1] || '';
+    let url = '{{ route('watchlist') }}?autoroll=1&wl_status=' + encodeURIComponent(status);
+    if (genres)  url += '&wl_genres='  + encodeURIComponent(genres);
+    if (type !== 'all') url += '&wl_type=' + encodeURIComponent(type);
+    if (exclude) url += '&wl_exclude=' + exclude;
+    window.location.href = url;
+});
+</script>
+@endif
 
 @endsection


### PR DESCRIPTION
## Summary

- Adds `type` filter (`movie`/`tv`/`all`) to `WatchlistController::roll` so the active type filter persists across rolls
- Roll button on movie and TV show pages now passes `wl_exclude` with the current TMDB ID so the same item is never re-rolled immediately
- Auto-roll trigger moved from `sessionStorage` to URL query params (`autoroll=1`) so all filter state (status, type, genres, exclude) survives the round-trip back to the watchlist
- Case-opening animation runs client-side on auto-roll using the visible cards, respecting all active filters

## Test plan

- [x] Open watchlist, set type filter to "Films", roll — confirm only movies appear in the animation and the result is a movie
- [x] Open watchlist, set type filter to "TV", roll — confirm only TV shows cycle through
- [x] Roll from a movie detail page, click Roll again — confirm the same movie is never picked when other options exist
- [x] Roll from a TV show detail page, same check
- [x] Roll with genre filter active — confirm genre filter is preserved across rolls
- [x] Roll with only one item in the filtered pool — confirm it still picks that item (no infinite loop)