### PR TITLE
Add Swipe entry point to roulette cards

### DIFF
--- a/app/Http/Controllers/SwipeController.php
+++ b/app/Http/Controllers/SwipeController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Roulette;
 use App\Services\MovieService;
+use App\Services\RouletteTagMapper;
 use App\Services\TmdbClient;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -19,7 +22,7 @@ class SwipeController extends Controller
 
     public function index(Request $request, MovieService $movieService, TmdbClient $tmdb): View
     {
-        $country   = $movieService->getUserCountry();
+        $country    = $movieService->getUserCountry();
         $forceReset = $request->boolean('reset');
         $criteria   = $movieService->resolveSessionCriteria(self::DEFAULTS, $forceReset);
         $all_genres     = $movieService->genres($tmdb);
@@ -45,6 +48,26 @@ class SwipeController extends Controller
             'providersArray' => $providersArray,
             'user_input'     => $user_input,
         ]);
+    }
+
+    public function fromRoulette(string $slug, MovieService $movieService): RedirectResponse
+    {
+        $roulette = Roulette::where('slug', $slug)
+            ->where(fn($q) => $q->where('is_public', true)->orWhere('user_id', auth()->id()))
+            ->firstOrFail();
+
+        $mapper = new RouletteTagMapper();
+        $base   = $roulette->media_type === 'tv'
+            ? $mapper->toCriteriaTv($roulette->tags)
+            : $mapper->toCriteriaMovie($roulette->tags);
+
+        $sessionCriteria = [];
+        foreach ($base as $key => $value) {
+            $sessionCriteria[str_replace('.', '_', $key)] = $value;
+        }
+        session(['userInput' => $sessionCriteria]);
+
+        return redirect()->route('swipe');
     }
 
     public function load(Request $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -44,6 +44,7 @@
                     </div>
                 </a>
                 <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
+                <a href="/swipe/roulette/{{ $roulette->slug }}" class="w-full btn-secondary text-xs py-1.5 mt-1 block text-center">Swipe</a>
                 </div>
 
             @endforeach

--- a/resources/views/roulettes.blade.php
+++ b/resources/views/roulettes.blade.php
@@ -18,6 +18,7 @@
 
     @include('includes.roulette-labels')
 
+
     {{-- Movies panel --}}
     <div id="roulette-panel-movies">
         @include('includes.roulette-grid', ['grouped' => $movieGrouped])

--- a/routes/web.php
+++ b/routes/web.php
@@ -107,6 +107,7 @@ Route::prefix('batch/collab/{token}')->group(function () {
 
 // ── Swipe ─────────────────────────────────────────────────────────────
 Route::get('/swipe', [SwipeController::class, 'index'])->name('swipe');
+Route::get('/swipe/roulette/{slug}', [SwipeController::class, 'fromRoulette'])->name('swipe.roulette');
 Route::post('/swipe/next', [SwipeController::class, 'next'])->name('swipe.next');
 Route::post('/swipe/load', [SwipeController::class, 'load'])->name('swipe.load');
 


### PR DESCRIPTION
## Summary
- Each roulette card now has a **Swipe** button below Roll that navigates to `/swipe/roulette/{slug}`
- `SwipeController::fromRoulette()` looks up the roulette, converts its tags to TMDB criteria via `RouletteTagMapper`, seeds the swipe session, and redirects to `/swipe`
- Swipe page loads pre-filtered to that roulette's criteria (genre, platform, era, etc.)

## Test plan
- [x] Visit `/roulettes`, confirm each card has Roll + Swipe buttons
- [x] Click Swipe on a roulette card, confirm swipe page loads with matching criteria
- [x] Confirm Roll button still works as before
- [x] Test with platform roulettes (Netflix, HBO etc.) and genre/decade roulettes