### PR TITLE
Refactor collab batch to delta broadcasts

### DIFF
--- a/app/Events/CollabStateUpdated.php
+++ b/app/Events/CollabStateUpdated.php
@@ -2,56 +2,23 @@
 
 namespace App\Events;
 
-use App\Models\CollabBatch;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Carbon;
 
 class CollabStateUpdated implements ShouldBroadcast
 {
     use Dispatchable, SerializesModels;
 
-    public array $state;
-
     public function __construct(
         public string $token,
-        CollabBatch   $batch,
         public string $eventType,
         public string $byName     = '',
         public string $byId       = '',
         public string $movieTitle = '',
-        public array  $winner     = [],
-    )
-    {
-        $slim = fn(array $movies) => array_values(array_map(fn($m) => [
-            'id'             => $m['id'],
-            'poster_path'    => $m['poster_path'] ?? null,
-            'title'          => $m['title'] ?? $m['name'] ?? '',
-            'name'           => $m['name'] ?? $m['title'] ?? '',
-            'vote_average'   => $m['vote_average'] ?? 0,
-            'media_type'     => $m['media_type'] ?? null,
-            'release_date'   => $m['release_date'] ?? null,
-            'first_air_date' => $m['first_air_date'] ?? null,
-            'genres'         => $m['genres'] ?? '',
-        ], $movies));
-
-        $this->state = [
-            'movies'        => $slim($batch->movies ?? []),
-            'graveyard'     => $slim($batch->graveyard ?? []),
-            'votes'         => $batch->votes ?? [],
-            'restore_votes' => $batch->restore_votes ?? [],
-            'ready'         => array_values($batch->ready ?? []),
-            'refresh_votes' => array_values($batch->refresh_votes ?? []),
-            'participants'  => array_values(
-                collect($batch->participants ?? [])
-                    ->filter(fn($p) => Carbon::parse($p['last_seen'])->gt(now()->subMinutes(3)))
-                    ->values()
-                    ->all()
-            ),
-        ];
-    }
+        public array  $delta      = [],
+    ) {}
 
     public function broadcastOn(): Channel
     {

--- a/app/Http/Controllers/CollabBatchController.php
+++ b/app/Http/Controllers/CollabBatchController.php
@@ -74,7 +74,7 @@ class CollabBatchController extends Controller
         ]);
 
         $sessionKey = $request->input('media_type') === 'tv' ? 'tvInput' : 'userInput';
-        $movies     = collect($request->movies)->shuffle()->take(100)->values()->all();
+        $movies     = $request->movies;
 
         $batch = CollabBatch::create([
             'token'      => Str::random(8),

--- a/app/Http/Controllers/CollabBatchController.php
+++ b/app/Http/Controllers/CollabBatchController.php
@@ -331,6 +331,45 @@ class CollabBatchController extends Controller
         return response()->json(['ok' => true, 'rolled' => false]);
     }
 
+    // ── Try Again — vote-based, requires all participants ────────────
+
+    public function restart(Request $request, string $token)
+    {
+        $batch  = $this->guardBatch($token);
+        $userId = $request->input('userId');
+        $name   = $request->input('name', 'Someone');
+        $pCount = $this->participantCount($batch);
+
+        $votes = $batch->try_again_votes ?? [];
+
+        if (in_array($userId, $votes)) {
+            $votes = array_values(array_diff($votes, [$userId]));
+            $batch->update(['try_again_votes' => $votes]);
+            $this->broadcast($token, 'try_again_off', $name, $userId, '', ['tryAgainVotes' => $votes, 'needed' => $pCount]);
+            return response()->json(['ok' => true]);
+        }
+
+        $votes[] = $userId;
+        $batch->update(['try_again_votes' => $votes]);
+
+        if (count($votes) >= $pCount) {
+            $movies = array_merge($batch->movies, $batch->graveyard ?? []);
+            $batch->update([
+                'movies'          => $movies,
+                'graveyard'       => [],
+                'votes'           => [],
+                'restore_votes'   => [],
+                'ready'           => [],
+                'try_again_votes' => [],
+            ]);
+            $this->broadcast($token, 'restarted', $name, $userId, '', ['movies' => $this->slimAll($movies)]);
+            return response()->json(['ok' => true, 'restarted' => true]);
+        }
+
+        $this->broadcast($token, 'try_again_on', $name, $userId, '', ['tryAgainVotes' => $votes, 'needed' => $pCount]);
+        return response()->json(['ok' => true]);
+    }
+
     // ── Roll New Batch ────────────────────────────────────────────────
 
     public function toggleRefreshVote(Request $request, string $token, MovieService $movieService, TmdbClient $tmdb)

--- a/app/Http/Controllers/CollabBatchController.php
+++ b/app/Http/Controllers/CollabBatchController.php
@@ -197,6 +197,22 @@ class CollabBatchController extends Controller
         return response()->json(['ok' => true]);
     }
 
+    // ── Voting signal (ephemeral, no DB write) ────────────────────────
+
+    public function voting(Request $request, string $token)
+    {
+        $batch   = $this->guardBatch($token);
+        $userId  = $request->input('userId');
+        $name    = $request->input('name', 'Someone');
+        $movieId = (int) $request->input('movieId');
+
+        if (!$movieId) return response()->json(['ok' => true]);
+
+        $isRecalling = (bool) $request->input('isRecalling', false);
+        $this->broadcast($token, 'voting', $name, $userId, '', ['movieId' => $movieId, 'isRecalling' => $isRecalling]);
+        return response()->json(['ok' => true]);
+    }
+
     // ── Voting ────────────────────────────────────────────────────────
 
     public function vote(Request $request, string $token, int $movieId)

--- a/app/Http/Controllers/CollabBatchController.php
+++ b/app/Http/Controllers/CollabBatchController.php
@@ -27,15 +27,34 @@ class CollabBatchController extends Controller
         return max(1, count($this->activeParticipants($batch)));
     }
 
-    private function vetoThreshold(int $n): int   { return (int) floor($n / 2) + 1; }
-    private function readyThreshold(int $n): int  { return (int) ceil($n * 0.75); }
+    private function vetoThreshold(int $n): int    { return (int) floor($n / 2) + 1; }
+    private function readyThreshold(int $n): int   { return (int) ceil($n * 0.75); }
     private function refreshThreshold(int $n): int { return $n; }
 
     // ── Helpers ───────────────────────────────────────────────────────
 
-    private function broadcast(CollabBatch $batch, string $type, string $byName = '', string $byId = '', string $movieTitle = '', array $winner = []): void
+    private function slim(array $movie): array
     {
-        broadcast(new CollabStateUpdated($batch->token, $batch->fresh(), $type, $byName, $byId, $movieTitle, $winner));
+        return [
+            'id'             => $movie['id'],
+            'poster_path'    => $movie['poster_path'] ?? null,
+            'title'          => $movie['title'] ?? $movie['name'] ?? '',
+            'vote_average'   => $movie['vote_average'] ?? 0,
+            'media_type'     => $movie['media_type'] ?? null,
+            'release_date'   => $movie['release_date'] ?? null,
+            'first_air_date' => $movie['first_air_date'] ?? null,
+            'genres'         => $movie['genres'] ?? '',
+        ];
+    }
+
+    private function slimAll(array $movies): array
+    {
+        return array_values(array_map(fn($m) => $this->slim($m), $movies));
+    }
+
+    private function broadcast(string $token, string $type, string $byName = '', string $byId = '', string $movieTitle = '', array $delta = []): void
+    {
+        broadcast(new CollabStateUpdated($token, $type, $byName, $byId, $movieTitle, $delta));
     }
 
     private function guardBatch(string $token): CollabBatch
@@ -55,10 +74,11 @@ class CollabBatchController extends Controller
         ]);
 
         $sessionKey = $request->input('media_type') === 'tv' ? 'tvInput' : 'userInput';
+        $movies     = collect($request->movies)->shuffle()->take(100)->values()->all();
 
         $batch = CollabBatch::create([
             'token'      => Str::random(8),
-            'movies'     => $request->movies,
+            'movies'     => $movies,
             'media_type' => $request->input('media_type', 'movie'),
             'created_by' => auth()->id(),
             'expires_at' => now()->addHours(24),
@@ -80,9 +100,9 @@ class CollabBatchController extends Controller
 
     public function join(Request $request, string $token)
     {
-        $batch    = $this->guardBatch($token);
-        $userId   = $request->input('userId');
-        $name     = $request->input('name', 'Anonymous');
+        $batch  = $this->guardBatch($token);
+        $userId = $request->input('userId');
+        $name   = $request->input('name', 'Anonymous');
 
         $participants = collect($batch->participants ?? [])
             ->reject(fn($p) => $p['userId'] === $userId)
@@ -91,7 +111,9 @@ class CollabBatchController extends Controller
             ->all();
 
         $batch->update(['participants' => $participants]);
-        $this->broadcast($batch, 'join', $name, $userId);
+
+        $participant = collect($participants)->firstWhere('userId', $userId);
+        $this->broadcast($token, 'join', $name, $userId, '', ['participant' => $participant]);
 
         return response()->json(['ok' => true]);
     }
@@ -115,18 +137,17 @@ class CollabBatchController extends Controller
             'refresh_votes' => array_values(array_diff($batch->refresh_votes ?? [], [$userId])),
         ]);
 
-        $this->broadcast($batch, 'leave', $name, $userId);
+        $this->broadcast($token, 'leave', $name, $userId);
         return response()->json(['ok' => true]);
     }
 
     public function removeVotes(Request $request, string $token)
     {
-        $batch        = CollabBatch::where('token', $token)->first();
+        $batch = CollabBatch::where('token', $token)->first();
         if (!$batch) return response()->json(['ok' => true]);
 
         $targetUserId = $request->input('targetUserId');
 
-        // Remove from all vote maps idempotently
         $votes = collect($batch->votes ?? [])
             ->map(fn($voters) => array_values(array_diff($voters, [$targetUserId])))
             ->all();
@@ -136,17 +157,21 @@ class CollabBatchController extends Controller
             ->all();
 
         $batch->update(['votes' => $votes, 'restore_votes' => $restoreVotes]);
-        $this->broadcast($batch, 'vote_cleanup');
+
+        $this->broadcast($token, 'vote_cleanup', '', '', '', [
+            'votes'        => $votes,
+            'restoreVotes' => $restoreVotes,
+        ]);
 
         return response()->json(['ok' => true]);
     }
 
     public function heartbeat(Request $request, string $token)
     {
-        $batch    = $this->guardBatch($token);
-        $userId   = $request->input('userId');
-        $name     = $request->input('name', 'Anonymous');
-        $oldName  = collect($batch->participants ?? [])->firstWhere('userId', $userId)['name'] ?? null;
+        $batch   = $this->guardBatch($token);
+        $userId  = $request->input('userId');
+        $name    = $request->input('name', 'Anonymous');
+        $oldName = collect($batch->participants ?? [])->firstWhere('userId', $userId)['name'] ?? null;
 
         $participants = collect($batch->participants ?? [])
             ->map(fn($p) => $p['userId'] === $userId
@@ -161,11 +186,12 @@ class CollabBatchController extends Controller
 
         $batch->update(['participants' => $participants]);
 
-        // Broadcast so others see name changes live
+        $participant = collect($participants)->firstWhere('userId', $userId);
+
         if ($oldName !== null && $oldName !== $name) {
-            $this->broadcast($batch, 'rename', $name, $userId, $oldName);
+            $this->broadcast($token, 'rename', $name, $userId, $oldName, ['participant' => $participant]);
         } elseif ($oldName === null) {
-            $this->broadcast($batch, 'join', $name, $userId);
+            $this->broadcast($token, 'join', $name, $userId, '', ['participant' => $participant]);
         }
 
         return response()->json(['ok' => true]);
@@ -183,19 +209,16 @@ class CollabBatchController extends Controller
         $pCount  = $this->participantCount($batch);
 
         if ($type === 'veto') {
-            $votes    = $batch->votes ?? [];
-            $voters   = $votes[$key] ?? [];
+            $votes   = $batch->votes ?? [];
+            $voters  = $votes[$key] ?? [];
             $removing = in_array($userId, $voters);
 
-            if ($removing) {
-                $voters = array_values(array_diff($voters, [$userId]));
-            } else {
-                $voters[] = $userId;
-            }
+            $voters      = $removing
+                ? array_values(array_diff($voters, [$userId]))
+                : [...$voters, $userId];
             $votes[$key] = $voters;
 
             if (count($voters) >= $this->vetoThreshold($pCount)) {
-                // Move to graveyard
                 $movie = collect($batch->movies)->first(fn($m) => $m['id'] === $movieId);
                 if ($movie) {
                     $graveyard = $batch->graveyard ?? [];
@@ -203,46 +226,64 @@ class CollabBatchController extends Controller
                     $movies = collect($batch->movies)->reject(fn($m) => $m['id'] === $movieId)->values()->all();
                     unset($votes[$key]);
                     $batch->update(['movies' => $movies, 'graveyard' => $graveyard, 'votes' => $votes]);
+
+                    $this->broadcast($token, 'veto_threshold', $name, $userId, $movie['title'] ?? $movie['name'] ?? '', [
+                        'movieId' => $movieId,
+                        'movie'   => $this->slim($movie),
+                        'votes'   => $votes,
+                    ]);
+                    return response()->json(['ok' => true]);
                 }
-            } else {
-                $batch->update(['votes' => $votes]);
             }
+
+            $batch->update(['votes' => $votes]);
+            $movieTitle = collect($batch->movies)->firstWhere('id', $movieId)['title']
+                ?? collect($batch->movies)->firstWhere('id', $movieId)['name'] ?? '';
+            $direction  = $removing ? 'off' : 'on';
+
+            $this->broadcast($token, "vote_veto_{$direction}", $name, $userId, $movieTitle, [
+                'movieId' => $movieId,
+                'voters'  => $voters,
+            ]);
+
         } else {
-            // Restore vote
             $restoreVotes = $batch->restore_votes ?? [];
             $voters       = $restoreVotes[$key] ?? [];
             $removing     = in_array($userId, $voters);
 
-            if ($removing) {
-                $voters = array_values(array_diff($voters, [$userId]));
-            } else {
-                $voters[] = $userId;
-            }
+            $voters             = $removing
+                ? array_values(array_diff($voters, [$userId]))
+                : [...$voters, $userId];
             $restoreVotes[$key] = $voters;
 
             if (count($voters) >= $this->vetoThreshold($pCount)) {
-                // Restore from graveyard
                 $movie = collect($batch->graveyard ?? [])->first(fn($m) => $m['id'] === $movieId);
                 if ($movie) {
-                    $movies = $batch->movies;
-                    $movies[] = $movie;
+                    $movies    = [...$batch->movies, $movie];
                     $graveyard = collect($batch->graveyard ?? [])->reject(fn($m) => $m['id'] === $movieId)->values()->all();
                     unset($restoreVotes[$key]);
                     $batch->update(['movies' => $movies, 'graveyard' => $graveyard, 'restore_votes' => $restoreVotes]);
+
+                    $this->broadcast($token, 'restore_threshold', $name, $userId, $movie['title'] ?? $movie['name'] ?? '', [
+                        'movieId'      => $movieId,
+                        'movie'        => $this->slim($movie),
+                        'restoreVotes' => $restoreVotes,
+                    ]);
+                    return response()->json(['ok' => true]);
                 }
-            } else {
-                $batch->update(['restore_votes' => $restoreVotes]);
             }
+
+            $batch->update(['restore_votes' => $restoreVotes]);
+            $movieTitle = collect($batch->graveyard ?? [])->firstWhere('id', $movieId)['title']
+                ?? collect($batch->graveyard ?? [])->firstWhere('id', $movieId)['name'] ?? '';
+            $direction  = $removing ? 'off' : 'on';
+
+            $this->broadcast($token, "vote_restore_{$direction}", $name, $userId, $movieTitle, [
+                'movieId' => $movieId,
+                'voters'  => $voters,
+            ]);
         }
 
-        $movieTitle = collect(array_merge($batch->fresh()->movies ?? [], $batch->fresh()->graveyard ?? []))
-            ->firstWhere('id', $movieId)['title']
-            ?? collect(array_merge($batch->fresh()->movies ?? [], $batch->fresh()->graveyard ?? []))
-            ->firstWhere('id', $movieId)['name'] ?? '';
-
-        $direction = $removing ? 'off' : 'on';
-        $eventType = "vote_{$type}_{$direction}"; // vote_veto_on/off or vote_restore_on/off
-        $this->broadcast($batch, $eventType, $name, $userId, $movieTitle);
         return response()->json(['ok' => true]);
     }
 
@@ -250,10 +291,10 @@ class CollabBatchController extends Controller
 
     public function toggleReady(Request $request, string $token)
     {
-        $batch   = $this->guardBatch($token);
-        $userId  = $request->input('userId');
-        $name    = $request->input('name', 'Someone');
-        $pCount  = $this->participantCount($batch);
+        $batch  = $this->guardBatch($token);
+        $userId = $request->input('userId');
+        $name   = $request->input('name', 'Someone');
+        $pCount = $this->participantCount($batch);
 
         $ready = $batch->ready ?? [];
         if (in_array($userId, $ready)) {
@@ -263,15 +304,14 @@ class CollabBatchController extends Controller
         }
         $batch->update(['ready' => $ready]);
 
-        // Check threshold
         if (count($ready) >= $this->readyThreshold($pCount) && count($batch->movies) > 0) {
             $winner = $batch->movies[array_rand($batch->movies)];
-            $this->broadcast($batch, 'rolled', $name, $userId, '', $winner);
+            $this->broadcast($token, 'rolled', $name, $userId, '', ['winner' => $this->slim($winner)]);
             return response()->json(['ok' => true, 'rolled' => true, 'winner' => $winner]);
         }
 
         $isReady = in_array($userId, $ready);
-        $this->broadcast($batch, $isReady ? 'ready_on' : 'ready_off', $name, $userId);
+        $this->broadcast($token, $isReady ? 'ready_on' : 'ready_off', $name, $userId, '', ['ready' => $ready]);
         return response()->json(['ok' => true, 'rolled' => false]);
     }
 
@@ -279,16 +319,16 @@ class CollabBatchController extends Controller
 
     public function toggleRefreshVote(Request $request, string $token, MovieService $movieService, TmdbClient $tmdb)
     {
-        $batch   = $this->guardBatch($token);
-        $userId  = $request->input('userId');
-        $name    = $request->input('name', 'Someone');
-        $pCount  = $this->participantCount($batch);
+        $batch  = $this->guardBatch($token);
+        $userId = $request->input('userId');
+        $name   = $request->input('name', 'Someone');
+        $pCount = $this->participantCount($batch);
 
         $refreshVotes = $batch->refresh_votes ?? [];
         if (in_array($userId, $refreshVotes)) {
             $refreshVotes = array_values(array_diff($refreshVotes, [$userId]));
             $batch->update(['refresh_votes' => $refreshVotes]);
-            $this->broadcast($batch, 'refresh_off', $name, $userId);
+            $this->broadcast($token, 'refresh_off', $name, $userId, '', ['refreshVotes' => $refreshVotes]);
             return response()->json(['ok' => true, 'refreshed' => false]);
         }
 
@@ -296,9 +336,9 @@ class CollabBatchController extends Controller
         $batch->update(['refresh_votes' => $refreshVotes]);
 
         if (count($refreshVotes) >= $this->refreshThreshold($pCount) && $batch->criteria) {
-            $criteria  = $batch->criteria;
-            $isTv      = $batch->media_type === 'tv';
-            $country   = $movieService->getUserCountry();
+            $criteria = $batch->criteria;
+            $isTv     = $batch->media_type === 'tv';
+            $country  = $movieService->getUserCountry();
 
             try {
                 if ($isTv) {
@@ -320,14 +360,14 @@ class CollabBatchController extends Controller
                     'refresh_votes' => [],
                 ]);
 
-                $this->broadcast($batch, 'refreshed', $name, $userId);
+                $this->broadcast($token, 'refreshed', $name, $userId, '', ['movies' => $this->slimAll($movies)]);
                 return response()->json(['ok' => true, 'refreshed' => true]);
             } catch (\Throwable) {
                 $batch->update(['refresh_votes' => []]);
             }
         }
 
-        $this->broadcast($batch, 'refresh_on', $name, $userId);
+        $this->broadcast($token, 'refresh_on', $name, $userId, '', ['refreshVotes' => $refreshVotes]);
         return response()->json(['ok' => true, 'refreshed' => false]);
     }
 }

--- a/app/Models/CollabBatch.php
+++ b/app/Models/CollabBatch.php
@@ -12,7 +12,7 @@ class CollabBatch extends Model
 
     protected $fillable = [
         'token','movies','media_type','created_by','expires_at',
-        'votes','restore_votes','graveyard','ready','refresh_votes','participants','criteria',
+        'votes','restore_votes','graveyard','ready','refresh_votes','try_again_votes','participants','criteria',
     ];
 
     protected $casts = [
@@ -21,7 +21,8 @@ class CollabBatch extends Model
         'restore_votes' => 'array',
         'graveyard'     => 'array',
         'ready'         => 'array',
-        'refresh_votes' => 'array',
+        'refresh_votes'   => 'array',
+        'try_again_votes' => 'array',
         'participants'  => 'array',
         'criteria'      => 'array',
         'expires_at'    => 'datetime',

--- a/database/migrations/2026_06_02_112755_add_try_again_votes_to_collab_batches_table.php
+++ b/database/migrations/2026_06_02_112755_add_try_again_votes_to_collab_batches_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('collab_batches', function (Blueprint $table) {
+            $table->json('try_again_votes')->nullable()->after('refresh_votes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('collab_batches', function (Blueprint $table) {
+            $table->dropColumn('try_again_votes');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -473,6 +473,12 @@ html[data-theme="light"] {
     }
     .pulse-dot { animation: pulse-dot 2s ease-in-out infinite; }
 
+    @keyframes collab-voting-ring {
+        0%, 100% { opacity: 0.5; transform: scale(1); }
+        50%       { opacity: 1;   transform: scale(1.02); }
+    }
+    .collab-voting-ring { animation: collab-voting-ring 0.7s ease-in-out infinite; }
+
     @keyframes collab-veto-glow-pulse {
         0%, 100% { box-shadow: 0 0 var(--glow-min, 4px) var(--glow-spread-min, 2px) rgba(239,68,68,var(--glow-opacity, 0.3)); }
         50%       { box-shadow: 0 0 var(--glow-max, 14px) var(--glow-spread-max, 6px) rgba(239,68,68,var(--glow-opacity, 0.5)); }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -473,6 +473,17 @@ html[data-theme="light"] {
     }
     .pulse-dot { animation: pulse-dot 2s ease-in-out infinite; }
 
+    @keyframes tension-vignette-pulse {
+        0%, 100% { opacity: 0.6; }
+        50%       { opacity: 1; }
+    }
+    @keyframes tension-progress-pulse {
+        0%, 100% { opacity: 1; }
+        50%       { opacity: 0.5; }
+    }
+    .tension-vignette  { animation: tension-vignette-pulse 2s ease-in-out infinite; }
+    .tension-progress  { animation: tension-progress-pulse 0.8s ease-in-out infinite; }
+
     @keyframes collab-voting-ring {
         0%, 100% { opacity: 0.5; transform: scale(1); }
         50%       { opacity: 1;   transform: scale(1.02); }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -473,6 +473,44 @@ html[data-theme="light"] {
     }
     .pulse-dot { animation: pulse-dot 2s ease-in-out infinite; }
 
+    @keyframes collab-veto-glow-pulse {
+        0%, 100% { box-shadow: 0 0 var(--glow-min, 4px) var(--glow-spread-min, 2px) rgba(239,68,68,var(--glow-opacity, 0.3)); }
+        50%       { box-shadow: 0 0 var(--glow-max, 14px) var(--glow-spread-max, 6px) rgba(239,68,68,var(--glow-opacity, 0.5)); }
+    }
+
+    @keyframes collab-veto-shake {
+        0%   { transform: translateX(0) rotate(0deg); }
+        20%  { transform: translateX(-8px) rotate(-3deg); }
+        40%  { transform: translateX(8px) rotate(3deg); }
+        60%  { transform: translateX(-6px) rotate(-2deg); }
+        80%  { transform: translateX(6px) rotate(2deg); }
+        100% { transform: translateX(0) rotate(0deg); }
+    }
+    @keyframes collab-veto-out {
+        0%   { transform: scale(1); opacity: 1; }
+        100% { transform: scale(0.7) translateY(12px); opacity: 0; }
+    }
+    @keyframes collab-restore-in {
+        0%   { transform: scale(0.6); opacity: 0; }
+        60%  { transform: scale(1.06); opacity: 1; }
+        100% { transform: scale(1); opacity: 1; }
+    }
+    @keyframes collab-red-flash {
+        0%   { box-shadow: 0 0 0 0 rgba(239,68,68,0); }
+        40%  { box-shadow: 0 0 0 8px rgba(239,68,68,0.5); }
+        100% { box-shadow: 0 0 0 0 rgba(239,68,68,0); }
+    }
+    @keyframes collab-green-flash {
+        0%   { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+        40%  { box-shadow: 0 0 0 8px rgba(34,197,94,0.5); }
+        100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+    }
+    @keyframes collab-btn-glow {
+        0%, 100% { box-shadow: 0 0 8px 2px rgba(192,57,58,0.4); }
+        50%       { box-shadow: 0 0 18px 6px rgba(192,57,58,0.7); }
+    }
+    .collab-btn-glow { animation: collab-btn-glow 1.2s ease-in-out infinite; }
+
     @keyframes confetti-fall {
         0%   { transform: translateY(0) rotate(0deg); opacity: 1; }
         100% { transform: translateY(100vh) rotate(720deg); opacity: 0; }

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -63,7 +63,7 @@ const echo = new Echo({
 });
 
 echo.channel('batch.' + token).listen('.CollabStateUpdated', (e) => {
-    applyState(e.state, e.eventType, e.byName, e.byId, e.movieTitle, e.winner || null);
+    applyDelta(e.eventType, e.byName || '', e.byId || '', e.movieTitle || '', e.delta || {});
 });
 
 // ── API helpers ───────────────────────────────────────────────────────
@@ -138,23 +138,25 @@ document.getElementById('refresh-btn')?.addEventListener('click', () => {
     api('refresh');
 });
 
-// ── Apply state from broadcast ────────────────────────────────────────
-function applyState(newState, eventType, byName = '', byId = '', movieTitle = '', e_winner = null) {
-    const isMe = byId === myId || byName === myName;
+// ── Apply delta from broadcast ────────────────────────────────────────
+function applyDelta(eventType, byName, byId, movieTitle, delta) {
+    const isMe = byId === myId;
     const who  = byName || 'Someone';
 
-    if (!isMe && who) {
+    // ── Toasts ──
+    if (!isMe) {
         if      (eventType === 'vote_veto_on'     && movieTitle) showToast(`${who} voted to skip ${movieTitle}`);
         else if (eventType === 'vote_veto_off'    && movieTitle) showToast(`${who} changed their mind on ${movieTitle}`);
+        else if (eventType === 'veto_threshold'   && movieTitle) showToast(`${movieTitle} was voted out`);
         else if (eventType === 'vote_restore_on'  && movieTitle) showToast(`${who} voted to restore ${movieTitle}`);
         else if (eventType === 'vote_restore_off' && movieTitle) showToast(`${who} changed their mind on restoring ${movieTitle}`);
-        else if (eventType === 'ready_on')                   showToast(`${who} is ready to roll`);
-        else if (eventType === 'ready_off')                  showToast(`${who} is no longer ready`);
-        else if (eventType === 'refresh_on')                 showToast(`${who} wants a new batch`);
-        else if (eventType === 'refresh_off')                showToast(`${who} changed their mind on new batch`);
-        else if (eventType === 'rename')                     showToast(`${movieTitle || 'Someone'} is now ${who}`, 'green');
+        else if (eventType === 'restore_threshold'&& movieTitle) showToast(`${movieTitle} was restored`, 'green');
+        else if (eventType === 'ready_on')                       showToast(`${who} is ready to roll`);
+        else if (eventType === 'ready_off')                      showToast(`${who} is no longer ready`);
+        else if (eventType === 'refresh_on')                     showToast(`${who} wants a new batch`);
+        else if (eventType === 'refresh_off')                    showToast(`${who} changed their mind on new batch`);
+        else if (eventType === 'rename')                         showToast(`${movieTitle || 'Someone'} is now ${who}`, 'green');
         else if (eventType === 'join') {
-            // Cancel pending leave toast — they just refreshed
             if (leavePending.has(byId)) {
                 clearTimeout(leavePending.get(byId));
                 leavePending.delete(byId);
@@ -162,7 +164,6 @@ function applyState(newState, eventType, byName = '', byId = '', movieTitle = ''
                 showToast(`${who} joined`, 'green');
             }
         } else if (eventType === 'leave') {
-            // Delay 8s — if they rejoin (page refresh) the toast and vote cleanup are cancelled
             const t = setTimeout(() => {
                 leavePending.delete(byId);
                 showToast(`${who} left`);
@@ -171,67 +172,110 @@ function applyState(newState, eventType, byName = '', byId = '', movieTitle = ''
             leavePending.set(byId, t);
         }
     }
-    const prevMovieIds    = new Set(state.movies.map(m => m.id));
-    const prevGraveyardIds = new Set(state.graveyard.map(m => m.id));
 
-    state = {
-        movies:       newState.movies        || [],
-        graveyard:    newState.graveyard      || [],
-        votes:        newState.votes          || {},
-        restoreVotes: newState.restore_votes  || {},
-        ready:        newState.ready          || [],
-        refreshVotes: newState.refresh_votes  || [],
-        participants: newState.participants    || [],
-    };
+    const prevMovieCount = state.movies.length;
 
-    const newMovieIds     = new Set(state.movies.map(m => m.id));
-    const newGraveyardIds = new Set(state.graveyard.map(m => m.id));
+    // ── State updates ──
+    switch (eventType) {
 
-    // Cards moved to graveyard
-    prevMovieIds.forEach(id => {
-        if (!newMovieIds.has(id)) animateToGraveyard(id);
-    });
+        case 'vote_veto_on':
+        case 'vote_veto_off':
+            if (delta.voters.length) {
+                state.votes[String(delta.movieId)] = delta.voters;
+            } else {
+                delete state.votes[String(delta.movieId)];
+            }
+            updateAllVoteBars();
+            break;
 
-    // Cards restored from graveyard
-    prevGraveyardIds.forEach(id => {
-        if (!newGraveyardIds.has(id)) removeGraveyardCard(id);
-    });
+        case 'veto_threshold':
+            state.movies = state.movies.filter(m => m.id !== delta.movieId);
+            delete state.votes[String(delta.movieId)];
+            state.graveyard.push(delta.movie);
+            animateToGraveyard(delta.movieId);
+            addCardToGraveyard(delta.movie);
+            updateAllVoteBars();
+            updateProgress();
+            break;
 
-    // Add newly restored cards to grid
-    state.movies.forEach(movie => {
-        if (!prevMovieIds.has(movie.id)) addCardToGrid(movie);
-    });
+        case 'vote_restore_on':
+        case 'vote_restore_off':
+            if (delta.voters.length) {
+                state.restoreVotes[String(delta.movieId)] = delta.voters;
+            } else {
+                delete state.restoreVotes[String(delta.movieId)];
+            }
+            updateAllVoteBars();
+            break;
 
-    // Add new graveyard cards
-    state.graveyard.forEach(movie => {
-        if (!prevGraveyardIds.has(movie.id)) addCardToGraveyard(movie);
-    });
+        case 'restore_threshold':
+            state.graveyard = state.graveyard.filter(m => m.id !== delta.movieId);
+            delete state.restoreVotes[String(delta.movieId)];
+            state.movies.push(delta.movie);
+            removeGraveyardCard(delta.movieId);
+            addCardToGrid(delta.movie);
+            updateAllVoteBars();
+            updateProgress();
+            break;
 
-    updateAllVoteBars();
-    updateParticipants();
-    updateReadyButton();
-    updateRefreshButton();
-    updateProgress();
+        case 'join':
+        case 'rename':
+            state.participants = state.participants.filter(p => p.userId !== delta.participant.userId);
+            state.participants.push(delta.participant);
+            updateParticipants();
+            break;
 
-    if (eventType === 'rolled' && e_winner) {
-        setTimeout(() => triggerRoll(e_winner), 400);
+        case 'leave':
+            state.participants = state.participants.filter(p => p.userId !== byId);
+            updateParticipants();
+            break;
+
+        case 'ready_on':
+        case 'ready_off':
+            state.ready = delta.ready;
+            updateReadyButton();
+            break;
+
+        case 'refresh_on':
+        case 'refresh_off':
+            state.refreshVotes = delta.refreshVotes;
+            updateRefreshButton();
+            break;
+
+        case 'vote_cleanup':
+            state.votes        = delta.votes;
+            state.restoreVotes = delta.restoreVotes;
+            updateAllVoteBars();
+            break;
+
+        case 'rolled':
+            setTimeout(() => triggerRoll(delta.winner), 400);
+            break;
+
+        case 'refreshed':
+            state.movies       = delta.movies;
+            state.graveyard    = [];
+            state.votes        = {};
+            state.restoreVotes = {};
+            state.ready        = [];
+            state.refreshVotes = [];
+            document.getElementById('collab-grid').innerHTML    = '';
+            document.getElementById('graveyard-grid').innerHTML = '';
+            document.getElementById('graveyard-section').classList.add('hidden');
+            totalMovies = state.movies.length;
+            document.getElementById('total-num').textContent = totalMovies;
+            state.movies.forEach(movie => addCardToGrid(movie));
+            updateAllVoteBars();
+            updateReadyButton();
+            updateRefreshButton();
+            updateProgress();
+            showToast('New batch loaded — let\'s go!', 'green');
+            break;
     }
 
-    if (prevMovieIds.size > 1 && state.movies.length === 1 && eventType !== 'rolled' && eventType !== 'refreshed') {
+    // Auto-roll when 1 movie left
+    if (prevMovieCount > 1 && state.movies.length === 1 && eventType !== 'rolled' && eventType !== 'refreshed') {
         setTimeout(() => triggerRoll(state.movies[0]), 600);
-    }
-
-    if (eventType === 'refreshed') {
-        // Full re-render — wipe grid and graveyard, add all new cards
-        document.getElementById('collab-grid').innerHTML = '';
-        document.getElementById('graveyard-grid').innerHTML = '';
-        document.getElementById('graveyard-section').classList.add('hidden');
-
-        totalMovies = state.movies.length;
-        document.getElementById('total-num').textContent = totalMovies;
-
-        state.movies.forEach(movie => addCardToGrid(movie));
-        showToast('New batch loaded — let\'s go!', 'green');
     }
 }
 
@@ -281,6 +325,7 @@ function addCardToGrid(movie) {
             <div class="p-2">
                 <div class="text-xs font-medium text-white truncate">${esc(title)}</div>
                 ${movie.vote_average ? `<div class="text-xs text-gray-500 mt-0.5">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
+                ${(movie.release_date || movie.first_air_date) ? `<div class="text-xs text-gray-600 mt-0.5">${(movie.release_date || movie.first_air_date).slice(0, 4)}</div>` : ''}
                 ${movie.genres ? `<div class="text-xs text-gray-600 mt-0.5 truncate">${esc(movie.genres)}</div>` : ''}
             </div>
         </div>`;

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -95,6 +95,16 @@ function saveName() {
 identityInput.addEventListener('blur', saveName);
 identityInput.addEventListener('keydown', e => { if (e.key === 'Enter') { identityInput.blur(); } });
 
+// ── Invite — always copy to clipboard ────────────────────────────────
+document.getElementById('invite-btn').addEventListener('click', function () {
+    const url = this.dataset.url;
+    navigator.clipboard.writeText(url).then(() => {
+        showToast('Invite link copied!', 'green');
+    }).catch(() => {
+        showToast('Could not copy link.');
+    });
+});
+
 // ── Join / Leave / Heartbeat ──────────────────────────────────────────
 api('join');
 
@@ -223,11 +233,17 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
             state.participants = state.participants.filter(p => p.userId !== delta.participant.userId);
             state.participants.push(delta.participant);
             updateParticipants();
+            updateReadyButton();
+            updateRefreshButton();
+            updateAllVoteBars();
             break;
 
         case 'leave':
             state.participants = state.participants.filter(p => p.userId !== byId);
             updateParticipants();
+            updateReadyButton();
+            updateRefreshButton();
+            updateAllVoteBars();
             break;
 
         case 'ready_on':
@@ -317,10 +333,15 @@ function addCardToGrid(movie) {
                 ${poster}
                 <div class="vote-heat absolute inset-0 bg-red-900/0 transition-all duration-500 pointer-events-none"></div>
                 <div class="voted-overlay absolute inset-0 border-2 border-red-500/70 hidden pointer-events-none"></div>
-                <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                    <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
+                <div class="absolute bottom-0 left-0 right-0">
+                    <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
+                        <div class="vote-avatars flex -space-x-1.5"></div>
+                        <span class="vote-count text-xs text-red-300"></span>
+                    </div>
+                    <div class="h-1 bg-white/10">
+                        <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
+                    </div>
                 </div>
-                <div class="vote-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
             </div>
             <div class="p-2">
                 <div class="text-xs font-medium text-white truncate">${esc(title)}</div>
@@ -339,26 +360,31 @@ function addCardToGrid(movie) {
 }
 
 function addCardToGraveyard(movie) {
-    const title = movie.title ?? movie.name ?? '';
+    const title  = movie.title ?? movie.name ?? '';
+    const year   = (movie.release_date || movie.first_air_date || '').slice(0, 4);
     const poster = movie.poster_path
-        ? `<img src="https://image.tmdb.org/t/p/w185${movie.poster_path}" alt="${esc(title)}" class="w-full h-full object-cover grayscale">`
-        : '';
+        ? `<img src="https://image.tmdb.org/t/p/w342${movie.poster_path}" alt="${esc(title)}" class="w-full h-full object-cover grayscale">`
+        : `<div class="w-full h-full flex items-center justify-center text-gray-600 text-xs px-2 text-center">${esc(title)}</div>`;
 
     const el = document.createElement('div');
-    el.className = 'graveyard-card relative flex-shrink-0 w-28 sm:w-32 cursor-pointer opacity-50 hover:opacity-80 transition-opacity group';
+    el.className = 'graveyard-card relative select-none cursor-pointer opacity-50 hover:opacity-75 active:opacity-90 transition-opacity';
     el.dataset.id = movie.id;
     el.innerHTML = `
-        <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] relative">
-            ${poster}
-            <div class="restore-overlay absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <span class="text-lg">↩</span>
-                <span class="text-xs text-gray-300">Restore</span>
+        <div class="card overflow-hidden">
+            <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden relative">
+                ${poster}
+                <div class="absolute top-2 right-2 w-5 h-5 rounded-full bg-black/70 flex items-center justify-center text-xs">↩</div>
+                <div class="restore-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
+                <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
+                    <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+                </div>
             </div>
-            <div class="restore-vote-bar absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+            <div class="p-2">
+                <div class="text-xs font-medium text-gray-400 truncate">${esc(title)}</div>
+                ${movie.vote_average ? `<div class="text-xs text-gray-600 mt-0.5">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
+                ${year ? `<div class="text-xs text-gray-600 mt-0.5">${year}</div>` : ''}
             </div>
-        </div>
-        <div class="text-xs text-gray-500 truncate mt-1 text-center">${esc(title)}</div>`;
+        </div>`;
 
     document.getElementById('graveyard-grid').appendChild(el);
     document.getElementById('graveyard-section').classList.remove('hidden');
@@ -377,23 +403,31 @@ function updateAllVoteBars() {
         const pct        = pCount > 0 ? Math.round((votes / vetoNeeded) * 100) : 0;
         const iVoted     = voters.includes(myId);
         const bar        = card.querySelector('.vote-bar');
-        const pips       = card.querySelector('.vote-pips');
         const heat       = card.querySelector('.vote-heat');
         const votedOvl   = card.querySelector('.voted-overlay');
         const voteTarget = card.querySelector('.vote-target');
 
         if (bar) bar.style.width = Math.min(pct, 100) + '%';
 
-        // Pip dots — one per required vote, filled red if voted
-        if (pips) {
-            if (votes > 0 || vetoNeeded <= 4) {
-                pips.classList.remove('hidden');
-                pips.innerHTML = Array.from({ length: vetoNeeded }, (_, i) =>
-                    `<span class="w-2 h-2 rounded-full border border-white/40 transition-colors duration-200
-                        ${i < votes ? 'bg-red-500 border-red-500' : 'bg-white/10'}"></span>`
-                ).join('');
+        // Vote info row in card info section
+        const voteInfo    = card.querySelector('.vote-info');
+        const voteAvatars = card.querySelector('.vote-avatars');
+        const voteCount   = card.querySelector('.vote-count');
+        if (voteInfo) {
+            if (votes > 0) {
+                voteInfo.classList.remove('hidden');
+                const visible = voters.slice(0, 3);
+                const overflow = voters.length - visible.length;
+                voteAvatars.innerHTML = visible.map(vid => {
+                    const p       = state.participants.find(p => p.userId === vid);
+                    const initial = p ? p.name.slice(0, 1).toUpperCase() : '?';
+                    const isMe    = vid === myId;
+                    return `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white ring-1 ring-black
+                        ${isMe ? 'bg-accent' : 'bg-red-500'}" title="${p ? esc(p.name) : ''}">${initial}</span>`;
+                }).join('') + (overflow > 0 ? `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white bg-white/20 ring-1 ring-black">+${overflow}</span>` : '');
+                voteCount.textContent = `${votes}/${vetoNeeded} to veto`;
             } else {
-                pips.classList.add('hidden');
+                voteInfo.classList.add('hidden');
             }
         }
 
@@ -413,10 +447,31 @@ function updateAllVoteBars() {
     // Graveyard
     document.querySelectorAll('.graveyard-card').forEach(card => {
         const movieId = String(card.dataset.id);
-        const votes   = (state.restoreVotes[movieId] || []).length;
+        const voters  = state.restoreVotes[movieId] || [];
+        const votes   = voters.length;
         const pct     = pCount > 0 ? Math.round((votes / vetoNeeded) * 100) : 0;
         const bar     = card.querySelector('.restore-bar');
+        const pips    = card.querySelector('.restore-pips');
         if (bar) bar.style.width = Math.min(pct, 100) + '%';
+
+        if (pips) {
+            if (votes > 0) {
+                pips.classList.remove('hidden');
+                pips.innerHTML = Array.from({ length: vetoNeeded }, (_, i) => {
+                    if (i < votes) {
+                        const vid     = voters[i];
+                        const p       = state.participants.find(p => p.userId === vid);
+                        const initial = p ? p.name.slice(0, 1).toUpperCase() : '✓';
+                        const isMe    = vid === myId;
+                        return `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white
+                            ${isMe ? 'bg-accent' : 'bg-green-500'}" title="${p ? p.name : ''}">${initial}</span>`;
+                    }
+                    return `<span class="w-4 h-4 rounded-full border border-white/20 bg-white/5"></span>`;
+                }).join('');
+            } else {
+                pips.classList.add('hidden');
+            }
+        }
     });
 
     // Update threshold info
@@ -469,11 +524,11 @@ function updateParticipants() {
 
 // ── Ready button ──────────────────────────────────────────────────────
 function updateReadyButton() {
-    const btn     = document.getElementById('ready-btn');
-    const countEl = document.getElementById('ready-count');
-    const pCount  = activeParticipantCount();
-    const needed  = readyThreshold(pCount);
-    const iReady  = state.ready.includes(myId);
+    const btn    = document.getElementById('ready-btn');
+    const pCount = activeParticipantCount();
+    const needed = readyThreshold(pCount);
+    const iReady = state.ready.includes(myId);
+    const isDeciding = !iReady && state.ready.length === needed - 1;
 
     btn.textContent = iReady ? 'Unready' : 'Ready to Roll';
     const span = document.createElement('span');
@@ -482,6 +537,7 @@ function updateReadyButton() {
     btn.appendChild(span);
     btn.classList.toggle('btn-secondary', iReady);
     btn.classList.toggle('btn-accent', !iReady);
+    btn.classList.toggle('animate-pulse', isDeciding);
 }
 
 // ── Refresh button ────────────────────────────────────────────────────
@@ -540,6 +596,9 @@ function showWinner(movie) {
     document.getElementById('winner-title').textContent = title;
     document.getElementById('winner-rating').textContent = movie.vote_average
         ? `★ ${Number(movie.vote_average).toFixed(1)}` : '';
+    const year = (movie.release_date || movie.first_air_date || '').slice(0, 4);
+    const meta = [year, movie.genres].filter(Boolean).join(' · ');
+    document.getElementById('winner-meta').textContent = meta;
     document.getElementById('winner-details-link').href = url;
     document.getElementById('winner-overlay').classList.remove('hidden');
     confetti();
@@ -583,6 +642,22 @@ function confetti() {
 function esc(s) {
     return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
 }
+
+// ── Tap to skip hint ──────────────────────────────────────────────────
+if (!localStorage.getItem('collab_hint_seen')) {
+    const firstCard = document.querySelector('.collab-card .vote-target');
+    if (firstCard) {
+        const hint = document.createElement('div');
+        hint.className = 'absolute inset-0 flex items-center justify-center bg-black/50 pointer-events-none z-10';
+        hint.innerHTML = '<span class="text-white text-xs font-medium bg-black/60 px-2 py-1 rounded-full">Tap to skip</span>';
+        firstCard.appendChild(hint);
+        setTimeout(() => hint.remove(), 3000);
+    }
+}
+
+document.getElementById('collab-grid').addEventListener('click', () => {
+    localStorage.setItem('collab_hint_seen', '1');
+}, { once: true });
 
 // ── Init ──────────────────────────────────────────────────────────────
 updateParticipants();

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -165,9 +165,9 @@ document.getElementById('refresh-btn')?.addEventListener('click', () => {
     api('refresh');
 });
 
-// ── Try Again ─────────────────────────────────────────────────────────
+// ── Try Again (on winner screen) ──────────────────────────────────────
 function updateTryAgainButton(needed = null) {
-    const btn    = document.getElementById('try-again-btn');
+    const btn    = document.getElementById('winner-try-again');
     const pCount = needed ?? activeParticipantCount();
     const iVoted = state.tryAgainVotes.includes(myId);
     const count  = state.tryAgainVotes.length;
@@ -176,7 +176,7 @@ function updateTryAgainButton(needed = null) {
     btn.classList.toggle('btn-secondary', !iVoted);
 }
 
-document.getElementById('try-again-btn').addEventListener('click', () => {
+document.getElementById('winner-try-again').addEventListener('click', () => {
     api('restart').then(() => updateTryAgainButton());
 });
 
@@ -321,6 +321,8 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
 
         case 'restarted':
             winnerShown = false;
+            rollInProgress = false;
+            document.getElementById('winner-overlay').classList.add('hidden');
             state.tryAgainVotes = [];
             state.graveyard    = [];
             state.votes        = {};
@@ -715,8 +717,6 @@ function updateTensionMode(remaining) {
     const graveyard  = document.getElementById('graveyard-section');
     const grid       = document.getElementById('collab-grid');
     const gravGrid   = document.getElementById('graveyard-grid');
-    const tryAgain   = document.getElementById('try-again-btn');
-
     if (isTension) {
         vignette.classList.remove('hidden');
         vignette.classList.add('tension-vignette');
@@ -739,7 +739,6 @@ function updateTensionMode(remaining) {
     // Lock/unlock voting
     grid.style.pointerEvents     = isLocked ? 'none' : '';
     gravGrid.style.pointerEvents = isLocked ? 'none' : '';
-    tryAgain.classList.toggle('hidden', !isLocked);
     document.getElementById('ready-btn').classList.toggle('hidden', isLocked);
     if (isLocked) updateTryAgainButton();
 
@@ -780,6 +779,12 @@ function showWinner(movie) {
     const url   = (isTv ? '/tv/' : '/movie/') + movie.id;
     const title = movie.title ?? movie.name ?? '';
 
+    // Blurred background
+    if (movie.poster_path) {
+        document.getElementById('winner-bg').style.backgroundImage
+            = `url(https://image.tmdb.org/t/p/w342${movie.poster_path})`;
+    }
+
     document.getElementById('winner-poster').innerHTML = movie.poster_path
         ? `<img src="https://image.tmdb.org/t/p/w342${movie.poster_path}" class="w-full h-full object-cover">`
         : '';
@@ -794,15 +799,11 @@ function showWinner(movie) {
     confetti();
 }
 
-document.getElementById('winner-dismiss').addEventListener('click', () => {
-    document.getElementById('winner-overlay').classList.add('hidden');
-    rollInProgress = false;
-    if (state.ready.includes(myId)) {
-        api('ready');
-    }
-    updateTensionMode(state.movies.length);
-    updateReadyButton();
+document.getElementById('winner-share').addEventListener('click', () => {
+    const link = document.getElementById('winner-details-link').href;
+    navigator.clipboard.writeText(link).then(() => showToast('Link copied!', 'green'));
 });
+
 
 // ── Toasts ────────────────────────────────────────────────────────────
 function showToast(msg, color = 'white') {
@@ -819,14 +820,22 @@ function showToast(msg, color = 'white') {
 // ── Confetti ──────────────────────────────────────────────────────────
 function confetti() {
     const container = document.getElementById('winner-overlay');
-    for (let i = 0; i < 60; i++) {
-        const dot = document.createElement('div');
-        dot.style.cssText = `position:absolute;width:8px;height:8px;border-radius:50%;
-            left:${Math.random()*100}%;top:-10px;
-            background:hsl(${Math.random()*360},80%,60%);
-            animation:confetti-fall ${1.5+Math.random()}s linear ${Math.random()*0.5}s forwards;`;
-        container.appendChild(dot);
-        setTimeout(() => dot.remove(), 2500);
+    const shapes    = ['50%', '0', '0'];
+    for (let i = 0; i < 80; i++) {
+        const piece = document.createElement('div');
+        const w     = 6 + Math.random() * 6;
+        const h     = 10 + Math.random() * 8;
+        const shape = shapes[Math.floor(Math.random() * shapes.length)];
+        const dur   = 1.4 + Math.random() * 1.2;
+        const delay = Math.random() * 0.8;
+        const spin  = Math.random() * 720 - 360;
+        piece.style.cssText = `position:absolute;width:${w}px;height:${h}px;border-radius:${shape};
+            left:${Math.random()*100}%;top:-16px;pointer-events:none;
+            background:hsl(${Math.random()*360},85%,60%);
+            animation:confetti-fall ${dur}s ease-in ${delay}s forwards;
+            transform:rotate(${Math.random()*360}deg);`;
+        container.appendChild(piece);
+        setTimeout(() => piece.remove(), (dur + delay) * 1000 + 100);
     }
 }
 

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -36,16 +36,20 @@ const leavePending = new Map(); // userId → timeout
 
 // ── Roll guard (prevents double animation) ────────────────────────────
 let rollInProgress = false;
+let winnerShown    = false;
 
 // ── Local state ───────────────────────────────────────────────────────
+let originalOrder = (window.collabMovies || []).map(m => m.id);
+
 let state = {
-    movies:       window.collabMovies       || [],
-    graveyard:    window.collabGraveyard    || [],
-    votes:        window.collabVotes        || {},
-    restoreVotes: window.collabRestore      || {},
-    ready:        window.collabReady        || [],
-    refreshVotes: window.collabRefresh      || [],
-    participants: window.collabParticipants || [],
+    movies:         window.collabMovies       || [],
+    graveyard:      window.collabGraveyard    || [],
+    votes:          window.collabVotes        || {},
+    restoreVotes:   window.collabRestore      || {},
+    ready:          window.collabReady        || [],
+    refreshVotes:   window.collabRefresh      || [],
+    participants:   window.collabParticipants || [],
+    tryAgainVotes:  [],
 };
 let totalMovies = state.movies.length + state.graveyard.length;
 
@@ -148,13 +152,32 @@ function castVote(movieId, type) {
 // ── Ready to Roll ─────────────────────────────────────────────────────
 document.getElementById('ready-btn').addEventListener('click', () => {
     api('ready').then(data => {
-        if (data.rolled && data.winner) triggerRoll(data.winner);
+        if (data.rolled && data.winner) {
+            state.movies.length === 1
+                ? showWinner(data.winner)
+                : triggerRoll(data.winner);
+        }
     });
 });
 
 // ── New Batch vote ────────────────────────────────────────────────────
 document.getElementById('refresh-btn')?.addEventListener('click', () => {
     api('refresh');
+});
+
+// ── Try Again ─────────────────────────────────────────────────────────
+function updateTryAgainButton(needed = null) {
+    const btn    = document.getElementById('try-again-btn');
+    const pCount = needed ?? activeParticipantCount();
+    const iVoted = state.tryAgainVotes.includes(myId);
+    const count  = state.tryAgainVotes.length;
+    btn.textContent = `Try Again (${count}/${pCount})`;
+    btn.classList.toggle('btn-accent', iVoted);
+    btn.classList.toggle('btn-secondary', !iVoted);
+}
+
+document.getElementById('try-again-btn').addEventListener('click', () => {
+    api('restart').then(() => updateTryAgainButton());
 });
 
 // ── Apply delta from broadcast ────────────────────────────────────────
@@ -278,10 +301,47 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
             break;
 
         case 'rolled':
-            setTimeout(() => triggerRoll(delta.winner), 400);
+            winnerShown = true;
+            setTimeout(() => {
+                state.movies.length === 1
+                    ? showWinner(delta.winner)
+                    : triggerRoll(delta.winner);
+            }, 400);
+            break;
+
+        case 'try_again_on':
+        case 'try_again_off':
+            state.tryAgainVotes = delta.tryAgainVotes;
+            updateTryAgainButton(delta.needed);
+            if (!isMe) {
+                const action = eventType === 'try_again_on' ? 'wants to try again' : 'changed their mind on try again';
+                showToast(`${who} ${action}`);
+            }
+            break;
+
+        case 'restarted':
+            winnerShown = false;
+            state.tryAgainVotes = [];
+            state.graveyard    = [];
+            state.votes        = {};
+            state.restoreVotes = {};
+            state.ready        = [];
+            // Add graveyard cards back in original order
+            delta.movies.filter(m => !state.movies.find(s => s.id === m.id)).forEach(m => {
+                state.movies.push(m);
+                addCardToGrid(m, true);
+            });
+            document.getElementById('graveyard-grid').innerHTML = '';
+            document.getElementById('graveyard-section').classList.add('hidden');
+            updateAllVoteBars();
+            updateReadyButton();
+            updateProgress();
+            showToast(`${who} hit Try Again — all movies are back!`, 'green');
             break;
 
         case 'refreshed':
+            winnerShown = false;
+            originalOrder  = delta.movies.map(m => m.id);
             state.movies       = delta.movies;
             state.graveyard    = [];
             state.votes        = {};
@@ -302,10 +362,6 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
             break;
     }
 
-    // Auto-roll when 1 movie left
-    if (prevMovieCount > 1 && state.movies.length === 1 && eventType !== 'rolled' && eventType !== 'refreshed') {
-        setTimeout(() => triggerRoll(state.movies[0]), 600);
-    }
 }
 
 // ── Animate card to graveyard ─────────────────────────────────────────
@@ -387,9 +443,14 @@ function buildCard(movie, isGraveyard = false) {
 }
 
 function addCardToGrid(movie, animate = false) {
-    const el = buildCard(movie, false);
+    const el   = buildCard(movie, false);
     el.style.opacity = '0';
-    document.getElementById('collab-grid').appendChild(el);
+    const grid = document.getElementById('collab-grid');
+    const pos  = originalOrder.indexOf(movie.id);
+    const after = [...grid.querySelectorAll('.collab-card')].find(card =>
+        originalOrder.indexOf(parseInt(card.dataset.id)) > pos
+    );
+    after ? grid.insertBefore(el, after) : grid.appendChild(el);
     requestAnimationFrame(() => {
         if (animate) {
             el.style.animation = 'collab-restore-in 0.4s ease-out forwards';
@@ -508,7 +569,7 @@ function updateAllVoteBars() {
 
         if (heat) {
             heat.style.background = votes > 0
-                ? `linear-gradient(to top, rgba(185,28,28,${(intensity * 0.75).toFixed(2)}), transparent 65%)`
+                ? `linear-gradient(to top, rgba(200,0,0,${(0.3 + intensity * 0.6).toFixed(2)}) 0%, rgba(180,0,0,${(intensity * 0.25).toFixed(2)}) 50%, transparent 80%)`
                 : '';
         }
 
@@ -641,6 +702,52 @@ function updateProgress() {
     const pct = totalMovies > 0 ? (remaining / totalMovies) * 100 : 0;
     document.getElementById('remaining-num').textContent = remaining;
     document.getElementById('veto-progress').style.width = pct + '%';
+    updateTensionMode(remaining);
+}
+
+// ── Tension mode ──────────────────────────────────────────────────────
+function updateTensionMode(remaining) {
+    const isTension  = remaining <= 3 && remaining > 0;
+    const isLocked   = remaining === 1;
+    const vignette   = document.getElementById('tension-vignette');
+    const title      = document.getElementById('collab-title');
+    const bar        = document.getElementById('veto-progress');
+    const graveyard  = document.getElementById('graveyard-section');
+    const grid       = document.getElementById('collab-grid');
+    const gravGrid   = document.getElementById('graveyard-grid');
+    const tryAgain   = document.getElementById('try-again-btn');
+
+    if (isTension) {
+        vignette.classList.remove('hidden');
+        vignette.classList.add('tension-vignette');
+
+        const labels = { 3: 'Final 3 🔥', 2: 'Final 2 🔥', 1: 'Last One Standing 🔥' };
+        if (title) title.textContent = labels[remaining];
+
+        bar.classList.add('tension-progress', '!bg-red-600');
+        if (graveyard) graveyard.style.opacity = isLocked ? '0.2' : '0.35';
+    } else {
+        vignette.classList.add('hidden');
+        vignette.classList.remove('tension-vignette');
+
+        if (title) title.textContent = 'Pick Together';
+
+        bar.classList.remove('tension-progress', '!bg-red-600');
+        if (graveyard) graveyard.style.opacity = '';
+    }
+
+    // Lock/unlock voting
+    grid.style.pointerEvents     = isLocked ? 'none' : '';
+    gravGrid.style.pointerEvents = isLocked ? 'none' : '';
+    tryAgain.classList.toggle('hidden', !isLocked);
+    document.getElementById('ready-btn').classList.toggle('hidden', isLocked);
+    if (isLocked) updateTryAgainButton();
+
+    // Auto-show winner when 1 card left (once only)
+    if (isLocked && state.movies.length === 1 && !winnerShown) {
+        winnerShown = true;
+        setTimeout(() => showWinner(state.movies[0]), 800);
+    }
 }
 
 // ── Roll animation then winner overlay ───────────────────────────────
@@ -691,8 +798,10 @@ document.getElementById('winner-dismiss').addEventListener('click', () => {
     document.getElementById('winner-overlay').classList.add('hidden');
     rollInProgress = false;
     if (state.ready.includes(myId)) {
-        api('ready'); // toggle ready off so session can continue
+        api('ready');
     }
+    updateTensionMode(state.movies.length);
+    updateReadyButton();
 });
 
 // ── Toasts ────────────────────────────────────────────────────────────
@@ -748,4 +857,5 @@ updateAllVoteBars();
 updateReadyButton();
 updateRefreshButton();
 updateProgress();
+updateTensionMode(state.movies.length);
 document.getElementById('total-num').textContent = totalMovies;

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -117,6 +117,15 @@ window.addEventListener('beforeunload', () => {
         new Blob([JSON.stringify({ userId: myId, _token: csrf() })], { type: 'application/json' }));
 });
 
+// ── Voting signal — debounced pointerdown ─────────────────────────────
+document.getElementById('collab-grid').addEventListener('pointerdown', (e) => {
+    const card = e.target.closest('.collab-card');
+    if (!card) return;
+    const movieId     = parseInt(card.dataset.id);
+    const isRecalling = (state.votes[String(movieId)] || []).includes(myId);
+    api('voting', { movieId, isRecalling });
+});
+
 // ── Card tap — single tap on poster = vote ────────────────────────────
 document.getElementById('collab-grid').addEventListener('click', (e) => {
     const card = e.target.closest('.collab-card');
@@ -256,6 +265,10 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
         case 'refresh_off':
             state.refreshVotes = delta.refreshVotes;
             updateRefreshButton();
+            break;
+
+        case 'voting':
+            if (!isMe) showVotingIndicator(delta.movieId, who, delta.isRecalling);
             break;
 
         case 'vote_cleanup':
@@ -402,6 +415,47 @@ function addCardToGraveyard(movie) {
     });
 }
 
+// ── Voting indicator ──────────────────────────────────────────────────
+const VOTING_MAX = 10;
+
+function getVotingContainer(voteTarget) {
+    let container = voteTarget.querySelector('.voting-badges');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'voting-badges absolute top-1.5 left-0 right-0 flex flex-col items-center gap-0.5 pointer-events-none z-20';
+        voteTarget.appendChild(container);
+    }
+    return container;
+}
+
+function showVotingIndicator(movieId, name, isRecalling = false) {
+    const card = document.querySelector(`.collab-card[data-id="${movieId}"]`);
+    if (!card) return;
+
+    const voteTarget = card.querySelector('.vote-target');
+    if (!voteTarget) return;
+
+    const container = getVotingContainer(voteTarget);
+
+    // Enforce limit — remove oldest instantly
+    while (container.children.length >= VOTING_MAX) {
+        const oldest = container.lastElementChild;
+        if (oldest._timeout) clearTimeout(oldest._timeout);
+        oldest.remove();
+    }
+
+    const badgeBg = isRecalling ? 'rgba(21,128,61,0.9)' : 'rgba(192,57,58,0.9)';
+    const label   = isRecalling ? `${esc(name)} reconsidering…` : `${esc(name)} is vetoing…`;
+
+    const badge = document.createElement('div');
+    badge.style.cssText = `font-size:9px;font-weight:600;color:#fff;background:${badgeBg};padding:2px 8px;border-radius:9999px;white-space:nowrap`;
+    badge.textContent = label;
+
+    container.prepend(badge);
+
+    badge._timeout = setTimeout(() => badge.remove(), 2000);
+}
+
 // ── Vote bars & badges ────────────────────────────────────────────────
 function updateAllVoteBars() {
     const pCount = activeParticipantCount();
@@ -458,29 +512,6 @@ function updateAllVoteBars() {
                 : '';
         }
 
-        if (inner) {
-            if (votes > 0) {
-                const boost       = iVoted ? 0.2 : 0;
-                const glowOpacity = Math.min(0.9, 0.3 + intensity * 0.5 + boost).toFixed(2);
-                const glowMin     = Math.round(intensity * 8 + boost * 4);
-                const glowMax     = Math.round(intensity * 22 + boost * 8);
-                const glowSpread  = Math.round(intensity * 4);
-                const duration    = Math.max(0.7, 1.8 - intensity * 1.1).toFixed(1);
-                inner.style.setProperty('--glow-min',        `${glowMin}px`);
-                inner.style.setProperty('--glow-max',        `${glowMax}px`);
-                inner.style.setProperty('--glow-spread-min', `${glowSpread}px`);
-                inner.style.setProperty('--glow-spread-max', `${glowSpread * 2}px`);
-                inner.style.setProperty('--glow-opacity',    glowOpacity);
-                inner.style.animation = `collab-veto-glow-pulse ${duration}s ease-in-out infinite`;
-            } else {
-                inner.style.animation = '';
-                inner.style.removeProperty('--glow-min');
-                inner.style.removeProperty('--glow-max');
-                inner.style.removeProperty('--glow-spread-min');
-                inner.style.removeProperty('--glow-spread-max');
-                inner.style.removeProperty('--glow-opacity');
-            }
-        }
 
         // "You" badge — shows when current user has voted on this card
         if (votedOvl) {

--- a/resources/js/custom/collabBatch.js
+++ b/resources/js/custom/collabBatch.js
@@ -223,7 +223,7 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
             delete state.restoreVotes[String(delta.movieId)];
             state.movies.push(delta.movie);
             removeGraveyardCard(delta.movieId);
-            addCardToGrid(delta.movie);
+            addCardToGrid(delta.movie, true);
             updateAllVoteBars();
             updateProgress();
             break;
@@ -299,95 +299,107 @@ function applyDelta(eventType, byName, byId, movieTitle, delta) {
 function animateToGraveyard(movieId) {
     const card = document.querySelector(`.collab-card[data-id="${movieId}"]`);
     if (!card) return;
-    card.style.transition = 'transform 0.2s, opacity 0.3s';
-    card.style.transform  = 'scale(0.8)';
-    card.style.opacity    = '0';
-    setTimeout(() => card.remove(), 320);
+    const inner = card.querySelector('.card');
+    if (inner) inner.style.animation = 'collab-red-flash 0.4s ease-out';
+    card.style.animation = 'collab-veto-shake 0.35s ease-in-out';
+    setTimeout(() => {
+        card.style.animation = 'collab-veto-out 0.3s ease-in forwards';
+        setTimeout(() => card.remove(), 300);
+    }, 350);
 }
 
 function removeGraveyardCard(movieId) {
     const card = document.querySelector(`.graveyard-card[data-id="${movieId}"]`);
     if (card) {
-        card.style.transition = 'opacity 0.3s';
-        card.style.opacity = '0';
-        setTimeout(() => card.remove(), 320);
+        card.style.animation = 'collab-veto-out 0.25s ease-in forwards';
+        setTimeout(() => card.remove(), 250);
     }
 }
 
-function addCardToGrid(movie) {
-    const isTv   = mediaType === 'tv' || movie.media_type === 'tv';
-    const url    = (isTv ? '/tv/' : '/movie/') + movie.id;
+function buildCard(movie, isGraveyard = false) {
     const title  = movie.title ?? movie.name ?? '';
+    const year   = (movie.release_date || movie.first_air_date || '').slice(0, 4);
+    const imgCls = `w-full h-full object-cover transition-all duration-300${isGraveyard ? ' grayscale' : ''}`;
     const poster = movie.poster_path
-        ? `<img src="https://image.tmdb.org/t/p/w342${movie.poster_path}" alt="${esc(title)}" class="w-full h-full object-cover transition-all duration-300" loading="lazy">`
+        ? `<img src="https://image.tmdb.org/t/p/w342${movie.poster_path}" alt="${esc(title)}" class="${imgCls}" loading="lazy">`
         : `<div class="w-full h-full flex items-center justify-center text-gray-600 text-xs px-2 text-center">${esc(title)}</div>`;
 
-    const el = document.createElement('div');
-    el.className = 'collab-card relative group cursor-pointer select-none';
-    el.dataset.id = movie.id;
-    el.style.opacity = '0';
-    el.style.transform = 'scale(0.8)';
-    el.innerHTML = `
-        <div class="card overflow-hidden transition-all duration-200" id="card-inner-${movie.id}">
-            <div class="vote-target aspect-[2/3] bg-white/[0.03] overflow-hidden relative cursor-pointer">
-                ${poster}
-                <div class="vote-heat absolute inset-0 bg-red-900/0 transition-all duration-500 pointer-events-none"></div>
-                <div class="voted-overlay absolute inset-0 border-2 border-red-500/70 hidden pointer-events-none"></div>
-                <div class="absolute bottom-0 left-0 right-0">
-                    <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
-                        <div class="vote-avatars flex -space-x-1.5"></div>
-                        <span class="vote-count text-xs text-red-300"></span>
-                    </div>
-                    <div class="h-1 bg-white/10">
-                        <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
-                    </div>
-                </div>
+    const posterOverlays = isGraveyard ? `
+        <div class="absolute top-2 right-2 w-5 h-5 rounded-full bg-black/70 flex items-center justify-center text-xs">↩</div>
+        <div class="absolute bottom-0 left-0 right-0">
+            <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
+                <div class="vote-avatars flex -space-x-1.5"></div>
+                <span class="vote-count text-xs text-green-300"></span>
             </div>
-            <div class="p-2">
-                <div class="text-xs font-medium text-white truncate">${esc(title)}</div>
-                ${movie.vote_average ? `<div class="text-xs text-gray-500 mt-0.5">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
-                ${(movie.release_date || movie.first_air_date) ? `<div class="text-xs text-gray-600 mt-0.5">${(movie.release_date || movie.first_air_date).slice(0, 4)}</div>` : ''}
-                ${movie.genres ? `<div class="text-xs text-gray-600 mt-0.5 truncate">${esc(movie.genres)}</div>` : ''}
+            <div class="h-1 bg-white/10">
+                <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+            </div>
+        </div>` : `
+        <div class="vote-heat absolute inset-0 bg-red-900/0 transition-all duration-500 pointer-events-none"></div>
+        <div class="voted-overlay absolute inset-0 hidden pointer-events-none"></div>
+        <div class="absolute bottom-0 left-0 right-0">
+            <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
+                <div class="vote-avatars flex -space-x-1.5"></div>
+                <span class="vote-count text-xs text-red-300"></span>
+            </div>
+            <div class="h-1 bg-white/10">
+                <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
             </div>
         </div>`;
 
+    const titleCls  = isGraveyard ? 'text-xs font-medium text-gray-400 truncate' : 'text-xs font-medium text-white truncate';
+    const ratingCls = isGraveyard ? 'text-xs text-gray-600 mt-0.5' : 'text-xs text-gray-500 mt-0.5';
+    const metaCls   = 'text-xs text-gray-600 mt-0.5';
+
+    const el = document.createElement('div');
+    el.className = isGraveyard
+        ? 'graveyard-card relative select-none cursor-pointer opacity-50 hover:opacity-75 active:opacity-90 transition-opacity'
+        : 'collab-card relative group cursor-pointer select-none';
+    el.dataset.id = movie.id;
+    el.innerHTML = `
+        <div class="card overflow-hidden transition-all duration-200">
+            <div class="${isGraveyard ? 'aspect-[2/3]' : 'vote-target aspect-[2/3]'} bg-white/[0.03] overflow-hidden relative${isGraveyard ? '' : ' cursor-pointer'}">
+                ${poster}
+                ${posterOverlays}
+            </div>
+            <div class="p-2">
+                <div class="${titleCls}">${esc(title)}</div>
+                ${movie.vote_average ? `<div class="${ratingCls}">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
+                ${year ? `<div class="${metaCls}">${year}</div>` : ''}
+                ${!isGraveyard && movie.genres ? `<div class="${metaCls} truncate">${esc(movie.genres)}</div>` : ''}
+            </div>
+        </div>`;
+
+    return el;
+}
+
+function addCardToGrid(movie, animate = false) {
+    const el = buildCard(movie, false);
+    el.style.opacity = '0';
     document.getElementById('collab-grid').appendChild(el);
     requestAnimationFrame(() => {
-        el.style.transition = 'transform 0.3s, opacity 0.3s';
-        el.style.transform = 'scale(1)';
+        if (animate) {
+            el.style.animation = 'collab-restore-in 0.4s ease-out forwards';
+            const inner = el.querySelector('.card');
+            if (inner) inner.style.animation = 'collab-green-flash 0.5s ease-out';
+        } else {
+            el.style.transition = 'opacity 0.2s';
+        }
         el.style.opacity = '1';
     });
 }
 
 function addCardToGraveyard(movie) {
-    const title  = movie.title ?? movie.name ?? '';
-    const year   = (movie.release_date || movie.first_air_date || '').slice(0, 4);
-    const poster = movie.poster_path
-        ? `<img src="https://image.tmdb.org/t/p/w342${movie.poster_path}" alt="${esc(title)}" class="w-full h-full object-cover grayscale">`
-        : `<div class="w-full h-full flex items-center justify-center text-gray-600 text-xs px-2 text-center">${esc(title)}</div>`;
-
-    const el = document.createElement('div');
-    el.className = 'graveyard-card relative select-none cursor-pointer opacity-50 hover:opacity-75 active:opacity-90 transition-opacity';
-    el.dataset.id = movie.id;
-    el.innerHTML = `
-        <div class="card overflow-hidden">
-            <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden relative">
-                ${poster}
-                <div class="absolute top-2 right-2 w-5 h-5 rounded-full bg-black/70 flex items-center justify-center text-xs">↩</div>
-                <div class="restore-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
-                <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                    <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
-                </div>
-            </div>
-            <div class="p-2">
-                <div class="text-xs font-medium text-gray-400 truncate">${esc(title)}</div>
-                ${movie.vote_average ? `<div class="text-xs text-gray-600 mt-0.5">★ ${Number(movie.vote_average).toFixed(1)}</div>` : ''}
-                ${year ? `<div class="text-xs text-gray-600 mt-0.5">${year}</div>` : ''}
-            </div>
-        </div>`;
-
+    const el = buildCard(movie, true);
+    el.style.opacity = '0';
     document.getElementById('graveyard-grid').appendChild(el);
     document.getElementById('graveyard-section').classList.remove('hidden');
+    requestAnimationFrame(() => {
+        el.style.animation = 'collab-restore-in 0.4s ease-out forwards';
+        el.style.opacity = '1';
+        const inner = el.querySelector('.card');
+        if (inner) inner.style.animation = 'collab-red-flash 0.5s ease-out';
+    });
 }
 
 // ── Vote bars & badges ────────────────────────────────────────────────
@@ -431,45 +443,85 @@ function updateAllVoteBars() {
             }
         }
 
-        // Heat overlay — visible to everyone, intensity scales with vote progress
-        if (heat) {
-            const opacity = votes === 0 ? 0 : Math.round((votes / vetoNeeded) * 50);
-            heat.style.backgroundColor = `rgba(127,29,29,${opacity / 100})`;
+        // Compound veto overlay — desaturation + gradient + pulsing glow
+        const intensity = votes / vetoNeeded; // 0 to 1
+        const img       = card.querySelector('img');
+        const inner     = card.querySelector('.card');
+
+        if (img) {
+            img.style.filter = votes > 0 ? `grayscale(${Math.round(intensity * 75)}%)` : '';
         }
 
-        if (votedOvl) votedOvl.classList.toggle('hidden', !iVoted);
-        if (voteTarget) {
-            voteTarget.classList.toggle('ring-2', iVoted);
-            voteTarget.classList.toggle('ring-red-500/60', iVoted);
+        if (heat) {
+            heat.style.background = votes > 0
+                ? `linear-gradient(to top, rgba(185,28,28,${(intensity * 0.75).toFixed(2)}), transparent 65%)`
+                : '';
+        }
+
+        if (inner) {
+            if (votes > 0) {
+                const boost       = iVoted ? 0.2 : 0;
+                const glowOpacity = Math.min(0.9, 0.3 + intensity * 0.5 + boost).toFixed(2);
+                const glowMin     = Math.round(intensity * 8 + boost * 4);
+                const glowMax     = Math.round(intensity * 22 + boost * 8);
+                const glowSpread  = Math.round(intensity * 4);
+                const duration    = Math.max(0.7, 1.8 - intensity * 1.1).toFixed(1);
+                inner.style.setProperty('--glow-min',        `${glowMin}px`);
+                inner.style.setProperty('--glow-max',        `${glowMax}px`);
+                inner.style.setProperty('--glow-spread-min', `${glowSpread}px`);
+                inner.style.setProperty('--glow-spread-max', `${glowSpread * 2}px`);
+                inner.style.setProperty('--glow-opacity',    glowOpacity);
+                inner.style.animation = `collab-veto-glow-pulse ${duration}s ease-in-out infinite`;
+            } else {
+                inner.style.animation = '';
+                inner.style.removeProperty('--glow-min');
+                inner.style.removeProperty('--glow-max');
+                inner.style.removeProperty('--glow-spread-min');
+                inner.style.removeProperty('--glow-spread-max');
+                inner.style.removeProperty('--glow-opacity');
+            }
+        }
+
+        // "You" badge — shows when current user has voted on this card
+        if (votedOvl) {
+            if (iVoted) {
+                votedOvl.classList.remove('hidden');
+                votedOvl.innerHTML = '<span class="absolute top-2 left-2 text-[9px] font-bold text-white bg-accent px-1.5 py-0.5 rounded-full">✓ You</span>';
+            } else {
+                votedOvl.classList.add('hidden');
+                votedOvl.innerHTML = '';
+            }
         }
     });
 
     // Graveyard
     document.querySelectorAll('.graveyard-card').forEach(card => {
-        const movieId = String(card.dataset.id);
-        const voters  = state.restoreVotes[movieId] || [];
-        const votes   = voters.length;
-        const pct     = pCount > 0 ? Math.round((votes / vetoNeeded) * 100) : 0;
-        const bar     = card.querySelector('.restore-bar');
-        const pips    = card.querySelector('.restore-pips');
+        const movieId     = String(card.dataset.id);
+        const voters      = state.restoreVotes[movieId] || [];
+        const votes       = voters.length;
+        const pct         = pCount > 0 ? Math.round((votes / vetoNeeded) * 100) : 0;
+        const bar         = card.querySelector('.restore-bar');
+        const voteInfo    = card.querySelector('.vote-info');
+        const voteAvatars = card.querySelector('.vote-avatars');
+        const voteCount   = card.querySelector('.vote-count');
+
         if (bar) bar.style.width = Math.min(pct, 100) + '%';
 
-        if (pips) {
+        if (voteInfo) {
             if (votes > 0) {
-                pips.classList.remove('hidden');
-                pips.innerHTML = Array.from({ length: vetoNeeded }, (_, i) => {
-                    if (i < votes) {
-                        const vid     = voters[i];
-                        const p       = state.participants.find(p => p.userId === vid);
-                        const initial = p ? p.name.slice(0, 1).toUpperCase() : '✓';
-                        const isMe    = vid === myId;
-                        return `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white
-                            ${isMe ? 'bg-accent' : 'bg-green-500'}" title="${p ? p.name : ''}">${initial}</span>`;
-                    }
-                    return `<span class="w-4 h-4 rounded-full border border-white/20 bg-white/5"></span>`;
-                }).join('');
+                voteInfo.classList.remove('hidden');
+                const visible  = voters.slice(0, 3);
+                const overflow = voters.length - visible.length;
+                voteAvatars.innerHTML = visible.map(vid => {
+                    const p       = state.participants.find(p => p.userId === vid);
+                    const initial = p ? p.name.slice(0, 1).toUpperCase() : '?';
+                    const isMe    = vid === myId;
+                    return `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white ring-1 ring-black
+                        ${isMe ? 'bg-accent' : 'bg-green-500'}" title="${p ? esc(p.name) : ''}">${initial}</span>`;
+                }).join('') + (overflow > 0 ? `<span class="w-4 h-4 rounded-full flex items-center justify-center text-[8px] font-bold text-white bg-white/20 ring-1 ring-black">+${overflow}</span>` : '');
+                voteCount.textContent = `${votes}/${vetoNeeded} to restore`;
             } else {
-                pips.classList.add('hidden');
+                voteInfo.classList.add('hidden');
             }
         }
     });
@@ -537,7 +589,7 @@ function updateReadyButton() {
     btn.appendChild(span);
     btn.classList.toggle('btn-secondary', iReady);
     btn.classList.toggle('btn-accent', !iReady);
-    btn.classList.toggle('animate-pulse', isDeciding);
+    btn.classList.toggle('collab-btn-glow', isDeciding);
 }
 
 // ── Refresh button ────────────────────────────────────────────────────

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -22,10 +22,8 @@
             <p class="text-xs text-gray-500 mt-0.5">Vote out movies — last one standing wins</p>
         </div>
         <div class="flex items-center gap-2 flex-shrink-0">
-            <button class="btn-secondary text-sm flex items-center gap-1.5"
-                data-share
-                data-share-url="{{ url()->current() }}"
-                data-share-title="Pick a movie with me! — MoviePickr">
+            <button class="btn-secondary text-sm flex items-center gap-1.5" id="invite-btn"
+                data-url="{{ url()->current() }}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
                 Invite
             </button>
@@ -95,20 +93,27 @@
                     {{-- My vote indicator (border glow) --}}
                     <div class="voted-overlay absolute inset-0 border-2 border-red-500/70 hidden pointer-events-none"></div>
 
-                    {{-- Vote progress bar --}}
-                    <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                        <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
+                    {{-- Vote info + bar --}}
+                    <div class="absolute bottom-0 left-0 right-0">
+                        <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
+                            <div class="vote-avatars flex -space-x-1.5"></div>
+                            <span class="vote-count text-xs text-red-300"></span>
+                        </div>
+                        <div class="h-1 bg-white/10">
+                            <div class="vote-bar h-full bg-red-500 transition-all duration-300" style="width:0%"></div>
+                        </div>
                     </div>
-
-                    {{-- Vote pip dots --}}
-                    <div class="vote-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
                 </div>
 
-                {{-- Title — tap to open details --}}
+                {{-- Title --}}
                 <div class="p-2">
                     <div class="text-xs font-medium text-white truncate">{{ $title }}</div>
                     @if(!empty($movie['vote_average']) && $movie['vote_average'] > 0)
                         <div class="text-xs text-gray-500 mt-0.5">★ {{ number_format($movie['vote_average'], 1) }}</div>
+                    @endif
+                    @php $year = !empty($movie['release_date']) ? substr($movie['release_date'], 0, 4) : (!empty($movie['first_air_date']) ? substr($movie['first_air_date'], 0, 4) : null); @endphp
+                    @if($year)
+                        <div class="text-xs text-gray-600 mt-0.5">{{ $year }}</div>
                     @endif
                     @if(!empty($movie['genres']))
                         <div class="text-xs text-gray-600 mt-0.5 truncate">{{ $movie['genres'] }}</div>
@@ -122,8 +127,10 @@
     {{-- Graveyard --}}
     <div id="graveyard-section" class="{{ count($batch->graveyard ?? []) > 0 ? '' : 'hidden' }} mb-24">
         <div class="flex items-center gap-3 mb-3">
-            <h2 class="text-sm font-semibold text-gray-500">Graveyard</h2>
+            <span class="text-base">⚰️</span>
+            <h2 class="text-sm font-semibold text-white">Graveyard</h2>
             <div class="flex-1 h-px bg-white/10"></div>
+            <span class="text-xs text-gray-500">Tap a movie to vote restore</span>
         </div>
         <div class="bg-white/5 rounded-xl px-4 py-3 mb-4 grid grid-cols-3 gap-3 text-center">
             <div>
@@ -139,28 +146,37 @@
                 <div class="text-xs text-gray-500 mt-0.5">to vote restore</div>
             </div>
         </div>
-        <div id="graveyard-grid" class="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
+        <div id="graveyard-grid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
             @foreach($batch->graveyard ?? [] as $movie)
             @php
-                $isTv    = ($batch->media_type === 'tv') || ($movie['media_type'] ?? '') === 'tv';
-                $title   = $movie['title'] ?? $movie['name'] ?? '';
+                $title = $movie['title'] ?? $movie['name'] ?? '';
+                $year  = !empty($movie['release_date']) ? substr($movie['release_date'], 0, 4) : (!empty($movie['first_air_date']) ? substr($movie['first_air_date'], 0, 4) : null);
             @endphp
-            <div class="graveyard-card relative flex-shrink-0 w-28 sm:w-32 cursor-pointer opacity-50 hover:opacity-80 transition-opacity group"
-                 data-id="{{ $movie['id'] }}">
-                <div class="aspect-[2/3] rounded-lg overflow-hidden bg-white/[0.03] relative">
-                    @if(!empty($movie['poster_path']))
-                        <img src="https://image.tmdb.org/t/p/w185{{ $movie['poster_path'] }}"
-                             alt="{{ $title }}" class="w-full h-full object-cover grayscale">
-                    @endif
-                    <div class="restore-overlay absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <span class="text-lg">↩</span>
-                        <span class="text-xs text-gray-300">Restore</span>
+            <div class="graveyard-card relative select-none cursor-pointer opacity-50 hover:opacity-75 active:opacity-90 transition-opacity" data-id="{{ $movie['id'] }}">
+                <div class="card overflow-hidden">
+                    <div class="aspect-[2/3] bg-white/[0.03] overflow-hidden relative">
+                        @if(!empty($movie['poster_path']))
+                            <img src="https://image.tmdb.org/t/p/w342{{ $movie['poster_path'] }}"
+                                 alt="{{ $title }}" class="w-full h-full object-cover grayscale">
+                        @else
+                            <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs px-2 text-center">{{ $title }}</div>
+                        @endif
+                        <div class="absolute top-2 right-2 w-5 h-5 rounded-full bg-black/70 flex items-center justify-center text-xs">↩</div>
+                        <div class="restore-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
+                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
+                            <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+                        </div>
                     </div>
-                    <div class="restore-vote-bar absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                        <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+                    <div class="p-2">
+                        <div class="text-xs font-medium text-gray-400 truncate">{{ $title }}</div>
+                        @if(!empty($movie['vote_average']) && $movie['vote_average'] > 0)
+                            <div class="text-xs text-gray-600 mt-0.5">★ {{ number_format($movie['vote_average'], 1) }}</div>
+                        @endif
+                        @if($year)
+                            <div class="text-xs text-gray-600 mt-0.5">{{ $year }}</div>
+                        @endif
                     </div>
                 </div>
-                <div class="text-xs text-gray-500 truncate mt-1 text-center">{{ $title }}</div>
             </div>
             @endforeach
         </div>
@@ -194,7 +210,8 @@
         <p class="text-gray-500 text-sm mb-5">Last one standing 🎉</p>
         <div id="winner-poster" class="mx-auto w-32 sm:w-40 rounded-xl overflow-hidden mb-5 shadow-2xl ring-2 ring-accent/50"></div>
         <h2 class="text-2xl font-bold text-white mb-1" id="winner-title"></h2>
-        <p class="text-gray-500 text-sm mb-6" id="winner-rating"></p>
+        <p class="text-gray-400 text-sm" id="winner-rating"></p>
+        <p class="text-gray-500 text-xs mt-0.5 mb-6" id="winner-meta"></p>
         <div class="flex gap-3 justify-center">
             <a id="winner-details-link" href="#" class="btn-accent px-6 py-3">View Details</a>
             <button id="winner-dismiss" class="btn-secondary px-6 py-3">Stay Here</button>

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -18,7 +18,7 @@
     {{-- Header --}}
     <div class="flex items-start justify-between mb-4 gap-3">
         <div>
-            <h1 class="text-xl font-bold text-white">Pick Together</h1>
+            <h1 id="collab-title" class="text-xl font-bold text-white">Pick Together</h1>
             <p class="text-xs text-gray-500 mt-0.5">Vote out movies — last one standing wins</p>
         </div>
         <div class="flex items-center gap-2 flex-shrink-0">
@@ -201,6 +201,7 @@
             @endif
         </div>
         <div class="flex items-center gap-3">
+            <button id="try-again-btn" class="btn-secondary px-6 min-h-[44px] hidden">Try Again</button>
             <button id="ready-btn" class="btn-accent px-6 min-h-[44px]">
                 Ready to Roll
                 <span id="ready-count" class="text-xs opacity-70 ml-1"></span>
@@ -208,6 +209,9 @@
         </div>
     </div>
 </div>
+
+{{-- Tension vignette --}}
+<div id="tension-vignette" class="hidden fixed inset-0 pointer-events-none z-30" style="background:radial-gradient(ellipse at center, transparent 30%, rgba(180,0,0,0.25) 100%)"></div>
 
 {{-- Winner overlay --}}
 <div id="winner-overlay" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm px-4">

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -90,8 +90,8 @@
                     {{-- Ambient vote heat (visible to all) --}}
                     <div class="vote-heat absolute inset-0 bg-red-900/0 transition-all duration-500 pointer-events-none"></div>
 
-                    {{-- My vote indicator (border glow) --}}
-                    <div class="voted-overlay absolute inset-0 border-2 border-red-500/70 hidden pointer-events-none"></div>
+                    {{-- My vote indicator --}}
+                    <div class="voted-overlay absolute inset-0 hidden pointer-events-none"></div>
 
                     {{-- Vote info + bar --}}
                     <div class="absolute bottom-0 left-0 right-0">
@@ -162,9 +162,14 @@
                             <div class="w-full h-full flex items-center justify-center text-gray-600 text-xs px-2 text-center">{{ $title }}</div>
                         @endif
                         <div class="absolute top-2 right-2 w-5 h-5 rounded-full bg-black/70 flex items-center justify-center text-xs">↩</div>
-                        <div class="restore-pips absolute top-2 left-0 right-0 flex justify-center gap-1 hidden"></div>
-                        <div class="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
-                            <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+                        <div class="absolute bottom-0 left-0 right-0">
+                            <div class="vote-info hidden px-2 py-1 flex items-center gap-1.5 bg-black/50">
+                                <div class="vote-avatars flex -space-x-1.5"></div>
+                                <span class="vote-count text-xs text-green-300"></span>
+                            </div>
+                            <div class="h-1 bg-white/10">
+                                <div class="restore-bar h-full bg-green-500 transition-all duration-300" style="width:0%"></div>
+                            </div>
                         </div>
                     </div>
                     <div class="p-2">

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -8,6 +8,8 @@
 @endsection
 @section('content')
 
+</div>
+
 <div class="max-w-7xl mx-auto px-4 py-6" id="collab-root"
      data-token="{{ $batch->token }}"
      data-media-type="{{ $batch->media_type }}"

--- a/resources/views/batch/collab.blade.php
+++ b/resources/views/batch/collab.blade.php
@@ -201,7 +201,6 @@
             @endif
         </div>
         <div class="flex items-center gap-3">
-            <button id="try-again-btn" class="btn-secondary px-6 min-h-[44px] hidden">Try Again</button>
             <button id="ready-btn" class="btn-accent px-6 min-h-[44px]">
                 Ready to Roll
                 <span id="ready-count" class="text-xs opacity-70 ml-1"></span>
@@ -214,16 +213,27 @@
 <div id="tension-vignette" class="hidden fixed inset-0 pointer-events-none z-30" style="background:radial-gradient(ellipse at center, transparent 30%, rgba(180,0,0,0.25) 100%)"></div>
 
 {{-- Winner overlay --}}
-<div id="winner-overlay" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm px-4">
-    <div class="text-center max-w-sm w-full">
-        <p class="text-gray-500 text-sm mb-5">Last one standing 🎉</p>
-        <div id="winner-poster" class="mx-auto w-32 sm:w-40 rounded-xl overflow-hidden mb-5 shadow-2xl ring-2 ring-accent/50"></div>
-        <h2 class="text-2xl font-bold text-white mb-1" id="winner-title"></h2>
-        <p class="text-gray-400 text-sm" id="winner-rating"></p>
-        <p class="text-gray-500 text-xs mt-0.5 mb-6" id="winner-meta"></p>
-        <div class="flex gap-3 justify-center">
-            <a id="winner-details-link" href="#" class="btn-accent px-6 py-3">View Details</a>
-            <button id="winner-dismiss" class="btn-secondary px-6 py-3">Stay Here</button>
+<div id="winner-overlay" class="hidden fixed inset-0 z-50 flex items-center justify-center px-4">
+    {{-- Blurred poster background --}}
+    <div id="winner-bg" class="absolute inset-0 bg-cover bg-center scale-110" style="filter:blur(24px)"></div>
+    <div class="absolute inset-0 bg-black/70"></div>
+
+    {{-- Content --}}
+    <div class="relative z-10 text-center max-w-xs w-full">
+        <p class="text-white/60 text-xs font-medium uppercase tracking-widest mb-4">Last one standing</p>
+
+        <div id="winner-poster" class="mx-auto w-44 sm:w-52 rounded-2xl overflow-hidden mb-6 shadow-[0_0_60px_rgba(0,0,0,0.8)] ring-2 ring-white/20"></div>
+
+        <h2 class="text-3xl font-bold text-white mb-1 leading-tight" id="winner-title"></h2>
+        <p class="text-accent font-semibold text-sm mt-1" id="winner-rating"></p>
+        <p class="text-white/50 text-xs mt-1 mb-8" id="winner-meta"></p>
+
+        <div class="flex flex-col gap-2.5 items-center">
+            <a id="winner-details-link" href="#" class="btn-accent w-full py-3 text-center">View Details</a>
+            <div class="flex gap-2.5 w-full">
+                <button id="winner-share" class="btn-secondary flex-1 py-3">Share</button>
+                <button id="winner-try-again" class="btn-secondary flex-1 py-3">Try Again</button>
+            </div>
         </div>
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -97,6 +97,7 @@ Route::prefix('batch/collab/{token}')->group(function () {
     Route::post('/leave',        [CollabBatchController::class, 'leave']);
     Route::post('/heartbeat',    [CollabBatchController::class, 'heartbeat']);
     Route::post('/vote/{movieId}', [CollabBatchController::class, 'vote']);
+    Route::post('/voting',       [CollabBatchController::class, 'voting']);
     Route::post('/ready',        [CollabBatchController::class, 'toggleReady']);
     Route::post('/refresh',      [CollabBatchController::class, 'toggleRefreshVote']);
     Route::post('/remove-votes', [CollabBatchController::class, 'removeVotes']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,6 +101,7 @@ Route::prefix('batch/collab/{token}')->group(function () {
     Route::post('/ready',        [CollabBatchController::class, 'toggleReady']);
     Route::post('/refresh',      [CollabBatchController::class, 'toggleRefreshVote']);
     Route::post('/remove-votes', [CollabBatchController::class, 'removeVotes']);
+    Route::post('/restart',      [CollabBatchController::class, 'restart']);
 });
 
 // ── Watchlist (auth required) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Refactor collab batch to delta broadcasts — payloads drop from ~10KB to ~100-200 bytes per event, fixing payload too large errors on large watchlists
- Phase 1: veto/restore animations, compound vote overlay (desaturation + red gradient), voter avatars on cards, shared card builder
- Phase 2: someone is voting indicator — stacked badges per card with veto/recall distinction
- Phase 3: tension mode (Final 3/2/1 header, red vignette, pulsed progress bar), Try Again voting, restore cards to original position, winner auto-show
- Phase 4: better winner screen with blurred poster background, Try Again on winner overlay, share button, improved confetti
- Misc: remove dead routes, add try_again_votes migration, fix payload too large on watchlist Pick Together