### PR TITLE
Clean up routes and protect internal endpoints

### DIFF
--- a/app/Http/Controllers/TmdbProxyController.php
+++ b/app/Http/Controllers/TmdbProxyController.php
@@ -8,21 +8,6 @@ use Illuminate\Http\Request;
 
 class TmdbProxyController extends Controller
 {
-    public function searchMovies(Request $request, TmdbClient $tmdb): JsonResponse
-    {
-        $query = trim($request->string('q'));
-        if (!$query) {
-            return response()->json([]);
-        }
-
-        $results = collect($tmdb->searchMovies($query)['results'] ?? [])
-            ->take(6)
-            ->values()
-            ->all();
-
-        return response()->json($results);
-    }
-
     public function searchPeople(Request $request, TmdbClient $tmdb): JsonResponse
     {
         $query = trim($request->string('q'));
@@ -47,34 +32,6 @@ class TmdbProxyController extends Controller
     public function person(int $id, TmdbClient $tmdb): JsonResponse
     {
         return response()->json($tmdb->person($id));
-    }
-
-    public function searchTv(Request $request, TmdbClient $tmdb): JsonResponse
-    {
-        $query = trim($request->string('q'));
-        if (!$query) {
-            return response()->json([]);
-        }
-
-        $results = collect($tmdb->searchTv($query)['results'] ?? [])
-            ->map(function ($show) {
-                $show['title']        = $show['name'] ?? '';
-                $show['release_date'] = $show['first_air_date'] ?? '';
-                return $show;
-            })
-            ->take(4)
-            ->values()
-            ->map(function ($show) use ($tmdb) {
-                try {
-                    $status = $tmdb->tvStatus($show['id']);
-                    $show['tv_status']     = $status['status'];
-                    $show['last_air_date'] = $status['last_air_date'];
-                } catch (\Throwable) {}
-                return $show;
-            })
-            ->all();
-
-        return response()->json($results);
     }
 
     public function searchAll(Request $request, TmdbClient $tmdb): JsonResponse

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,7 +52,8 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        'admin'    => \App\Http\Middleware\AdminMiddleware::class,
+        'internal' => \App\Http\Middleware\InternalOnly::class,
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Middleware/InternalOnly.php
+++ b/app/Http/Middleware/InternalOnly.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class InternalOnly
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!$request->ajax()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,10 +44,8 @@ Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 Route::middleware('internal')->group(function () {
     Route::get('/userinput', UserInputController::class);
     Route::prefix('tmdb')->group(function () {
-        Route::get('/search/all', [TmdbProxyController::class, 'searchAll']);
-        Route::get('/search/movies', [TmdbProxyController::class, 'searchMovies']);
+        Route::get('/search/all',    [TmdbProxyController::class, 'searchAll']);
         Route::get('/search/people', [TmdbProxyController::class, 'searchPeople']);
-        Route::get('/search/tv', [TmdbProxyController::class, 'searchTv']);
         Route::get('/people/{id}', [TmdbProxyController::class, 'person']);
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ContactController;
@@ -14,10 +13,6 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\WatchlistController;
 use App\Http\Controllers\TmdbProxyController;
 use App\Http\Controllers\UserRouletteController;
-use App\Http\Controllers\Admin\AdminController;
-use App\Http\Controllers\Admin\AdminRouletteController;
-use App\Http\Controllers\Admin\AdminUserController;
-use App\Http\Controllers\Admin\RowOrderController;
 use App\Http\Controllers\TvCriteriaController;
 use App\Http\Controllers\TvPickController;
 use App\Http\Controllers\TvShowController;
@@ -25,116 +20,129 @@ use App\Http\Controllers\TvSeasonController;
 use App\Http\Controllers\TvEpisodeController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\PersonRollController;
+use App\Http\Controllers\BatchShareController;
+use App\Http\Controllers\CollabBatchController;
+use App\Http\Controllers\Admin\AdminController;
+use App\Http\Controllers\Admin\AdminRouletteController;
+use App\Http\Controllers\Admin\AdminUserController;
+use App\Http\Controllers\Admin\RowOrderController;
 
-Route::get('/',  HomeController::class);
+// ── Public pages ─────────────────────────────────────────────────────────────
+Route::get('/', HomeController::class);
 Route::post('/', ContactController::class);
 Route::get('/privacy', fn() => view('privacy'))->name('privacy');
-
-// Auth
-Route::get('/auth/google',          [AuthController::class, 'redirect'])->name('auth.google');
-Route::get('/auth/google/callback', [AuthController::class, 'callback']);
-Route::post('/logout',              [AuthController::class, 'logout'])->name('logout');
-
-// Watchlist (auth required)
-Route::middleware('auth')->group(function () {
-    Route::get('/watchlist',                    [WatchlistController::class, 'index'])->name('watchlist');
-    Route::get('/watchlist/roll',               [WatchlistController::class, 'roll'])->name('watchlist.roll');
-    Route::post('/watchlist/toggle',            [WatchlistController::class, 'toggle'])->name('watchlist.toggle');
-    Route::delete('/watchlist/{tmdbId}',        [WatchlistController::class, 'remove'])->name('watchlist.remove');
-    Route::patch('/watchlist/{tmdbId}/status',  [WatchlistController::class, 'setStatus'])->name('watchlist.status');
-});
-
-Route::get('/userinput', UserInputController::class);
-
-Route::prefix('tmdb')->group(function () {
-    Route::get('/search/all',      [TmdbProxyController::class, 'searchAll']);
-    Route::get('/search/movies', [TmdbProxyController::class, 'searchMovies']);
-    Route::get('/search/people', [TmdbProxyController::class, 'searchPeople']);
-    Route::get('/search/tv',     [TmdbProxyController::class, 'searchTv']);
-    Route::get('/people/{id}',   [TmdbProxyController::class, 'person']);
-});
 Route::get('/no-results', NoResultsController::class)->name('no-results');
-Route::get('/criteria',  CriteriaController::class);
+Route::get('/criteria', CriteriaController::class);
+Route::get('/tv/criteria', TvCriteriaController::class);
 
+// ── Auth ──────────────────────────────────────────────────────────────────────
+Route::get('/auth/google', [AuthController::class, 'redirect'])->name('auth.google');
+Route::get('/auth/google/callback', [AuthController::class, 'callback']);
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+
+// ── TMDB proxy (AJAX only) ────────────────────────────────────────────────────
+Route::middleware('internal')->group(function () {
+    Route::get('/userinput', UserInputController::class);
+    Route::prefix('tmdb')->group(function () {
+        Route::get('/search/all', [TmdbProxyController::class, 'searchAll']);
+        Route::get('/search/movies', [TmdbProxyController::class, 'searchMovies']);
+        Route::get('/search/people', [TmdbProxyController::class, 'searchPeople']);
+        Route::get('/search/tv', [TmdbProxyController::class, 'searchTv']);
+        Route::get('/people/{id}', [TmdbProxyController::class, 'person']);
+    });
+});
+
+// ── Movie & TV picks (throttled) ──────────────────────────────────────────────
 Route::middleware('throttle:60,1')->group(function () {
-    Route::match(['get', 'post'], '/movie',               [MoviePickController::class, 'single']);
-    Route::match(['get', 'post'], '/multiple',            [MoviePickController::class, 'batch']);
-    Route::get('/movie/roll',                             [MoviePickController::class, 'homepageRoll']);
+    Route::match(['get', 'post'], '/movie', [MoviePickController::class, 'single']);
+    Route::match(['get', 'post'], '/multiple', [MoviePickController::class, 'batch']);
+    Route::get('/movie/roll', [MoviePickController::class, 'homepageRoll']);
     Route::match(['get', 'post'], '/movie/roll/criteria', [MoviePickController::class, 'criteriaRoll']);
 
-    Route::match(['get', 'post'], '/tv/pick',             [TvPickController::class, 'single'])->name('tv.pick');
-    Route::match(['get', 'post'], '/tv/multiple',         [TvPickController::class, 'batch']);
-    Route::get('/tv/roll',                                [TvPickController::class, 'homepageRoll']);
-    Route::match(['get', 'post'], '/tv/roll/criteria',    [TvPickController::class, 'criteriaRoll']);
+    Route::match(['get', 'post'], '/tv/pick', [TvPickController::class, 'single'])->name('tv.pick');
+    Route::match(['get', 'post'], '/tv/multiple', [TvPickController::class, 'batch']);
+    Route::get('/tv/roll', [TvPickController::class, 'homepageRoll']);
+    Route::match(['get', 'post'], '/tv/roll/criteria', [TvPickController::class, 'criteriaRoll']);
 
-    Route::get('/person/{id}/roll/movie',                 [PersonRollController::class, 'movie'])->name('person.roll.movie');
-    Route::get('/person/{id}/roll/tv',                    [PersonRollController::class, 'tv'])->name('person.roll.tv');
-    Route::get('/person/{id}/roll/movie/json',            [PersonRollController::class, 'movieRollJson']);
-    Route::get('/person/{id}/roll/tv/json',               [PersonRollController::class, 'tvRollJson']);
+    Route::get('/person/{id}/roll/movie', [PersonRollController::class, 'movie'])->name('person.roll.movie');
+    Route::get('/person/{id}/roll/tv', [PersonRollController::class, 'tv'])->name('person.roll.tv');
+    Route::middleware('internal')->group(function () {
+        Route::get('/person/{id}/roll/movie/json', [PersonRollController::class, 'movieRollJson']);
+        Route::get('/person/{id}/roll/tv/json', [PersonRollController::class, 'tvRollJson']);
+    });
 });
 
-Route::get('/movie/{id}',          MovieController::class)->name('movie');
+// ── Detail pages ──────────────────────────────────────────────────────────────
+Route::get('/movie/{id}', MovieController::class)->name('movie');
 
-// TV Shows
-Route::get('/tv/criteria',                     TvCriteriaController::class);
-Route::get('/tv/{id}',             TvShowController::class)->name('tv.show');
+Route::get('/tv/{id}', TvShowController::class)->name('tv.show');
 Route::get('/tv/{id}/season/{season}', TvSeasonController::class)->name('tv.season');
 Route::get('/tv/{id}/season/{season}/episode/{episode}', TvEpisodeController::class)->name('tv.episode');
 
-Route::get('/person/roll/tv/next',    [PersonRollController::class, 'nextTvRoll'])->name('person.roll.tv.next');
-Route::get('/person/{id}',            PersonController::class)->name('person');
+Route::get('/person/roll/tv/next', [PersonRollController::class, 'nextTvRoll'])->name('person.roll.tv.next');
+Route::get('/person/{id}', PersonController::class)->name('person');
 
-// My Roulettes (auth required — must be before /roulettes/{slug} wildcard)
+// ── Roulettes ─────────────────────────────────────────────────────────────────
+Route::get('/roulettes', [RouletteController::class, 'index']);
+Route::get('/roulettes/{slug}/movies', [RouletteController::class, 'moviesJson']);
+Route::get('/roulettes/{slug}', [RouletteController::class, 'show']);
+
+
+// ── Batch & Collab ────────────────────────────────────────────────────────────
+Route::get('/batch/share/{token}', [BatchShareController::class, 'show'])->name('batch.share');
+Route::post('/batch/share', [BatchShareController::class, 'create'])->name('batch.share.create');
+
+Route::post('/batch/collab', [CollabBatchController::class, 'create'])->name('batch.collab.create')->middleware('auth');
+Route::get('/batch/collab/{token}', [CollabBatchController::class, 'show'])->name('batch.collab.show');
+Route::middleware('internal')->prefix('batch/collab/{token}')->group(function () {
+    Route::post('/join',         [CollabBatchController::class, 'join']);
+    Route::post('/leave',        [CollabBatchController::class, 'leave']);
+    Route::post('/heartbeat',    [CollabBatchController::class, 'heartbeat']);
+    Route::post('/vote/{movieId}', [CollabBatchController::class, 'vote']);
+    Route::post('/ready',        [CollabBatchController::class, 'toggleReady']);
+    Route::post('/refresh',      [CollabBatchController::class, 'toggleRefreshVote']);
+    Route::post('/remove-votes', [CollabBatchController::class, 'removeVotes']);
+});
+
+// ── Watchlist (auth required) ─────────────────────────────────────────────────
+Route::middleware('auth')->group(function () {
+    Route::get('/watchlist', [WatchlistController::class, 'index'])->name('watchlist');
+    Route::get('/watchlist/roll', [WatchlistController::class, 'roll'])->name('watchlist.roll');
+    Route::post('/watchlist/toggle', [WatchlistController::class, 'toggle'])->name('watchlist.toggle');
+    Route::delete('/watchlist/{tmdbId}', [WatchlistController::class, 'remove'])->name('watchlist.remove');
+    Route::patch('/watchlist/{tmdbId}/status', [WatchlistController::class, 'setStatus'])->name('watchlist.status');
+});
+
+// ── My Roulettes (auth required) ──────────────────────────────────────────────
 Route::middleware('auth')->prefix('my-roulettes')->name('my-roulettes.')->group(function () {
-    Route::get('/',                              [UserRouletteController::class, 'index'])->name('index');
-    Route::get('/manage',                        [UserRouletteController::class, 'manage'])->name('manage');
-    Route::get('/manage/create',                 [UserRouletteController::class, 'create'])->name('create');
-    Route::post('/manage',                       [UserRouletteController::class, 'store'])->name('store');
-    Route::get('/manage/{roulette}/edit',        [UserRouletteController::class, 'edit'])->name('edit');
-    Route::put('/manage/{roulette}',             [UserRouletteController::class, 'update'])->name('update');
-    Route::delete('/manage/{roulette}',          [UserRouletteController::class, 'destroy'])->name('destroy');
-    Route::patch('/manage/{roulette}/toggle',    [UserRouletteController::class, 'togglePublic'])->name('toggle');
+    Route::get('/', [UserRouletteController::class, 'index'])->name('index');
+    Route::get('/manage', [UserRouletteController::class, 'manage'])->name('manage');
+    Route::get('/manage/create', [UserRouletteController::class, 'create'])->name('create');
+    Route::post('/manage', [UserRouletteController::class, 'store'])->name('store');
+    Route::get('/manage/{roulette}/edit', [UserRouletteController::class, 'edit'])->name('edit');
+    Route::put('/manage/{roulette}', [UserRouletteController::class, 'update'])->name('update');
+    Route::delete('/manage/{roulette}', [UserRouletteController::class, 'destroy'])->name('destroy');
+    Route::patch('/manage/{roulette}/toggle', [UserRouletteController::class, 'togglePublic'])->name('toggle');
     Route::post('/manage/{roulette}/refresh-poster', [UserRouletteController::class, 'refreshPoster'])->name('refresh-poster');
-    Route::post('/manage/rows/reorder',              [UserRouletteController::class, 'reorderRows'])->name('rows.reorder');
-    Route::post('/from-criteria',                    [UserRouletteController::class, 'fromCriteria'])->name('from-criteria');
+    Route::post('/manage/rows/reorder', [UserRouletteController::class, 'reorderRows'])->name('rows.reorder');
+    Route::post('/from-criteria', [UserRouletteController::class, 'fromCriteria'])->name('from-criteria');
 });
 
-// Admin (must be before /roulettes/{slug} wildcard)
+// ── Admin (auth + admin role) ─────────────────────────────────────────────────
 Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(function () {
-    Route::get('/',                             [AdminController::class, 'index'])->name('dashboard');
-    Route::post('roulettes/reorder',                    [AdminRouletteController::class, 'reorder'])->name('roulettes.reorder');
-    Route::post('roulettes/{roulette}/refresh-poster',  [AdminRouletteController::class, 'refreshPoster'])->name('roulettes.refresh-poster');
-    Route::patch('roulettes/{roulette}/toggle',          [AdminRouletteController::class, 'togglePublic'])->name('roulettes.toggle');
-    Route::patch('roulettes/{roulette}/system',          [AdminRouletteController::class, 'toggleSystem'])->name('roulettes.system');
+    Route::get('/', [AdminController::class, 'index'])->name('dashboard');
+    Route::post('roulettes/reorder', [AdminRouletteController::class, 'reorder'])->name('roulettes.reorder');
+    Route::post('roulettes/{roulette}/refresh-poster', [AdminRouletteController::class, 'refreshPoster'])->name('roulettes.refresh-poster');
+    Route::patch('roulettes/{roulette}/toggle', [AdminRouletteController::class, 'togglePublic'])->name('roulettes.toggle');
     Route::resource('roulettes', AdminRouletteController::class)->except(['show']);
-    Route::get('rows',                                          [RowOrderController::class, 'index'])->name('rows.index');
-    Route::post('rows/reorder',                               [RowOrderController::class, 'reorder'])->name('rows.reorder');
-    Route::get('users',                                        [AdminUserController::class, 'index'])->name('users.index');
-    Route::get('users/{user}',                                 [AdminUserController::class, 'show'])->name('users.show');
-    Route::delete('users/{user}/roulettes/{roulette}',         [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
+    Route::get('rows', [RowOrderController::class, 'index'])->name('rows.index');
+    Route::post('rows/reorder', [RowOrderController::class, 'reorder'])->name('rows.reorder');
+    Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
+    Route::get('users/{user}', [AdminUserController::class, 'show'])->name('users.show');
+    Route::delete('users/{user}/roulettes/{roulette}', [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
 });
 
-Route::get('/batch/share/{token}',           [\App\Http\Controllers\BatchShareController::class,  'show'])->name('batch.share');
-Route::post('/batch/share',                  [\App\Http\Controllers\BatchShareController::class,  'create'])->name('batch.share.create');
-Route::post('/batch/collab',                           [\App\Http\Controllers\CollabBatchController::class, 'create'])->name('batch.collab.create')->middleware('auth');
-Route::get('/batch/collab/{token}',                    [\App\Http\Controllers\CollabBatchController::class, 'show'])->name('batch.collab.show');
-Route::post('/batch/collab/{token}/join',              [\App\Http\Controllers\CollabBatchController::class, 'join']);
-Route::post('/batch/collab/{token}/leave',             [\App\Http\Controllers\CollabBatchController::class, 'leave']);
-Route::post('/batch/collab/{token}/heartbeat',         [\App\Http\Controllers\CollabBatchController::class, 'heartbeat']);
-Route::post('/batch/collab/{token}/vote/{movieId}',    [\App\Http\Controllers\CollabBatchController::class, 'vote']);
-Route::post('/batch/collab/{token}/ready',             [\App\Http\Controllers\CollabBatchController::class, 'toggleReady']);
-Route::post('/batch/collab/{token}/refresh',           [\App\Http\Controllers\CollabBatchController::class, 'toggleRefreshVote']);
-Route::post('/batch/collab/{token}/remove-votes',      [\App\Http\Controllers\CollabBatchController::class, 'removeVotes']);
-Route::get('/roulettes',                [RouletteController::class, 'index']);
-Route::get('/roulettes/{slug}/movies',  [RouletteController::class, 'moviesJson']);
-Route::get('/roulettes/{slug}',         [RouletteController::class, 'show']);
-
-// Legacy roulette URLs → redirect to new slugs
-Route::get('/roulettes/netflix/horror',    fn() => redirect('/roulettes/netflix-horror', 301));
-Route::get('/roulettes/netflix/doc',       fn() => redirect('/roulettes/netflix-docs', 301));
-Route::get('/roulettes/netflix/animovies', fn() => redirect('/roulettes/netflix-anime', 301));
-
-// Dev-only login bypass (local environment only)
+// ── Dev only ──────────────────────────────────────────────────────────────────
 if (app()->environment('local')) {
     Route::get('/dev/login', function () {
         $email = config('api.admin_email') ?: 'dev@local.test';


### PR DESCRIPTION
## Summary

- Reorganize routes/web.php into clearly labeled sections for readability
- Add InternalOnly middleware to block direct access to TMDB proxy and internal AJAX endpoints
- Group collab batch action routes under a shared prefix
- Remove dead toggleSystem route (method didn't exist)
- Remove legacy roulette redirect routes