### PR TITLE
Mobile UX improvements

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -142,6 +142,35 @@ html[data-theme="light"] {
         color: var(--text-primary);
     }
 
+    /* Mobile sticky bar tab buttons */
+    .btn-nav-tab {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.2rem;
+        padding: 0.45rem 0.25rem;
+        border-radius: 0.75rem;
+        background-color: rgba(255,255,255,0.05);
+        color: rgba(156,163,175,1);
+        border: none;
+        cursor: pointer;
+        transition: background-color 0.15s, color 0.15s, transform 0.1s;
+        text-decoration: none;
+        font-size: 0.625rem;
+        font-weight: 500;
+        line-height: 1;
+    }
+    .btn-nav-tab:hover { color: #fff; background-color: rgba(255,255,255,0.08); }
+    .btn-nav-tab:active { transform: scale(0.96); }
+    .btn-nav-tab:disabled { opacity: 0.35; pointer-events: none; }
+    .btn-nav-tab.accent {
+        background-color: rgba(192,57,58,0.15);
+        color: #c0393a;
+    }
+    .btn-nav-tab.accent:hover { background-color: rgba(192,57,58,0.25); color: #c0393a; }
+
     .watchlist-filter.active,
     .trend-toggle.active,
     .roulette-tab.active {

--- a/resources/js/custom/trailerModal.js
+++ b/resources/js/custom/trailerModal.js
@@ -1,4 +1,6 @@
 import TomSelect from 'tom-select';
+import jq from 'jquery';
+window.jQuery = window.jQuery || jq;   // flexdatalist expects a global jQuery
 import 'jquery-flexdatalist/jquery.flexdatalist.min';
 
 $(document).ready(function () {

--- a/resources/js/custom/watchlist.js
+++ b/resources/js/custom/watchlist.js
@@ -29,6 +29,18 @@ $(document).ready(function () {
     // Disable Pick Together when fewer than 2 cards are visible
     $('#watchlist-collab').prop('disabled', $('.watchlist-card:visible').length <= 1);
 
+    // Filter expand toggle
+    $('#filter-expand-btn').on('click', function () {
+        $('#filter-expand-body').toggleClass('hidden flex');
+        $(this).toggleClass('text-accent bg-white/10');
+    });
+
+    // Mobile sticky bar proxies
+    $('#watchlist-share-m').on('click', () => $('#watchlist-share').trigger('click'));
+    $('#wl-swipe-btn-m').on('click', () => document.getElementById('wl-swipe-btn')?.click());
+    $('#watchlist-collab-m').on('click', () => $('#watchlist-collab').trigger('click'));
+    $('#watchlist-roll-m').on('click', () => $('#watchlist-roll').trigger('click'));
+
     // Save / unsave toggle on movie detail page
     $(document).on('click', '.watchlist-toggle', function () {
         const btn = $(this);
@@ -61,6 +73,9 @@ $(document).ready(function () {
         .always(function () { btn.prop('disabled', false); });
     });
 
+    const svgChecked   = '<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg>';
+    const svgUnchecked = '<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/></svg>';
+
     // Toggle watched / unwatched on watchlist page
     $(document).on('click', '.toggle-watched', function () {
         const btn = $(this);
@@ -78,12 +93,14 @@ $(document).ready(function () {
             card.attr('data-status', next);
 
             if (next === 'watched') {
-                btn.text('✓ Watched')
+                btn.html(svgChecked)
+                   .attr('title', 'Mark unwatched')
                    .removeClass('bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white')
                    .addClass('bg-white/10 text-white hover:bg-white/5 hover:text-gray-400');
                 card.find('.watched-overlay').removeClass('hidden');
             } else {
-                btn.text('Mark watched')
+                btn.html(svgUnchecked)
+                   .attr('title', 'Mark watched')
                    .removeClass('bg-white/10 text-white hover:bg-white/5 hover:text-gray-400')
                    .addClass('bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white');
                 card.find('.watched-overlay').addClass('hidden');
@@ -423,3 +440,373 @@ $(document).ready(function () {
     });
 
 });
+
+/* ── Watchlist Swipe Mode ──────────────────────────────────────────────── */
+(function () {
+    const overlay       = document.getElementById('wl-swipe-overlay');
+    const cardStack     = document.getElementById('wl-card-stack');
+    const overlayKeep   = document.getElementById('wl-overlay-keep');
+    const overlayRemove = document.getElementById('wl-overlay-remove');
+    const doneScreen    = document.getElementById('wl-swipe-done');
+    const doneTitle     = document.getElementById('wl-done-title');
+    const doneStats     = document.getElementById('wl-done-stats');
+    const counterEl     = document.getElementById('wl-swipe-counter');
+    const undoBtn       = document.getElementById('wl-btn-undo');
+    if (!overlay) return;
+
+    const THRESHOLD     = 70;
+    const VEL_THRESHOLD = 0.25;
+    const MIN_FLICK_DX  = 20;
+
+    let queue        = [];
+    let history      = [];
+    let toRemove     = [];
+    let totalItems   = 0;
+    let keptCount    = 0;
+    let removedCount = 0;
+    let animating    = false;
+
+    const csrf = () => document.querySelector('meta[name=csrf-token]').content;
+
+    const style = document.createElement('style');
+    style.textContent = '@keyframes wlConfettiFall{from{top:-20px;opacity:1}to{top:110%;opacity:0}}';
+    document.head.appendChild(style);
+
+    function shuffle(arr) {
+        for (let i = arr.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [arr[i], arr[j]] = [arr[j], arr[i]];
+        }
+    }
+
+    function buildQueue() {
+        queue = [];
+        document.querySelectorAll('.watchlist-card').forEach(card => {
+            if (getComputedStyle(card).display === 'none') return;
+            const link    = card.querySelector('a[href]');
+            const img     = card.querySelector('img');
+            const href    = link?.getAttribute('href') || '';
+            const idMatch = href.match(/\/(?:movie|tv)\/(\d+)/);
+            if (!idMatch) return;
+            queue.push({
+                id:     parseInt(idMatch[1]),
+                type:   card.dataset.type || 'movie',
+                title:  card.dataset.title || '',
+                year:   card.dataset.year || '',
+                rating: card.dataset.rating || '',
+                poster: img ? img.src : '',
+                href,
+                el:     card,
+            });
+        });
+        shuffle(queue);
+        totalItems = queue.length;
+    }
+
+    function buildCard(item) {
+        const el = document.createElement('div');
+        el.className = 'wl-swipe-card absolute inset-0 rounded-2xl overflow-hidden shadow-2xl bg-[#1a1a1a] cursor-grab active:cursor-grabbing select-none';
+        el.style.cssText = 'touch-action:none;will-change:transform;';
+        el.innerHTML = `
+            <div class="absolute inset-0">
+                ${item.poster
+                    ? `<img src="${item.poster}" class="w-full h-full object-cover" draggable="false">`
+                    : `<div class="w-full h-full bg-white/5 flex items-center justify-center text-gray-600 text-sm px-4 text-center">${item.title}</div>`}
+                <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/10 to-transparent"></div>
+                <div class="absolute bottom-0 left-0 right-0 p-5">
+                    <a href="${item.href}" target="_blank" rel="noopener" class="inline-block" onclick="event.stopPropagation()">
+                        <h2 class="text-2xl font-bold text-white leading-tight hover:underline">${item.title}</h2>
+                    </a>
+                    <div class="flex items-center gap-2 mt-1.5 flex-wrap">
+                        ${item.year   ? `<span class="text-sm text-gray-300">${item.year}</span>` : ''}
+                        ${item.rating ? `<span class="text-sm text-gray-300">★ ${Number(item.rating).toFixed(1)}</span>` : ''}
+                        <span class="text-xs bg-white/15 text-white/80 px-2 py-0.5 rounded-full">${item.type === 'tv' ? 'TV' : 'Film'}</span>
+                    </div>
+                </div>
+            </div>`;
+        return el;
+    }
+
+    function renderStack() {
+        cardStack.innerHTML = '';
+        if (queue.length === 0) { showDone(); return; }
+
+        if (queue.length > 1) {
+            const behind = buildCard(queue[1]);
+            behind.style.cssText += 'z-index:1;pointer-events:none;transform:scale(0.94) translateY(10px);';
+            cardStack.appendChild(behind);
+        }
+        const top = buildCard(queue[0]);
+        top.style.zIndex = '2';
+        cardStack.appendChild(top);
+        attachDrag(top);
+        updateCounter();
+        updateUndoBtn();
+    }
+
+    function advanceStack(action) {
+        const item = queue.shift();
+        history.push({ item, action });
+
+        if (action === 'remove') {
+            removedCount++;
+            item.el.style.display = 'none';
+            toRemove.push(item);
+        } else {
+            keptCount++;
+        }
+
+        const oldTop = cardStack.querySelector('.wl-swipe-card:last-child');
+        if (oldTop) oldTop.remove();
+
+        if (queue.length === 0) { showDone(); return; }
+
+        const newTop = cardStack.querySelector('.wl-swipe-card');
+        if (newTop) {
+            newTop.style.transition    = 'transform 0.25s ease-out';
+            newTop.style.transform     = 'scale(1) translateY(0)';
+            newTop.style.zIndex        = '2';
+            newTop.style.pointerEvents = '';
+            attachDrag(newTop);
+        }
+
+        if (queue.length > 1) {
+            const behind = buildCard(queue[1]);
+            behind.style.cssText += 'z-index:1;pointer-events:none;transform:scale(0.94) translateY(10px);opacity:0;';
+            cardStack.insertBefore(behind, newTop);
+            requestAnimationFrame(() => {
+                behind.style.transition = 'opacity 0.2s ease';
+                behind.style.opacity    = '1';
+            });
+        }
+        updateCounter();
+        updateUndoBtn();
+    }
+
+    function triggerUndo() {
+        if (!history.length || animating) return;
+        const last = history.pop();
+        queue.unshift(last.item);
+
+        if (last.action === 'remove') {
+            removedCount--;
+            last.item.el.style.display = '';
+            toRemove = toRemove.filter(i => i.id !== last.item.id);
+        } else {
+            keptCount--;
+        }
+
+        // Demote current top to behind
+        const cards = cardStack.querySelectorAll('.wl-swipe-card');
+        if (cards.length >= 2) {
+            for (let i = 0; i < cards.length - 1; i++) cards[i].remove();
+        }
+        const currentTop = cardStack.querySelector('.wl-swipe-card:last-child');
+        if (currentTop) {
+            currentTop.style.transition    = 'transform 0.25s ease-out';
+            currentTop.style.transform     = 'scale(0.94) translateY(10px)';
+            currentTop.style.zIndex        = '1';
+            currentTop.style.pointerEvents = 'none';
+        }
+
+        // Fly undone card back in from direction it left
+        const card     = buildCard(last.item);
+        const startX   = (last.action === 'keep' ? 1 : -1) * (window.innerWidth + 200);
+        card.style.zIndex     = '2';
+        card.style.transform  = `translateX(${startX}px) rotate(${(last.action === 'keep' ? 1 : -1) * 20}deg)`;
+        card.style.transition = 'none';
+        cardStack.appendChild(card);
+        attachDrag(card);
+        requestAnimationFrame(() => {
+            card.style.transition = 'transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94)';
+            card.style.transform  = 'translateX(0) rotate(0deg)';
+        });
+
+        updateCounter();
+        updateUndoBtn();
+    }
+
+    function updateCounter() {
+        if (!counterEl) return;
+        const pos = totalItems - queue.length + 1;
+        counterEl.textContent = queue.length > 0 ? `${pos} / ${totalItems}` : `${totalItems} / ${totalItems}`;
+    }
+
+    function updateUndoBtn() {
+        if (!undoBtn) return;
+        undoBtn.disabled = history.length === 0;
+        undoBtn.classList.toggle('text-gray-500', history.length === 0);
+        undoBtn.classList.toggle('text-yellow-400', history.length > 0);
+    }
+
+    function attachDrag(card) {
+        if (card.dataset.dragAttached) return;
+        card.dataset.dragAttached = '1';
+        let startX = 0, startY = 0, dx = 0, startTime = 0, active = false;
+
+        const onStart = (e) => {
+            if (animating) return;
+            active    = true;
+            dx        = 0;
+            const pt  = e.touches ? e.touches[0] : e;
+            startX    = pt.clientX;
+            startY    = pt.clientY;
+            startTime = Date.now();
+            card.style.transition = 'none';
+        };
+
+        const onMove = (e) => {
+            if (!active) return;
+            e.preventDefault();
+            const pt = e.touches ? e.touches[0] : e;
+            dx       = pt.clientX - startX;
+            const dy = pt.clientY - startY;
+            card.style.transform = `translate(${dx}px, ${dy * 0.3}px) rotate(${dx * 0.08}deg)`;
+            const ratio = Math.min(Math.abs(dx) / THRESHOLD, 1);
+            if (dx > 0) {
+                overlayKeep.style.opacity   = ratio;
+                overlayRemove.style.opacity = 0;
+            } else {
+                overlayRemove.style.opacity = ratio;
+                overlayKeep.style.opacity   = 0;
+            }
+        };
+
+        const onEnd = () => {
+            if (!active) return;
+            active = false;
+            overlayKeep.style.opacity   = 0;
+            overlayRemove.style.opacity = 0;
+            const velocity = Math.abs(dx) / Math.max(Date.now() - startTime, 1);
+            const isFlick  = velocity > VEL_THRESHOLD && Math.abs(dx) > MIN_FLICK_DX;
+            if (Math.abs(dx) >= THRESHOLD || isFlick) {
+                dx > 0 ? triggerKeep(card) : triggerRemove(card);
+            } else {
+                card.style.transition = 'transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275)';
+                card.style.transform  = 'translate(0,0) rotate(0deg)';
+            }
+            dx = 0;
+        };
+
+        card.addEventListener('pointerdown', onStart);
+        card.addEventListener('pointermove', onMove, { passive: false });
+        card.addEventListener('pointerup',   onEnd);
+        card.addEventListener('pointercancel', onEnd);
+    }
+
+    function flyOut(card, direction, cb) {
+        animating = true;
+        const x = direction * (window.innerWidth + 200);
+        card.style.transition = 'transform 0.35s ease-in, opacity 0.35s ease-in';
+        card.style.transform  = `translate(${x}px, 20px) rotate(${direction * 30}deg)`;
+        card.style.opacity    = '0';
+        setTimeout(() => { animating = false; cb(); }, 360);
+    }
+
+    function triggerKeep(card)   { flyOut(card,  1, () => advanceStack('keep')); }
+    function triggerRemove(card) { flyOut(card, -1, () => advanceStack('remove')); }
+
+    function showDone() {
+        const total = keptCount + removedCount;
+        const icon  = document.getElementById('wl-done-icon');
+        if (removedCount === total && total > 0) {
+            doneTitle.textContent = 'Watchlist Cleared!';
+            icon.textContent = '🏆';
+        } else if (removedCount === 0) {
+            doneTitle.textContent = 'You kept everything!';
+            icon.textContent = '👍';
+        } else {
+            doneTitle.textContent = 'All done!';
+            icon.textContent = '🎉';
+        }
+        doneStats.textContent = `${removedCount} removed · ${keptCount} kept`;
+        doneScreen.classList.remove('hidden');
+        spawnConfetti();
+        syncCount();
+    }
+
+    function spawnConfetti() {
+        const container = document.getElementById('wl-done-confetti');
+        if (!container) return;
+        container.innerHTML = '';
+        const colors = ['#f59e0b', '#10b981', '#3b82f6', '#ef4444', '#8b5cf6', '#ec4899'];
+        for (let i = 0; i < 70; i++) {
+            const el     = document.createElement('div');
+            const isRect = Math.random() > 0.5;
+            const size   = Math.random() * 8 + 5;
+            el.style.cssText = [
+                'position:absolute',
+                `width:${size}px`,
+                `height:${isRect ? size * 0.4 : size}px`,
+                `background:${colors[i % colors.length]}`,
+                `border-radius:${isRect ? '2px' : '50%'}`,
+                `left:${Math.random() * 100}%`,
+                'top:-20px',
+                `animation:wlConfettiFall ${Math.random() * 2 + 2}s ${Math.random() * 1.5}s linear forwards`,
+            ].join(';');
+            container.appendChild(el);
+        }
+    }
+
+    function syncCount() {
+        let visible = 0;
+        document.querySelectorAll('.watchlist-card').forEach(c => {
+            if (getComputedStyle(c).display !== 'none') visible++;
+        });
+        const countEl = document.getElementById('wl-count');
+        if (countEl) countEl.textContent = `(${visible})`;
+    }
+
+    function fireDeletes() {
+        toRemove.forEach(item => {
+            fetch(`/watchlist/${item.id}`, {
+                method:  'DELETE',
+                headers: { 'X-CSRF-TOKEN': csrf() },
+            }).catch(() => {});
+        });
+        toRemove = [];
+    }
+
+    function closeOverlay() {
+        fireDeletes();
+        overlay.classList.add('hidden');
+        document.body.style.overflow = '';
+        syncCount();
+        if (!document.querySelector('.watchlist-card:not([style*="display: none"])')) location.reload();
+    }
+
+    document.getElementById('wl-swipe-btn')?.addEventListener('click', () => {
+        buildQueue();
+        if (!queue.length) return;
+        history      = [];
+        toRemove     = [];
+        keptCount    = 0;
+        removedCount = 0;
+        doneScreen.classList.add('hidden');
+        overlay.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        renderStack();
+    });
+
+    document.getElementById('wl-swipe-close')?.addEventListener('click', closeOverlay);
+    document.getElementById('wl-done-close')?.addEventListener('click', closeOverlay);
+
+    document.getElementById('wl-btn-keep')?.addEventListener('click', () => {
+        if (animating || !queue.length) return;
+        triggerKeep(cardStack.querySelector('.wl-swipe-card:last-child'));
+    });
+
+    document.getElementById('wl-btn-remove')?.addEventListener('click', () => {
+        if (animating || !queue.length) return;
+        triggerRemove(cardStack.querySelector('.wl-swipe-card:last-child'));
+    });
+
+    undoBtn?.addEventListener('click', triggerUndo);
+
+    document.addEventListener('keydown', (e) => {
+        if (overlay.classList.contains('hidden')) return;
+        if (e.key === 'ArrowRight') document.getElementById('wl-btn-keep')?.click();
+        if (e.key === 'ArrowLeft')  document.getElementById('wl-btn-remove')?.click();
+        if (e.key === 'ArrowDown')  undoBtn?.click();
+    });
+})();

--- a/resources/views/batch.blade.php
+++ b/resources/views/batch.blade.php
@@ -21,11 +21,39 @@
     @endif
 
     {{-- Header row --}}
-    <div class="flex items-center justify-between gap-4 mb-6 flex-wrap">
-        <div>
-            <h1 class="text-2xl font-bold text-white">{{ $tag ?? ($isTv ? 'TV Batch' : 'Movie Batch') }}</h1>
+    <div class="mb-6">
+        <h1 class="text-2xl font-bold text-white mb-3">{{ $tag ?? ($isTv ? 'TV Batch' : 'Movie Batch') }}</h1>
+
+        {{-- Mobile: btn-nav-tab row --}}
+        <div class="flex gap-2 sm:hidden">
+            @if(isset($shareToken) && empty($isShared))
+            <button type="button" class="btn-nav-tab"
+                data-share
+                data-share-url="{{ url('/batch/share/'.$shareToken) }}"
+                data-share-title="{{ $tag ?? 'Shared Batch' }} — MoviePickr">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+                Share
+            </button>
+            @endif
+            @auth
+            @if(isset($shareToken))
+            <button type="button" id="collab-start-btn-m" class="btn-nav-tab"
+                data-media-type="{{ $mediaType ?? 'movie' }}">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+                Together
+            </button>
+            @endif
+            @endauth
+            @auth
+            <button type="button" id="save-roulette-btn-m" class="btn-nav-tab">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>
+                Roulette
+            </button>
+            @endauth
         </div>
-        <div class="flex items-center gap-2">
+
+        {{-- Desktop: text buttons --}}
+        <div class="hidden sm:flex items-center gap-2">
             @if(isset($shareToken) && empty($isShared))
             <button type="button" class="btn-secondary text-sm"
                 data-share
@@ -115,8 +143,35 @@
 </div>
 
 {{-- Sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex items-center justify-end gap-3">
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile --}}
+    <div class="md:hidden flex px-3 py-1.5 gap-2">
+        @if(empty($isShared))
+            @if(isset($providersArray) && isset($all_genres))
+            <button type="button" class="btn-nav-tab" data-modal-open="modal-form">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 6h18M7 12h10M11 18h2"/></svg>
+                Filters
+            </button>
+            @endif
+            <a href="{{ Request::url() }}" class="btn-nav-tab">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 4v16m8-8H4"/></svg>
+                New
+            </a>
+            <button id="batch-roll-btn-m" class="btn-nav-tab accent" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                Roll
+            </button>
+        @else
+            <button id="shared-batch-roll-btn-m" class="btn-nav-tab accent" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                Roll
+            </button>
+        @endif
+    </div>
+
+    {{-- Desktop --}}
+    <div class="hidden md:flex max-w-7xl mx-auto px-4 items-center justify-end gap-3">
         @if(isset($providersArray) && isset($all_genres) && empty($isShared))
             <button type="button" class="btn-secondary flex-1 sm:flex-none" data-modal-open="modal-form">Filters</button>
         @endif
@@ -127,6 +182,13 @@
             <button id="shared-batch-roll-btn" class="btn-accent flex-1 sm:flex-none" data-media-type="{{ $isTv ? 'tv' : 'movie' }}">Roll</button>
         @endif
     </div>
+
 </div>
+<script>
+document.getElementById('batch-roll-btn-m')?.addEventListener('click',()=>document.getElementById('batch-roll-btn').click());
+document.getElementById('shared-batch-roll-btn-m')?.addEventListener('click',()=>document.getElementById('shared-batch-roll-btn').click());
+document.getElementById('collab-start-btn-m')?.addEventListener('click',()=>document.getElementById('collab-start-btn').click());
+document.getElementById('save-roulette-btn-m')?.addEventListener('click',()=>document.getElementById('save-roulette-btn').click());
+</script>
 
 @endsection

--- a/resources/views/criteria.blade.php
+++ b/resources/views/criteria.blade.php
@@ -149,14 +149,32 @@
 </div>
 
 {{-- Sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
-    <div class="max-w-2xl mx-auto flex items-center justify-between gap-2">
-        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden flex-shrink-0">Reset</button>
-        <div class="flex items-center gap-2 sm:ml-auto">
-            <button type="submit" form="criteria" formaction="/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
-            <button type="submit" form="criteria" formaction="/movie" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Movie</button>
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile --}}
+    <div class="md:hidden flex px-3 py-1.5 gap-2">
+        <button type="button" id="btn-reset-mobile" class="btn-nav-tab">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+            Reset
+        </button>
+        <button type="submit" form="criteria" formaction="/multiple" class="btn-nav-tab">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+            Multiple
+        </button>
+        <button type="submit" form="criteria" formaction="/movie" class="btn-nav-tab accent">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+            Find Movie
+        </button>
+    </div>
+
+    {{-- Desktop --}}
+    <div class="hidden md:flex max-w-2xl mx-auto px-4 py-3 items-center justify-between gap-2">
+        <div class="flex items-center gap-2 ml-auto">
+            <button type="submit" form="criteria" formaction="/multiple" class="btn-secondary long-single flex-none text-center">Multiple</button>
+            <button type="submit" form="criteria" formaction="/movie" class="btn-accent long-single flex-none text-center">Find Movie</button>
         </div>
     </div>
+
 </div>
 
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -176,7 +176,6 @@
                         <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
                     </a>
                     <a href="/criteria" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Filters</a>
-                    <a href="/roulettes" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Roulettes</a>
                 </div>
             </div>
 
@@ -196,9 +195,14 @@
                         <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
                     </a>
                     <a href="/tv/criteria" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Filters</a>
-                    <a href="/roulettes?tab=tv" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Roulettes</a>
                 </div>
             </div>
+
+            {{-- Roulettes --}}
+            <a href="/roulettes" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm font-semibold text-white hover:bg-white/5 transition-colors">
+                Roulettes
+                <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
+            </a>
 
             {{-- Account --}}
             <div class="h-px bg-white/5 my-2"></div>
@@ -217,19 +221,21 @@
                     </div>
                 </div>
 
+                <a href="{{ route('watchlist') }}" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">Watchlist</a>
+                <a href="{{ route('my-roulettes.index') }}" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">My Roulettes</a>
                 @if(auth()->user()->email === config('api.admin_email'))
                     <a href="{{ route('admin.dashboard') }}" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-red-400 hover:text-red-300 hover:bg-red-500/5 transition-colors">Admin</a>
+                @endif
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="w-full text-left px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Sign out</button>
+                </form>
+                @if(auth()->user()->email === config('api.admin_email'))
                     <button id="debug-toggle-btn-mobile" class="w-full text-left px-4 py-3 rounded-xl text-sm text-gray-500 hover:text-white hover:bg-white/5 transition-colors flex items-center justify-between">
                         Debug mode
                         <span id="debug-toggle-indicator-mobile" class="text-[10px] px-1.5 py-0.5 rounded-full bg-white/10">off</span>
                     </button>
                 @endif
-                <a href="{{ route('watchlist') }}" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">Watchlist</a>
-                <a href="{{ route('my-roulettes.index') }}" class="flex items-center justify-between px-4 py-3 rounded-xl text-sm text-gray-300 hover:text-white hover:bg-white/5 transition-colors">My Roulettes</a>
-                <form method="POST" action="{{ route('logout') }}">
-                    @csrf
-                    <button type="submit" class="w-full text-left px-4 py-3 rounded-xl text-sm text-gray-400 hover:text-white hover:bg-white/5 transition-colors">Sign out</button>
-                </form>
             @else
                 @if(app()->environment('local'))
                     <a href="/dev/login" class="flex items-center justify-between px-4 py-3.5 rounded-xl bg-yellow-500/10 border border-yellow-500/20 hover:bg-yellow-500/20 text-sm text-yellow-400 font-medium transition-colors">

--- a/resources/views/movie.blade.php
+++ b/resources/views/movie.blade.php
@@ -356,9 +356,39 @@
 </div>
 
 {{-- Sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
-        {{-- Left --}}
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile --}}
+    <div class="md:hidden flex px-3 py-1.5 gap-2">
+        @if(request()->query('wl_status'))
+            <a href="{{ route('watchlist') }}" class="btn-nav-tab">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+                Watchlist
+            </a>
+            <button id="wl-roll-btn-m" class="btn-nav-tab accent">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                Roll
+            </button>
+        @else
+            @if($batchUrl)
+            <a href="{{ $batchUrl }}" class="btn-nav-tab js-back-roulettes">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+                Batch
+            </a>
+            @endif
+            <button type="button" class="btn-nav-tab js-criteria-btn" data-modal-open="modal-form">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 6h18M7 12h10M11 18h2"/></svg>
+                Filters
+            </button>
+            <a href="/movie" class="btn-nav-tab accent" data-roll="movie-criteria">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                Roll
+            </a>
+        @endif
+    </div>
+
+    {{-- Desktop --}}
+    <div class="hidden md:flex max-w-7xl mx-auto px-4 items-center justify-between gap-3">
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
@@ -366,7 +396,6 @@
                 <a href="{{ $batchUrl ?? '#' }}" class="btn-secondary text-center js-back-roulettes {{ $batchUrl ? '' : 'hidden' }}">← Batch</a>
             @endif
         </div>
-        {{-- Right --}}
         <div class="flex items-center gap-3">
             @if(request()->query('wl_status'))
                 <button id="wl-roll-btn" class="btn-accent">Roll</button>
@@ -376,7 +405,11 @@
             @endif
         </div>
     </div>
+
 </div>
+@if(request()->query('wl_status'))
+<script>document.getElementById('wl-roll-btn-m')?.addEventListener('click',()=>document.getElementById('wl-roll-btn').click());</script>
+@endif
 
 @if(request()->query('wl_status'))
 <script>

--- a/resources/views/person.blade.php
+++ b/resources/views/person.blade.php
@@ -4,8 +4,11 @@
 <div class="max-w-4xl mx-auto px-4 py-8">
 
     {{-- Header --}}
-    <div class="flex gap-6 mb-8">
-        <div class="flex-shrink-0 w-32 sm:w-44">
+    <div class="flex gap-4 sm:gap-6 mb-4 sm:mb-8">
+
+        {{-- Left: photo + roll buttons --}}
+        <div class="flex-shrink-0 w-28 sm:w-44 flex flex-col gap-3">
+            {{-- Photo --}}
             @if(!empty($person->profile_path))
                 <img src="https://image.tmdb.org/t/p/w300{{ $person->profile_path }}"
                      alt="{{ $person->name }}"
@@ -15,13 +18,63 @@
                     {{ strtoupper(substr($person->name ?? '?', 0, 1)) }}
                 </div>
             @endif
+
+            {{-- Roll buttons --}}
+            @if($hasMovieCast || $hasMovieCrew)
+            <div>
+                <p class="text-[10px] text-gray-500 uppercase tracking-wide mb-1">Movies</p>
+                <div class="flex flex-col gap-1">
+                    @if($hasMovieCast)
+                    <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'cast']) }}"
+                       data-roll="person-movie" data-back-label="← {{ $person->name ?? 'Person' }}"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=cast') }}"
+                       class="block text-center text-xs px-2 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll as actor
+                    </a>
+                    @endif
+                    @if($hasMovieCrew)
+                    <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'crew']) }}"
+                       data-roll="person-movie" data-back-label="← {{ $person->name ?? 'Person' }}"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=crew') }}"
+                       class="block text-center text-xs px-2 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll as crew
+                    </a>
+                    @endif
+                </div>
+            </div>
+            @endif
+            @if($hasTvCast || $hasTvCrew)
+            <div>
+                <p class="text-[10px] text-gray-500 uppercase tracking-wide mb-1">TV Shows</p>
+                <div class="flex flex-col gap-1">
+                    @if($hasTvCast)
+                    <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'cast']) }}"
+                       data-roll="person-tv" data-back-label="← {{ $person->name ?? 'Person' }}"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=cast') }}"
+                       class="block text-center text-xs px-2 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll as actor
+                    </a>
+                    @endif
+                    @if($hasTvCrew)
+                    <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'crew']) }}"
+                       data-roll="person-tv" data-back-label="← {{ $person->name ?? 'Person' }}"
+                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=crew') }}"
+                       class="block text-center text-xs px-2 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
+                        Roll as crew
+                    </a>
+                    @endif
+                </div>
+            </div>
+            @endif
         </div>
-        <div class="min-w-0 flex flex-col justify-center">
+
+        {{-- Right: text info --}}
+        <div class="min-w-0 flex flex-col">
             @if(!empty($person->known_for_department))
                 <span class="inline-block text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent/15 text-accent border border-accent/20 mb-2 w-fit">{{ $person->known_for_department }}</span>
             @endif
-            <h1 class="text-2xl sm:text-3xl font-bold text-white leading-tight">{{ $person->name }}</h1>
-            <div class="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-sm text-gray-500">
+            <h1 class="text-xl sm:text-3xl font-bold text-white leading-tight">{{ $person->name }}</h1>
+            <div class="flex flex-col gap-0.5 mt-2 text-sm text-gray-500">
                 @if(!empty($person->birthday))
                     <span>Born {{ \Carbon\Carbon::parse($person->birthday)->format('M j, Y') }}
                         @if(empty($person->deathday))
@@ -36,72 +89,22 @@
                     <span>{{ $person->place_of_birth }}</span>
                 @endif
             </div>
-            {{-- External links --}}
             @if(!empty($person->imdb_id) || !empty($person->homepage))
             <div class="flex flex-wrap gap-2 mt-3">
                 @if(!empty($person->imdb_id))
                     <a href="https://www.imdb.com/name/{{ $person->imdb_id }}" target="_blank"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 hover:bg-yellow-500/20 transition-colors">
+                       class="inline-flex items-center text-xs px-3 py-1.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 hover:bg-yellow-500/20 transition-colors">
                         IMDb
                     </a>
                 @endif
                 @if(!empty($person->homepage))
                     <a href="{{ $person->homepage }}" target="_blank"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 transition-colors">
+                       class="inline-flex items-center text-xs px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-gray-400 hover:text-white hover:bg-white/10 transition-colors">
                         Website
                     </a>
                 @endif
             </div>
             @endif
-
-            {{-- Discover buttons --}}
-            @if($hasMovieCast || $hasMovieCrew)
-            <div class="mt-3">
-                <p class="text-xs text-gray-500 mb-1.5">Movies</p>
-                <div class="flex flex-wrap gap-2">
-                    @if($hasMovieCast)
-                    <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'cast']) }}"
-                       data-roll="person-movie" data-back-label="← {{ $person->name ?? 'Person' }}"
-                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=cast') }}"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
-                        Roll as actor
-                    </a>
-                    @endif
-                    @if($hasMovieCrew)
-                    <a href="{{ route('person.roll.movie', ['id' => $person->id, 'type' => 'crew']) }}"
-                       data-roll="person-movie" data-back-label="← {{ $person->name ?? 'Person' }}"
-                       data-json-url="{{ url('/person/'.$person->id.'/roll/movie/json?type=crew') }}"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
-                        Roll as crew
-                    </a>
-                    @endif
-                </div>
-            </div>
-            @endif
-            @if($hasTvCast || $hasTvCrew)
-            <div class="mt-3">
-                <p class="text-xs text-gray-500 mb-1.5">TV Shows</p>
-                <div class="flex flex-wrap gap-2">
-                    @if($hasTvCast)
-                    <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'cast']) }}"
-                       data-roll="person-tv" data-back-label="← {{ $person->name ?? 'Person' }}"
-                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=cast') }}"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
-                        Roll as actor
-                    </a>
-                    @endif
-                    @if($hasTvCrew)
-                    <a href="{{ route('person.roll.tv', ['id' => $person->id, 'type' => 'crew']) }}"
-                       data-roll="person-tv" data-back-label="← {{ $person->name ?? 'Person' }}"
-                       data-json-url="{{ url('/person/'.$person->id.'/roll/tv/json?type=crew') }}"
-                       class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-accent/10 border border-accent/20 text-accent hover:bg-accent/20 transition-colors">
-                        Roll as crew
-                    </a>
-                    @endif
-                </div>
-            </div>
-            @endif
-
             @if(!empty($person->biography))
                 <p class="text-gray-400 text-sm mt-3 leading-relaxed line-clamp-4">{{ $person->biography }}</p>
                 @if(strlen($person->biography) > 300)
@@ -112,11 +115,11 @@
         </div>
     </div>
 
-    {{-- Photo strip --}}
-    @php $photos = collect($person->images->profiles ?? [])->sortByDesc('vote_average')->skip(1)->take(6)->values(); @endphp
-    @if($photos->isNotEmpty())
-    <div class="flex gap-2 overflow-x-auto pb-2 scrollbar-hide mb-8">
-        @foreach($photos as $photo)
+    {{-- Photo strip: hidden on mobile --}}
+    @php $photoStrip = collect($person->images->profiles ?? [])->sortByDesc('vote_average')->skip(1)->take(6)->values(); @endphp
+    @if($photoStrip->isNotEmpty())
+    <div class="hidden sm:flex gap-2 overflow-x-auto pb-2 scrollbar-hide mb-6">
+        @foreach($photoStrip as $photo)
         <div class="flex-shrink-0 w-20 aspect-[2/3] rounded-lg overflow-hidden border border-white/5">
             <img src="https://image.tmdb.org/t/p/w185{{ $photo->file_path }}"
                  alt="{{ $person->name }}"
@@ -138,7 +141,7 @@
     @endphp
     @if($firstTab)
     <div>
-        <div class="section-header mb-4">
+        <div class="section-header mb-3">
             <h2 class="text-xl font-bold text-white mb-3">Filmography</h2>
             <div class="section-divider"></div>
         </div>

--- a/resources/views/tv/criteria.blade.php
+++ b/resources/views/tv/criteria.blade.php
@@ -157,14 +157,32 @@
 </div>
 
 {{-- Sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 py-3 z-40">
-    <div class="max-w-2xl mx-auto flex items-center justify-between gap-2">
-        <button type="button" id="btn-reset-mobile" class="btn-secondary text-sm px-4 sm:hidden flex-shrink-0">Reset</button>
-        <div class="flex items-center gap-2 sm:ml-auto">
-            <button type="submit" form="criteria" formaction="/tv/multiple" class="btn-secondary long-single flex-1 sm:flex-none text-center">Multiple</button>
-            <button type="submit" form="criteria" formaction="/tv/pick" class="btn-accent long-single flex-1 sm:flex-none text-center">Find Show</button>
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile --}}
+    <div class="md:hidden flex px-3 py-1.5 gap-2">
+        <button type="button" id="btn-reset-mobile" class="btn-nav-tab">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+            Reset
+        </button>
+        <button type="submit" form="criteria" formaction="/tv/multiple" class="btn-nav-tab">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+            Multiple
+        </button>
+        <button type="submit" form="criteria" formaction="/tv/pick" class="btn-nav-tab accent">
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+            Find Show
+        </button>
+    </div>
+
+    {{-- Desktop --}}
+    <div class="hidden md:flex max-w-2xl mx-auto px-4 py-3 items-center justify-between gap-2">
+        <div class="flex items-center gap-2 ml-auto">
+            <button type="submit" form="criteria" formaction="/tv/multiple" class="btn-secondary long-single flex-none text-center">Multiple</button>
+            <button type="submit" form="criteria" formaction="/tv/pick" class="btn-accent long-single flex-none text-center">Find Show</button>
         </div>
     </div>
+
 </div>
 
 @endsection

--- a/resources/views/tv/show.blade.php
+++ b/resources/views/tv/show.blade.php
@@ -458,9 +458,48 @@
 </div>
 
 {{-- Sticky bottom bar --}}
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex items-center justify-between gap-3">
-        {{-- Back button --}}
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile --}}
+    <div class="md:hidden flex px-3 py-1.5 gap-2">
+        @if(request()->query('wl_status'))
+            <a href="{{ route('watchlist') }}" class="btn-nav-tab">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+                Watchlist
+            </a>
+            <button id="wl-roll-btn-m" class="btn-nav-tab accent">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                Roll
+            </button>
+        @else
+            @if($batchUrl)
+            <a href="{{ $batchUrl }}" class="btn-nav-tab js-back-roulettes">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+                Batch
+            </a>
+            @endif
+            @if(!session('tvPersonRollIds'))
+            <button type="button" class="btn-nav-tab js-criteria-btn" data-modal-open="modal-form">
+                <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 6h18M7 12h10M11 18h2"/></svg>
+                Filters
+            </button>
+            @endif
+            @if(session('tvPersonRollIds'))
+                <a href="{{ route('person.roll.tv.next') }}" class="btn-nav-tab accent">
+                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                    Roll
+                </a>
+            @else
+                <a href="/tv/pick" class="btn-nav-tab accent" data-roll="tv-criteria">
+                    <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+                    Roll
+                </a>
+            @endif
+        @endif
+    </div>
+
+    {{-- Desktop --}}
+    <div class="hidden md:flex max-w-7xl mx-auto px-4 items-center justify-between gap-3">
         <div class="flex-shrink-0">
             @if(request()->query('wl_status'))
                 <a href="{{ route('watchlist') }}" class="btn-secondary text-center">← Watchlist</a>
@@ -468,7 +507,6 @@
                 <a href="{{ $batchUrl ?? '#' }}" class="btn-secondary text-center js-back-roulettes {{ $batchUrl ? '' : 'hidden' }}">← Batch</a>
             @endif
         </div>
-        {{-- Right actions --}}
         <div class="flex items-center gap-3">
             @if(!request()->query('wl_status') && !session('tvPersonRollIds'))
                 <button type="button" class="btn-secondary js-criteria-btn" data-modal-open="modal-form">Filters</button>
@@ -482,7 +520,11 @@
             @endif
         </div>
     </div>
+
 </div>
+@if(request()->query('wl_status'))
+<script>document.getElementById('wl-roll-btn-m')?.addEventListener('click',()=>document.getElementById('wl-roll-btn').click());</script>
+@endif
 
 @if(request()->query('wl_status'))
 <script>

--- a/resources/views/watchlist.blade.php
+++ b/resources/views/watchlist.blade.php
@@ -4,63 +4,69 @@
 @section('content')
 <div class="max-w-7xl mx-auto px-4 py-8 pb-24">
 
-    <div class="mb-6">
-        <h1 class="text-2xl font-bold text-white mb-4">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
+    <div class="mb-4">
+        {{-- Header + filter toggle --}}
+        <div class="flex items-center gap-3 mb-3">
+            <h1 class="text-2xl font-bold text-white flex-1">My Watchlist <span id="wl-count" class="text-gray-500 font-normal text-lg">({{ $items->count() }})</span></h1>
+            @if($items->isNotEmpty())
+            <button id="filter-expand-btn" class="flex-shrink-0 flex items-center gap-1.5 text-sm px-3 py-2 rounded-lg bg-white/5 text-gray-400 hover:text-white transition-colors">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 6h18M7 12h10M11 18h2"/></svg>
+                Filters
+            </button>
+            @endif
+        </div>
+
         @if($items->isNotEmpty())
-            <div class="flex flex-col gap-2">
-
-                {{-- Status + type filters --}}
-                <div class="flex flex-wrap gap-2">
-                    <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-filter="all">All</button>
-                        <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="saved">To Watch</button>
-                        <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="watched">Watched</button>
-                    </div>
-                    <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="type-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-type="all">All</button>
-                        <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="movie">Films</button>
-                        <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="tv">TV</button>
-                    </div>
-                    @if($items->where('source', 'swipe')->isNotEmpty())
-                    <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
-                        <button class="source-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-source="all">All</button>
-                        <button class="source-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-source="swipe">Swipe</button>
-                        <button class="source-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-source="manual">Manual</button>
-                    </div>
-                    @endif
+        {{-- Collapsible filter panel --}}
+        <div id="filter-expand-body" class="hidden flex-col gap-2">
+            <div class="flex flex-wrap gap-2">
+                <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
+                    <button class="watchlist-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-filter="all">All</button>
+                    <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="saved">To Watch</button>
+                    <button class="watchlist-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-filter="watched">Watched</button>
                 </div>
-
-                {{-- Genre selects + sort --}}
-                <div class="flex flex-col sm:flex-row gap-2">
-                    @if($genres->isNotEmpty())
-                        <div class="flex-1">
-                            <select id="genre-select" multiple placeholder="Filter by genre...">
-                                @foreach($genres as $genre)
-                                    <option value="{{ $genre }}">{{ $genre }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="flex-1">
-                            <select id="exclude-genre-select" multiple placeholder="Exclude genre...">
-                                @foreach($genres as $genre)
-                                    <option value="{{ $genre }}">{{ $genre }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                    @endif
-                    <select id="sort-select" class="input-dark text-sm flex-shrink-0 sm:w-44">
-                        <option value="date-desc">Newest Added</option>
-                        <option value="date-asc">Oldest Added</option>
-                        <option value="title-asc">Title A–Z</option>
-                        <option value="title-desc">Title Z–A</option>
-                        <option value="year-desc">Year (Newest)</option>
-                        <option value="year-asc">Year (Oldest)</option>
-                        <option value="rating-desc">Rating (High–Low)</option>
-                        <option value="rating-asc">Rating (Low–High)</option>
-                    </select>
+                <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
+                    <button class="type-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-type="all">All</button>
+                    <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="movie">Films</button>
+                    <button class="type-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-type="tv">TV</button>
                 </div>
-
+                @if($items->where('source', 'swipe')->isNotEmpty())
+                <div class="flex gap-1 bg-white/5 p-1 rounded-lg">
+                    <button class="source-filter active text-xs px-3 py-1.5 rounded-md transition-all text-accent" data-source="all">All</button>
+                    <button class="source-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-source="swipe">Swipe</button>
+                    <button class="source-filter text-xs px-3 py-1.5 rounded-md transition-all text-gray-400" data-source="manual">Manual</button>
+                </div>
+                @endif
             </div>
+            @if($genres->isNotEmpty())
+                <div class="flex flex-col sm:flex-row gap-2">
+                    <div class="flex-1">
+                        <select id="genre-select" multiple placeholder="Filter by genre...">
+                            @foreach($genres as $genre)
+                                <option value="{{ $genre }}">{{ $genre }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="flex-1">
+                        <select id="exclude-genre-select" multiple placeholder="Exclude genre...">
+                            @foreach($genres as $genre)
+                                <option value="{{ $genre }}">{{ $genre }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+            @endif
+            <select id="sort-select" class="input-dark text-sm w-full sm:w-44">
+                <option value="date-desc">Newest Added</option>
+                <option value="date-asc">Oldest Added</option>
+                <option value="title-asc">Title A–Z</option>
+                <option value="title-desc">Title Z–A</option>
+                <option value="year-desc">Year (Newest)</option>
+                <option value="year-asc">Year (Oldest)</option>
+                <option value="rating-desc">Rating (High–Low)</option>
+                <option value="rating-asc">Rating (Low–High)</option>
+            </select>
+        </div>
         @endif
     </div>
 
@@ -126,19 +132,25 @@
                         </div>
                     </a>
 
-                    {{-- Action buttons --}}
+                    {{-- Action buttons (icon-only) --}}
                     <div class="flex gap-1.5 mt-2">
-                        <button class="toggle-watched flex-1 text-xs py-2 rounded-lg transition-all text-center
+                        <button class="toggle-watched flex-1 py-2 rounded-lg transition-all flex items-center justify-center
                             {{ $item->status === 'watched'
                                 ? 'bg-white/10 text-white hover:bg-white/5 hover:text-gray-400'
                                 : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white' }}"
                             data-tmdb-id="{{ $item->tmdb_id }}"
-                            data-status="{{ $item->status }}">
-                            {{ $item->status === 'watched' ? '✓ Watched' : 'Mark watched' }}
+                            data-status="{{ $item->status }}"
+                            title="{{ $item->status === 'watched' ? 'Mark unwatched' : 'Mark watched' }}">
+                            @if($item->status === 'watched')
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg>
+                            @else
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/></svg>
+                            @endif
                         </button>
-                        <button class="remove-from-watchlist text-xs py-2 px-3 rounded-lg bg-white/5 text-gray-500 hover:bg-red-900/30 hover:text-red-400 transition-all"
-                            data-tmdb-id="{{ $item->tmdb_id }}">
-                            Remove
+                        <button class="remove-from-watchlist py-2 px-3 rounded-lg bg-white/5 text-gray-500 hover:bg-red-900/30 hover:text-red-400 transition-all flex items-center justify-center"
+                            data-tmdb-id="{{ $item->tmdb_id }}"
+                            title="Remove">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
                         </button>
                     </div>
 
@@ -151,19 +163,90 @@
 
 {{-- Sticky bar --}}
 @if($items->isNotEmpty())
-<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 px-4 z-40 sticky-bar-safe">
-    <div class="max-w-7xl mx-auto flex items-center justify-between py-1">
+<div class="fixed bottom-0 left-0 right-0 bg-[#0f0f0f]/95 backdrop-blur-lg border-t border-white/10 z-40 sticky-bar-safe">
+
+    {{-- Mobile: 4 equal-width buttons --}}
+    <div class="md:hidden flex px-3 py-2 gap-2">
+        <button id="watchlist-share-m" class="flex-1 flex flex-col items-center justify-center gap-1 py-2 rounded-xl bg-white/5 text-gray-400 hover:text-white transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
+            <span class="text-[10px] font-medium">Share</span>
+        </button>
+        <button id="wl-swipe-btn-m" class="flex-1 flex flex-col items-center justify-center gap-1 py-2 rounded-xl bg-white/5 text-gray-400 hover:text-white transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24"><path d="M7 16l-4-4m0 0l4-4m-4 4h18M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            <span class="text-[10px] font-medium">Swipe</span>
+        </button>
+        <button id="watchlist-collab-m" class="flex-1 flex flex-col items-center justify-center gap-1 py-2 rounded-xl bg-white/5 text-gray-400 hover:text-white transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+            <span class="text-[10px] font-medium">Collab</span>
+        </button>
+        <button id="watchlist-roll-m" class="flex-1 flex flex-col items-center justify-center gap-1 py-2 rounded-xl bg-accent/15 text-accent hover:bg-accent/25 transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24"><path d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+            <span class="text-[10px] font-semibold">Roll</span>
+        </button>
+    </div>
+
+    {{-- Desktop: original layout --}}
+    <div class="hidden md:flex max-w-7xl mx-auto px-4 items-center justify-between py-1">
         <div class="flex-shrink-0">
             <button id="watchlist-share" class="btn-secondary text-sm" title="Share visible list">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13"/></svg>
             </button>
         </div>
         <div class="flex items-center gap-3">
+            <button id="wl-swipe-btn" class="btn-secondary text-sm">Swipe</button>
             <button id="watchlist-collab" class="btn-secondary text-sm">Pick Together</button>
             <button id="watchlist-roll" class="btn-accent px-8">Roll</button>
         </div>
     </div>
+
 </div>
 @endif
+
+{{-- Watchlist Swipe Mode overlay (sits below nav) --}}
+<div id="wl-swipe-overlay" class="hidden fixed top-16 left-0 right-0 bottom-0 z-40 bg-[#0f0f0f] flex flex-col">
+
+    {{-- Counter row --}}
+    <div class="flex-shrink-0 flex items-center justify-between px-4 pt-2 pb-0">
+        <button id="wl-swipe-close" class="p-1.5 text-gray-400 hover:text-white transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
+        </button>
+        <span id="wl-swipe-counter" class="text-xs text-gray-500"></span>
+        <div class="w-8"></div>
+    </div>
+
+    {{-- Card area --}}
+    <div class="flex-1 flex items-center justify-center overflow-hidden min-h-0 px-4 py-2" id="wl-card-area">
+        <div id="wl-overlay-keep" class="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 z-20">
+            <span class="text-5xl font-black text-green-400 border-4 border-green-400 rounded-xl px-5 py-2 rotate-[-12deg]">KEEP</span>
+        </div>
+        <div id="wl-overlay-remove" class="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 z-20">
+            <span class="text-5xl font-black text-red-400 border-4 border-red-400 rounded-xl px-5 py-2 rotate-[12deg]">REMOVE</span>
+        </div>
+        <div id="wl-card-stack" class="relative h-full w-full" style="max-width:min(100%, calc((100vh - 160px) * 2/3))"></div>
+    </div>
+
+    {{-- Action buttons: same layout as swipe page but without criteria/results --}}
+    <div class="flex items-center justify-center gap-6 pt-1 pb-4 flex-shrink-0">
+        <button id="wl-btn-remove" class="w-14 h-14 rounded-full bg-white/10 flex items-center justify-center text-red-400 hover:bg-red-500/20 transition-all active:scale-90">
+            <svg class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+        <button id="wl-btn-undo" class="w-10 h-10 rounded-full bg-white/10 flex items-center justify-center text-gray-500 hover:text-white transition-all active:scale-90" disabled>
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 10h10a8 8 0 018 8v2M3 10l6 6M3 10l6-6"/></svg>
+        </button>
+        <button id="wl-btn-keep" class="w-14 h-14 rounded-full bg-green-500/20 flex items-center justify-center text-green-400 hover:bg-green-500/30 transition-all active:scale-90">
+            <svg class="w-7 h-7" fill="currentColor" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+        </button>
+    </div>
+
+    {{-- Done screen --}}
+    <div id="wl-swipe-done" class="hidden absolute inset-0 flex flex-col items-center justify-center gap-5 bg-[#0f0f0f] z-30 px-6 text-center">
+        <div id="wl-done-confetti" class="absolute inset-0 pointer-events-none overflow-hidden"></div>
+        <div id="wl-done-icon" class="text-8xl select-none">🎉</div>
+        <h2 id="wl-done-title" class="text-3xl font-black text-white"></h2>
+        <p id="wl-done-stats" class="text-gray-400 text-base"></p>
+        <button id="wl-done-close" class="btn-accent px-10 py-3 text-base mt-2">Back to Watchlist</button>
+    </div>
+
+</div>
 
 @endsection

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ import inject from '@rollup/plugin-inject';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
+    optimizeDeps: {
+        exclude: ['jquery-flexdatalist'],
+    },
     plugins: [
         tailwindcss(),
         laravel({


### PR DESCRIPTION
## Summary

- **Watchlist page**: collapsible filters, icon-only card buttons, 4-button mobile sticky bar, swipe mode (left = remove, right = keep) with undo, counter, and confetti end screen
- **Sticky bars**: standardised to icon+label `btn-nav-tab` style on mobile across movie, TV show, batch, and criteria pages
- **Mobile nav**: Watchlist/My Roulettes above Admin, Debug mode at the bottom, Roulettes as a standalone link instead of buried in Movies/TV sections
- **Person page**: roll buttons moved under the photo in the left column; text info flows cleanly on the right; removes the floating photo strip that caused empty gaps on mobile
- **Bug fix**: `jQuery is not defined` from flexdatalist in Vite dev mode

## Test plan

- [x] Watchlist swipe mode — swipe left removes, swipe right keeps, undo restores, end screen shows after last card
- [x] Watchlist mobile sticky bar — all 4 buttons work (Share, Swipe, Collab, Roll)
- [x] Watchlist filter toggle — Filters button expands/collapses all filter controls
- [x] Sticky bars on movie/TV/batch/criteria pages — icon+label buttons on mobile, text buttons on desktop
- [x] Mobile nav — Roulettes link works, account section order correct
- [x] Person page — roll buttons appear under photo, no empty gap between header and filmography
- [x] Criteria form actor/director autocomplete — no jQuery console error