### PR TITLE
TV swipe, roulette swipe buttons, homepage hero cleanup

### DIFF
--- a/app/Http/Controllers/SwipeController.php
+++ b/app/Http/Controllers/SwipeController.php
@@ -20,6 +20,15 @@ class SwipeController extends Controller
         'vote_count_gte'           => 50,
     ];
 
+    private const TV_DEFAULTS = [
+        'with_original_language' => 'en',
+        'first_air_date_gte'     => 2000,
+        'vote_average_gte'       => 6,
+        'vote_count_gte'         => 20,
+    ];
+
+    // ── Movies ────────────────────────────────────────────────────────
+
     public function index(Request $request, MovieService $movieService, TmdbClient $tmdb): View
     {
         $country    = $movieService->getUserCountry();
@@ -30,12 +39,14 @@ class SwipeController extends Controller
         $user_input     = session('userInput', 'default');
         $page           = $movieService->resolvePage($tmdb, $criteria, $country);
         $results        = $tmdb->discover(array_merge($criteria, ['page' => $page]), $country);
-        $movies         = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $all_genres, $page);
+        $movies         = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $all_genres, $page, 'movie');
         $totalResults   = $results['total_results'] ?? 0;
 
         $watchlistIds = auth()->check()
             ? auth()->user()->watchlist()->pluck('tmdb_id')->all()
             : [];
+
+        $freshStart = session()->pull('swipe_fresh', false);
 
         return view('swipe', [
             'movies'         => $movies,
@@ -47,6 +58,7 @@ class SwipeController extends Controller
             'all_genres'     => $all_genres,
             'providersArray' => $providersArray,
             'user_input'     => $user_input,
+            'freshStart'     => $freshStart,
         ]);
     }
 
@@ -65,7 +77,7 @@ class SwipeController extends Controller
         foreach ($base as $key => $value) {
             $sessionCriteria[str_replace('.', '_', $key)] = $value;
         }
-        session(['userInput' => $sessionCriteria]);
+        session(['userInput' => $sessionCriteria, 'swipe_fresh' => true]);
 
         return redirect()->route('swipe');
     }
@@ -74,20 +86,19 @@ class SwipeController extends Controller
     {
         $country = $movieService->getUserCountry();
 
-        // Build criteria from the full criteria form fields
         $input = array_filter([
-            'with_genres'                => $request->input('with_genres'),
-            'without_genres'             => $request->input('without_genres'),
-            'with_watch_providers'       => $request->input('with_watch_providers'),
-            'primary_release_date_gte'   => $request->input('primary_release_date_gte'),
-            'primary_release_date_lte'   => $request->input('primary_release_date_lte'),
-            'vote_average_gte'           => $request->input('vote_average_gte'),
-            'vote_average_lte'           => $request->input('vote_average_lte'),
-            'vote_count_gte'             => $request->input('vote_count_gte'),
-            'with_original_language'     => $request->input('with_original_language'),
-            'with_origin_country'        => $request->input('with_origin_country'),
-            'with_cast'                  => $request->input('with_cast'),
-            'with_crew'                  => $request->input('with_crew'),
+            'with_genres'              => $request->input('with_genres'),
+            'without_genres'           => $request->input('without_genres'),
+            'with_watch_providers'     => $request->input('with_watch_providers'),
+            'primary_release_date_gte' => $request->input('primary_release_date_gte'),
+            'primary_release_date_lte' => $request->input('primary_release_date_lte'),
+            'vote_average_gte'         => $request->input('vote_average_gte'),
+            'vote_average_lte'         => $request->input('vote_average_lte'),
+            'vote_count_gte'           => $request->input('vote_count_gte'),
+            'with_original_language'   => $request->input('with_original_language'),
+            'with_origin_country'      => $request->input('with_origin_country'),
+            'with_cast'                => $request->input('with_cast'),
+            'with_crew'                => $request->input('with_crew'),
         ], fn($v) => !empty($v));
 
         session(['userInput' => $input]);
@@ -95,33 +106,135 @@ class SwipeController extends Controller
         $genres  = $movieService->genres($tmdb);
         $page    = $movieService->resolvePage($tmdb, $input, $country);
         $results = $tmdb->discover(array_merge($input, ['page' => $page]), $country);
-        $movies  = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $genres, $page);
+        $movies  = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $genres, $page, 'movie');
 
         return response()->json(['movies' => $movies, 'page' => $page, 'total_results' => $results['total_results'] ?? 0]);
     }
 
     public function next(Request $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
     {
-        $country   = $movieService->getUserCountry();
-        $criteria  = $movieService->resolveSessionCriteria([], false);
-        $seenPages = array_map('intval', $request->input('seen_pages', []));
+        $country    = $movieService->getUserCountry();
+        $criteria   = $movieService->resolveSessionCriteria([], false);
+        $seenPages  = array_map('intval', $request->input('seen_pages', []));
         $totalPages = session('userInput.total_pages', 500);
-        $genres  = $movieService->genres($tmdb);
-        $page    = $this->pickPage((int) $totalPages, $seenPages);
-        $results = $tmdb->discover(array_merge($criteria, ['page' => $page]), $country);
-        $movies  = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $genres, $page);
+        $genres     = $movieService->genres($tmdb);
+        $page       = $this->pickPage((int) $totalPages, $seenPages);
+        $results    = $tmdb->discover(array_merge($criteria, ['page' => $page]), $country);
+        $movies     = $this->attachGenres($movieService->pickBatch($results['results'] ?? []), $genres, $page, 'movie');
 
         return response()->json(['movies' => $movies, 'page' => $page]);
     }
 
-    private function attachGenres(array $movies, array $allGenres, int $page = 0): array
+    // ── TV Shows ──────────────────────────────────────────────────────
+
+    public function tvIndex(Request $request, MovieService $movieService, TmdbClient $tmdb): View
+    {
+        $country    = $movieService->getUserCountry();
+        $forceReset = $request->boolean('reset');
+        $criteria   = $movieService->resolveSessionCriteria(self::TV_DEFAULTS, $forceReset, 'tvInput');
+        $all_genres     = $movieService->genres($tmdb, 'tv');
+        $providersArray = $movieService->buildProvidersArray($tmdb);
+        $user_input     = session('tvInput', 'default');
+        $page           = $movieService->resolvePage($tmdb, $criteria, $country, 'tv');
+        $results        = $tmdb->discoverTv(array_merge($criteria, ['page' => $page]), $country);
+        $shows          = $movieService->normaliseShows($results['results'] ?? []);
+        $movies         = $this->attachGenres($movieService->pickBatch($shows), $all_genres, $page, 'tv');
+        $totalResults   = $results['total_results'] ?? 0;
+
+        $watchlistIds = auth()->check()
+            ? auth()->user()->watchlist()->where('type', 'tv')->pluck('tmdb_id')->all()
+            : [];
+
+        $freshStart = session()->pull('swipe_fresh', false);
+
+        return view('swipe-tv', [
+            'movies'         => $movies,
+            'initialPage'    => $page,
+            'totalResults'   => $totalResults,
+            'isLoggedIn'     => auth()->check(),
+            'isAdmin'        => auth()->check() && auth()->user()->email === config('api.admin_email'),
+            'watchlistIds'   => $watchlistIds,
+            'all_genres'     => $all_genres,
+            'providersArray' => $providersArray,
+            'user_input'     => $user_input,
+            'freshStart'     => $freshStart,
+        ]);
+    }
+
+    public function tvFromRoulette(string $slug, MovieService $movieService): RedirectResponse
+    {
+        $roulette = Roulette::where('slug', $slug)
+            ->where(fn($q) => $q->where('is_public', true)->orWhere('user_id', auth()->id()))
+            ->firstOrFail();
+
+        $mapper = new RouletteTagMapper();
+        $base   = $mapper->toCriteriaTv($roulette->tags);
+
+        $sessionCriteria = [];
+        foreach ($base as $key => $value) {
+            $sessionCriteria[str_replace('.', '_', $key)] = $value;
+        }
+        session(['tvInput' => $sessionCriteria, 'swipe_fresh' => true]);
+
+        return redirect()->route('swipe.tv');
+    }
+
+    public function tvLoad(Request $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country = $movieService->getUserCountry();
+
+        $input = array_filter([
+            'with_genres'            => $request->input('with_genres'),
+            'without_genres'         => $request->input('without_genres'),
+            'with_watch_providers'   => $request->input('with_watch_providers'),
+            'first_air_date_gte'     => $request->input('first_air_date_gte'),
+            'first_air_date_lte'     => $request->input('first_air_date_lte'),
+            'vote_average_gte'       => $request->input('vote_average_gte'),
+            'vote_average_lte'       => $request->input('vote_average_lte'),
+            'vote_count_gte'         => $request->input('vote_count_gte'),
+            'with_original_language' => $request->input('with_original_language'),
+            'with_origin_country'    => $request->input('with_origin_country'),
+            'with_cast'              => $request->input('with_cast'),
+            'with_crew'              => $request->input('with_crew'),
+        ], fn($v) => !empty($v));
+
+        session(['tvInput' => $input]);
+
+        $genres  = $movieService->genres($tmdb, 'tv');
+        $page    = $movieService->resolvePage($tmdb, $input, $country, 'tv');
+        $results = $tmdb->discoverTv(array_merge($input, ['page' => $page]), $country);
+        $shows   = $movieService->normaliseShows($results['results'] ?? []);
+        $movies  = $this->attachGenres($movieService->pickBatch($shows), $genres, $page, 'tv');
+
+        return response()->json(['movies' => $movies, 'page' => $page, 'total_results' => $results['total_results'] ?? 0]);
+    }
+
+    public function tvNext(Request $request, MovieService $movieService, TmdbClient $tmdb): JsonResponse
+    {
+        $country    = $movieService->getUserCountry();
+        $criteria   = $movieService->resolveSessionCriteria([], false, 'tvInput');
+        $seenPages  = array_map('intval', $request->input('seen_pages', []));
+        $totalPages = session('tvInput.total_pages', 500);
+        $genres     = $movieService->genres($tmdb, 'tv');
+        $page       = $this->pickPage((int) $totalPages, $seenPages);
+        $results    = $tmdb->discoverTv(array_merge($criteria, ['page' => $page]), $country);
+        $shows      = $movieService->normaliseShows($results['results'] ?? []);
+        $movies     = $this->attachGenres($movieService->pickBatch($shows), $genres, $page, 'tv');
+
+        return response()->json(['movies' => $movies, 'page' => $page]);
+    }
+
+    // ── Shared helpers ────────────────────────────────────────────────
+
+    private function attachGenres(array $movies, array $allGenres, int $page = 0, string $mediaType = 'movie'): array
     {
         $idToName = collect($allGenres)->pluck('name', 'id')->all();
-        return array_map(function ($movie, $i) use ($idToName, $page) {
+        return array_map(function ($movie, $i) use ($idToName, $page, $mediaType) {
             $names = array_filter(array_map(fn($id) => $idToName[$id] ?? null, $movie['genre_ids'] ?? []));
-            $movie['genres']    = implode(', ', $names);
-            $movie['_page']     = $page;
-            $movie['_pos']      = $i + 1;
+            $movie['genres']     = implode(', ', $names);
+            $movie['media_type'] = $mediaType;
+            $movie['_page']      = $page;
+            $movie['_pos']       = $i + 1;
             return $movie;
         }, $movies, array_keys($movies));
     }

--- a/resources/js/custom/swipe.js
+++ b/resources/js/custom/swipe.js
@@ -10,6 +10,9 @@ if (new URLSearchParams(window.location.search).get('reset') === '1') {
     sessionStorage.removeItem(SESSION_KEY);
     localStorage.removeItem('swipe_liked');
 }
+if (window.swipeFresh) {
+    sessionStorage.removeItem(SESSION_KEY);
+}
 
 const saved    = JSON.parse(sessionStorage.getItem(SESSION_KEY) || 'null');
 let queue      = saved?.queue?.length ? saved.queue : [...window.swipeMovies];
@@ -341,7 +344,7 @@ function saveLike(movie) {
 // ── Prefetch ──────────────────────────────────────────────────────────
 function prefetch() {
     fetching = true;
-    fetch('/swipe/next', {
+    fetch(window.swipeNextUrl || '/swipe/next', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').content },
         body: JSON.stringify({ seen_pages: seenPages }),
@@ -441,7 +444,7 @@ document.getElementById('results-end').addEventListener('click', () => {
 const swipeCriteriaForm = document.getElementById('modal-criteria');
 if (swipeCriteriaForm) {
     // Change action so roulettes.js doesn't trigger case-opening animation
-    swipeCriteriaForm.action = '/swipe/load';
+    swipeCriteriaForm.action = window.swipeLoadUrl || '/swipe/load';
 
     // Replace footer buttons with single Load button
     const modalFooter = swipeCriteriaForm.querySelector('.modal-sticky-footer');
@@ -470,7 +473,7 @@ document.addEventListener('submit', async (e) => {
     const data = new FormData(form);
 
     try {
-        const res  = await fetch('/swipe/load', { method: 'POST', body: data });
+        const res  = await fetch(window.swipeLoadUrl || '/swipe/load', { method: 'POST', body: data });
         const json = await res.json();
         if (json.movies?.length) {
             queue        = [...json.movies];

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -62,10 +62,7 @@
                         <span class="font-semibold text-white">Movies</span>
                     </div>
                     <a href="/movie?i=new" class="btn-accent long-single text-center">Random Movie</a>
-                    <div class="flex gap-2">
-                        <a href="/multiple?i=new" class="btn-secondary long-single text-center text-sm flex-1">Batch</a>
-                        <a href="/criteria" class="btn-secondary text-center text-sm flex-1">Filters</a>
-                    </div>
+                    <a href="/swipe?reset=1" class="text-sm font-semibold text-white bg-accent/20 border border-accent/50 rounded-lg py-2 text-center hover:bg-accent/30 transition-all shadow-[0_0_14px_rgba(192,57,58,0.35)] hover:shadow-[0_0_22px_rgba(192,57,58,0.55)]">Swipe →</a>
                 </div>
                 {{-- TV Shows card --}}
                 <div class="bg-white/5 border border-white/8 rounded-2xl p-4 sm:p-6 flex flex-col gap-3 sm:gap-4 hover:bg-white/7 hover:border-white/15 transition-all duration-200 hover:shadow-[0_0_28px_rgba(192,57,58,0.12)]">
@@ -79,27 +76,9 @@
                         <span class="font-semibold text-white">TV Shows</span>
                     </div>
                     <a href="/tv/pick?i=new" class="btn-accent long-single text-center">Random TV Show</a>
-                    <div class="flex gap-2">
-                        <a href="/tv/multiple?i=new" class="btn-secondary long-single text-center text-sm flex-1">Batch</a>
-                        <a href="/tv/criteria" class="btn-secondary text-center text-sm flex-1">Filters</a>
-                    </div>
+                    <a href="/swipe/tv?reset=1" class="text-sm font-semibold text-white bg-accent/20 border border-accent/50 rounded-lg py-2 text-center hover:bg-accent/30 transition-all shadow-[0_0_14px_rgba(192,57,58,0.35)] hover:shadow-[0_0_22px_rgba(192,57,58,0.55)]">Swipe →</a>
                 </div>
             </div>
-
-            {{-- Movie Swipe featured card --}}
-            <a href="/swipe?reset=1" class="group mt-4 block bg-gradient-to-r from-accent/20 to-accent/5 border border-accent/20 hover:border-accent/40 rounded-2xl p-5 transition-all duration-200 hover:shadow-[0_0_32px_rgba(192,57,58,0.2)]">
-                <div class="flex items-center justify-between">
-                    <div>
-                        <div class="flex items-center gap-2.5 mb-1.5">
-                            <span class="text-2xl">🎬</span>
-                            <span class="font-bold text-white text-lg">Movie Swipe</span>
-                            <span class="text-xs bg-accent/30 text-accent px-2 py-0.5 rounded-full font-medium">New</span>
-                        </div>
-                        <p class="text-sm text-gray-400">Swipe through movies one by one. Like what you want to watch, skip the rest.</p>
-                    </div>
-                    <svg class="w-5 h-5 text-accent/60 flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
-                </div>
-            </a>
         </div>
     </section>
 

--- a/resources/views/includes/criteria-modal.blade.php
+++ b/resources/views/includes/criteria-modal.blade.php
@@ -1,6 +1,12 @@
 @php
+    $modalMediaType = $modalMediaType ?? 'movie';
+    $isTvModal      = $modalMediaType === 'tv';
+    $yearGteField   = $isTvModal ? 'first_air_date_gte'   : 'primary_release_date_gte';
+    $yearLteField   = $isTvModal ? 'first_air_date_lte'   : 'primary_release_date_lte';
+    $yearLabel      = $isTvModal ? 'First Air Date'        : 'Release Year';
+
     if ($user_input === 'default') $user_input = [];
-    $openYear     = !empty($user_input['primary_release_date_gte'] ?? '') || !empty($user_input['primary_release_date_lte'] ?? '');
+    $openYear     = !empty($user_input[$yearGteField] ?? '') || !empty($user_input[$yearLteField] ?? '');
     $openGenres   = !empty($user_input['with_genres'] ?? []) || !empty($user_input['without_genres'] ?? []);
     $openLanguage  = !empty($user_input['with_original_language'] ?? '') || !empty($user_input['with_origin_country'] ?? '');
     $openStreaming  = !empty($user_input['with_watch_providers'] ?? []);
@@ -26,18 +32,18 @@
                 {{-- Years --}}
                 <div class="accordion-section border-t border-white/5 {{ $openYear ? 'accordion-open' : '' }}">
                     <button type="button" class="accordion-header w-full flex items-center justify-between py-2.5 sm:py-3.5 text-left">
-                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Release Year</h3>
+                        <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">{{ $yearLabel }}</h3>
                         <svg class="accordion-chevron w-4 h-4 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7"/></svg>
                     </button>
                     <div class="accordion-body">
                         <div class="pb-4 grid grid-cols-2 gap-3">
                             <div>
                                 <label class="block text-sm text-gray-400 mb-1">From</label>
-                                <input type="text" class="input-dark" name="primary_release_date_gte" placeholder="1874" value="{{ $user_input['primary_release_date_gte'] ?? '' }}">
+                                <input type="text" class="input-dark" name="{{ $yearGteField }}" placeholder="1874" value="{{ $user_input[$yearGteField] ?? '' }}">
                             </div>
                             <div>
                                 <label class="block text-sm text-gray-400 mb-1">To</label>
-                                <input type="text" class="input-dark" name="primary_release_date_lte" placeholder="{{ date('Y') }}" value="{{ $user_input['primary_release_date_lte'] ?? '' }}">
+                                <input type="text" class="input-dark" name="{{ $yearLteField }}" placeholder="{{ date('Y') }}" value="{{ $user_input[$yearLteField] ?? '' }}">
                             </div>
                         </div>
                     </div>

--- a/resources/views/includes/roulette-grid.blade.php
+++ b/resources/views/includes/roulette-grid.blade.php
@@ -44,7 +44,7 @@
                     </div>
                 </a>
                 <button class="w-full btn-accent text-xs py-1.5 mt-2" data-roulette-roll data-slug="{{ $roulette->slug }}">Roll</button>
-                <a href="/swipe/roulette/{{ $roulette->slug }}" class="w-full btn-secondary text-xs py-1.5 mt-1 block text-center">Swipe</a>
+                <a href="/swipe/{{ $roulette->media_type === 'tv' ? 'tv/' : '' }}roulette/{{ $roulette->slug }}" class="w-full btn-secondary text-xs py-1.5 mt-1 block text-center">Swipe</a>
                 </div>
 
             @endforeach

--- a/resources/views/roulettes.blade.php
+++ b/resources/views/roulettes.blade.php
@@ -26,6 +26,16 @@
 
     {{-- TV Shows panel --}}
     <div id="roulette-panel-tv" class="hidden">
+        <a href="/swipe/tv?reset=1" class="group flex items-center justify-between bg-gradient-to-r from-accent/20 to-accent/5 border border-accent/20 hover:border-accent/40 rounded-2xl p-4 mb-8 transition-all duration-200 hover:shadow-[0_0_32px_rgba(192,57,58,0.2)]">
+            <div>
+                <div class="flex items-center gap-2 mb-1">
+                    <span class="text-xl">📺</span>
+                    <span class="font-bold text-white">TV Show Swipe</span>
+                </div>
+                <p class="text-xs text-gray-400">Swipe through TV shows one by one. Like what you want to watch, skip the rest.</p>
+            </div>
+            <svg class="w-5 h-5 text-accent/60 flex-shrink-0 ml-4 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9 18l6-6-6-6"/></svg>
+        </a>
         @include('includes.roulette-grid', ['grouped' => $tvGrouped])
     </div>
 

--- a/resources/views/swipe-tv.blade.php
+++ b/resources/views/swipe-tv.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.app')
-@section('page_title', 'Movie Swipe — MoviePickr')
+@section('page_title', 'TV Show Swipe — MoviePickr')
 @section('scripts')
     @vite(['resources/js/custom/criteriaForm.js', 'resources/js/custom/swipe.js'])
 @endsection
@@ -16,7 +16,6 @@
         <div id="overlay-skip" class="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 z-20">
             <span class="text-5xl font-black text-red-400 border-4 border-red-400 rounded-xl px-5 py-2 rotate-[12deg]">SKIP</span>
         </div>
-        {{-- aspect-[2/3] keeps poster ratio, h-full fills available height, w-auto derives width --}}
         <div id="card-stack" class="relative h-full w-full" style="max-width:min(100%, calc((100vh - 160px) * 2/3))"></div>
     </div>
 
@@ -47,24 +46,21 @@
     </div>
 </div>
 
-{{-- Full criteria modal (action overridden by JS) --}}
-@include('includes.criteria-modal')
+{{-- Full criteria modal --}}
+@include('includes.criteria-modal', ['modalMediaType' => 'tv'])
 
 {{-- Results overlay --}}
 <div id="results-overlay" class="hidden fixed inset-0 z-50 bg-[#0f0f0f] flex flex-col">
-    {{-- Sticky header --}}
     <div class="flex-shrink-0 bg-[#0f0f0f]/95 backdrop-blur-sm flex items-center justify-between px-4 pt-4 pb-3 border-b border-white/10">
         <button id="results-close" class="text-gray-400 hover:text-white transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 12H5M12 5l-7 7 7 7"/></svg>
         </button>
-        <h2 class="text-base font-bold text-white">Movies you liked</h2>
+        <h2 class="text-base font-bold text-white">Shows you liked</h2>
         <div class="w-8"></div>
     </div>
-    {{-- Scrollable grid --}}
     <div class="flex-1 overflow-y-auto min-h-0">
         <div id="results-grid" class="p-4 grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-3"></div>
     </div>
-    {{-- Sticky footer --}}
     <div class="flex-shrink-0 p-4 flex gap-3 border-t border-white/10 bg-[#0f0f0f]">
         <button id="results-continue" class="btn-accent flex-1 py-3">Keep Swiping</button>
         <button id="results-end" class="flex-1 py-3 rounded-xl font-semibold text-sm bg-red-600/20 text-red-400 hover:bg-red-600/30 transition-colors">End Session</button>
@@ -72,11 +68,13 @@
 </div>
 
 <script>
-window.swipeMovies      = @json($movies);
-window.swipePage        = {{ $initialPage }};
-window.swipeLoggedIn    = {{ $isLoggedIn ? 'true' : 'false' }};
+window.swipeMovies       = @json($movies);
+window.swipePage         = {{ $initialPage }};
+window.swipeLoggedIn     = {{ $isLoggedIn ? 'true' : 'false' }};
 window.swipeTotalResults = {{ $totalResults }};
 window.swipeWatchlistIds = @json($watchlistIds);
-window.swipeFresh       = {{ $freshStart ? 'true' : 'false' }};
+window.swipeNextUrl      = '/swipe/tv/next';
+window.swipeLoadUrl      = '/swipe/tv/load';
+window.swipeFresh        = {{ $freshStart ? 'true' : 'false' }};
 </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -110,6 +110,10 @@ Route::get('/swipe', [SwipeController::class, 'index'])->name('swipe');
 Route::get('/swipe/roulette/{slug}', [SwipeController::class, 'fromRoulette'])->name('swipe.roulette');
 Route::post('/swipe/next', [SwipeController::class, 'next'])->name('swipe.next');
 Route::post('/swipe/load', [SwipeController::class, 'load'])->name('swipe.load');
+Route::get('/swipe/tv', [SwipeController::class, 'tvIndex'])->name('swipe.tv');
+Route::get('/swipe/tv/roulette/{slug}', [SwipeController::class, 'tvFromRoulette'])->name('swipe.tv.roulette');
+Route::post('/swipe/tv/next', [SwipeController::class, 'tvNext'])->name('swipe.tv.next');
+Route::post('/swipe/tv/load', [SwipeController::class, 'tvLoad'])->name('swipe.tv.load');
 
 // ── Watchlist (auth required) ─────────────────────────────────────────────────
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## What's in this PR

- **TV swipe page** at `/swipe/tv` — mirrors movie swipe but uses TV shows, TV genres, and `first_air_date` fields. Reuses `swipe.js` via `window.swipeNextUrl` / `window.swipeLoadUrl`.
- **Roulette swipe entry** — each roulette card now has a Swipe button that navigates to `/swipe/roulette/{slug}` or `/swipe/tv/roulette/{slug}`, prefilling criteria from the roulette's tags.
- **Queue reset on roulette entry** — fixed a bug where the old sessionStorage queue persisted after entering swipe from a roulette. Server sets a `swipe_fresh` session flag; JS clears the cached queue on load.
- **TV swipe featured card** added at the top of the TV roulettes panel.
- **Homepage hero simplified** — removed Batch and Filters buttons from hero cards, replaced with a glowing Swipe button. Reduces mobile clutter and promotes swipe as a featured mode.