### PR TITLE
Admin traffic analytics: bot detection, page flow tracking, and visitor insights

### DIFF
--- a/app/Console/Commands/PruneAnalyticsData.php
+++ b/app/Console/Commands/PruneAnalyticsData.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PageView;
+use App\Models\TmdbRequestLog;
+use Illuminate\Console\Command;
+
+class PruneAnalyticsData extends Command
+{
+    protected $signature   = 'analytics:prune';
+    protected $description = 'Delete page_views and tmdb_request_logs older than 30 days';
+
+    public function handle(): void
+    {
+        $cutoff = now()->subDays(30);
+
+        $pageViews = PageView::where('created_at', '<', $cutoff)->delete();
+        $this->info("Deleted {$pageViews} page_views older than 30 days.");
+
+        $tmdbLogs = TmdbRequestLog::where('created_at', '<', $cutoff)->delete();
+        $this->info("Deleted {$tmdbLogs} tmdb_request_logs older than 30 days.");
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         $schedule->command('collab:cleanup')->daily();
+        $schedule->command('analytics:prune')->dailyAt('03:00');
     }
 
     protected function commands(): void

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -32,8 +32,12 @@ class AdminController extends Controller
                 SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) as hits,
                 AVG(CASE WHEN cached = 0 THEN response_time_ms ELSE NULL END) as avg_ms,
                 SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END) as rate_limited,
+                SUM(CASE WHEN bot IS NULL THEN 1 ELSE 0 END) as human_total,
+                SUM(CASE WHEN bot IS NULL AND cached = 0 THEN 1 ELSE 0 END) as human_live,
+                SUM(CASE WHEN bot IS NULL AND cached = 1 THEN 1 ELSE 0 END) as human_hits,
+                AVG(CASE WHEN bot IS NULL AND cached = 0 THEN response_time_ms ELSE NULL END) as human_avg_ms,
                 COUNT(DISTINCT user_id) as unique_auth,
-                COUNT(DISTINCT CASE WHEN user_id IS NULL THEN visitor_hash END) as unique_anon,
+                COUNT(DISTINCT CASE WHEN user_id IS NULL AND bot IS NULL THEN visitor_hash END) as unique_anon,
                 SUM(CASE WHEN bot IS NOT NULL THEN 1 ELSE 0 END) as bot_total
             ')->whereDate('created_at', $today)->first();
 
@@ -41,6 +45,13 @@ class AdminController extends Controller
                 ->whereDate('created_at', $today)
                 ->whereNotNull('bot')
                 ->groupBy('bot')
+                ->orderByDesc('total')
+                ->get();
+
+            $tmdb['by_endpoint_bots'] = TmdbRequestLog::selectRaw('endpoint, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNotNull('bot')
+                ->groupBy('endpoint')
                 ->orderByDesc('total')
                 ->get();
 
@@ -87,12 +98,19 @@ class AdminController extends Controller
                 COUNT(*) as total,
                 SUM(CASE WHEN cached = 0 THEN 1 ELSE 0 END) as live,
                 SUM(CASE WHEN cached = 1 THEN 1 ELSE 0 END) as hits,
+                SUM(CASE WHEN bot IS NULL THEN 1 ELSE 0 END) as human_total,
+                SUM(CASE WHEN bot IS NOT NULL THEN 1 ELSE 0 END) as bot_count,
                 COUNT(DISTINCT user_id) as unique_auth,
-                COUNT(DISTINCT CASE WHEN user_id IS NULL THEN visitor_hash END) as unique_anon
+                COUNT(DISTINCT CASE WHEN user_id IS NULL AND bot IS NULL THEN visitor_hash END) as unique_anon
             ')->where('created_at', '>=', $sevenDays)
               ->groupByRaw('DATE(created_at)')
               ->orderByDesc('date')
               ->get();
+
+            $rpm = 1.50;
+            $tmdb['rpm']           = $rpm;
+            $tmdb['revenue_today'] = round((($tmdb['today']->human_total ?? 0) / 1000) * $rpm, 2);
+            $tmdb['revenue_week']  = round(($tmdb['daily']->sum('human_total') / 1000) * $rpm, 2);
 
             $topAuth = TmdbRequestLog::selectRaw('user_id, COUNT(*) as total')
                 ->whereDate('created_at', $today)

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -19,10 +19,10 @@ class AdminController extends Controller
         ];
 
         $rowOrder   = Setting::get('roulette_row_order', []);
-        $activeTab  = request('tab', 'overview');
+        $activeTab  = request('tab', 'roulettes');
         $tmdb       = [];
 
-        if ($activeTab === 'tmdb') {
+        if (in_array($activeTab, ['tmdb', 'traffic'])) {
             $today     = now()->toDateString();
             $sevenDays = now()->subDays(6)->startOfDay();
 

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -123,23 +123,28 @@ class AdminController extends Controller
                 ->with('user')
                 ->get()
                 ->map(fn($r) => (object)[
-                    'label' => $r->user?->name ?? "User #{$r->user_id}",
-                    'type'  => 'auth',
-                    'total' => $r->total,
+                    'label'   => $r->user?->name ?? "User #{$r->user_id}",
+                    'type'    => 'auth',
+                    'total'   => $r->total,
+                    'user_id' => $r->user_id,
+                    'hash'    => null,
                 ]);
 
             $topAnon = TmdbRequestLog::selectRaw('visitor_hash, COUNT(*) as total')
                 ->whereDate('created_at', $today)
                 ->whereNull('user_id')
+                ->whereNull('bot')
                 ->whereNotNull('visitor_hash')
                 ->groupBy('visitor_hash')
                 ->orderByDesc('total')
                 ->limit(10)
                 ->get()
                 ->map(fn($r) => (object)[
-                    'label' => $r->visitor_hash,
-                    'type'  => 'anon',
-                    'total' => $r->total,
+                    'label'   => $r->visitor_hash,
+                    'type'    => 'anon',
+                    'total'   => $r->total,
+                    'user_id' => null,
+                    'hash'    => $r->visitor_hash,
                 ]);
 
             $tmdb['top_users'] = $topAuth->concat($topAnon)->sortByDesc('total')->take(10)->values();

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -175,6 +175,86 @@ class AdminController extends Controller
                 return $row;
             });
 
+            // Active now: unique human visitors in last 10 minutes
+            $tmdb['active_now'] = PageView::whereNull('bot')
+                ->where('created_at', '>=', now()->subMinutes(10))
+                ->distinct('visitor_hash')
+                ->count('visitor_hash');
+
+            // Hourly traffic today (human only) — fill all 24 hours
+            $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNull('bot')
+                ->groupByRaw('HOUR(created_at)')
+                ->get()
+                ->keyBy('hour');
+            $tmdb['hourly'] = collect(range(0, 23))->map(fn($h) => (object)[
+                'hour'  => $h,
+                'total' => $hourlyRows->get($h)?->total ?? 0,
+            ]);
+
+            // Top external referrers today (external = stored as domain, not /path)
+            $tmdb['referrers'] = PageView::selectRaw('referrer, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNull('bot')
+                ->whereNotNull('referrer')
+                ->where('referrer', 'not like', '/%')
+                ->groupBy('referrer')
+                ->orderByDesc('total')
+                ->limit(10)
+                ->get();
+
+            // Bounce rate + avg session length from today's page views
+            $todayViews = PageView::whereDate('created_at', $today)
+                ->whereNull('bot')
+                ->whereNotNull('visitor_hash')
+                ->orderBy('visitor_hash')
+                ->orderBy('created_at')
+                ->get(['visitor_hash', 'created_at']);
+
+            $sessionStats = [];
+            foreach ($todayViews->groupBy('visitor_hash') as $views) {
+                $session = [];
+                foreach ($views->sortBy('created_at') as $view) {
+                    if (empty($session) || $view->created_at->diffInSeconds(end($session)->created_at) <= 1800) {
+                        $session[] = $view;
+                    } else {
+                        $sessionStats[] = ['pages' => count($session), 'secs' => $session[0]->created_at->diffInSeconds(end($session)->created_at)];
+                        $session = [$view];
+                    }
+                }
+                if (!empty($session)) {
+                    $sessionStats[] = ['pages' => count($session), 'secs' => $session[0]->created_at->diffInSeconds(end($session)->created_at)];
+                }
+            }
+            $totalSess = count($sessionStats);
+            $bounced   = count(array_filter($sessionStats, fn($s) => $s['pages'] === 1));
+            $tmdb['bounce_rate']      = $totalSess > 0 ? round(($bounced / $totalSess) * 100) : null;
+            $tmdb['avg_session_secs'] = $totalSess > 0 ? (int) round(array_sum(array_column($sessionStats, 'secs')) / $totalSess) : null;
+
+            // A→B transitions — last 7 days, human, PHP session grouping
+            $recentViews = PageView::where('created_at', '>=', $sevenDays)
+                ->whereNull('bot')
+                ->whereNotNull('visitor_hash')
+                ->orderBy('visitor_hash')
+                ->orderBy('created_at')
+                ->get(['visitor_hash', 'route', 'created_at']);
+
+            $transCounts = [];
+            foreach ($recentViews->groupBy('visitor_hash') as $views) {
+                $sorted = $views->sortBy('created_at')->values();
+                for ($i = 0; $i < $sorted->count() - 1; $i++) {
+                    $curr = $sorted[$i];
+                    $next = $sorted[$i + 1];
+                    if ($next->created_at->diffInSeconds($curr->created_at) <= 1800 && $curr->route !== $next->route) {
+                        $key = $curr->route . ' → ' . $next->route;
+                        $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
+                    }
+                }
+            }
+            arsort($transCounts);
+            $tmdb['transitions'] = array_slice($transCounts, 0, 10, true);
+
             $tmdb['recent'] = TmdbRequestLog::with('user')
                 ->orderByDesc('id')
                 ->paginate(25)

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -232,29 +232,6 @@ class AdminController extends Controller
             $tmdb['bounce_rate']      = $totalSess > 0 ? round(($bounced / $totalSess) * 100) : null;
             $tmdb['avg_session_secs'] = $totalSess > 0 ? (int) round(array_sum(array_column($sessionStats, 'secs')) / $totalSess) : null;
 
-            // A→B transitions — last 7 days, human, PHP session grouping
-            $recentViews = PageView::where('created_at', '>=', $sevenDays)
-                ->whereNull('bot')
-                ->whereNotNull('visitor_hash')
-                ->orderBy('visitor_hash')
-                ->orderBy('created_at')
-                ->get(['visitor_hash', 'route', 'created_at']);
-
-            $transCounts = [];
-            foreach ($recentViews->groupBy('visitor_hash') as $views) {
-                $sorted = $views->sortBy('created_at')->values();
-                for ($i = 0; $i < $sorted->count() - 1; $i++) {
-                    $curr = $sorted[$i];
-                    $next = $sorted[$i + 1];
-                    if ($next->created_at->diffInSeconds($curr->created_at) <= 1800 && $curr->route !== $next->route) {
-                        $key = $curr->route . ' → ' . $next->route;
-                        $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
-                    }
-                }
-            }
-            arsort($transCounts);
-            $tmdb['transitions'] = array_slice($transCounts, 0, 10, true);
-
             $tmdb['recent'] = TmdbRequestLog::with('user')
                 ->orderByDesc('id')
                 ->paginate(25)

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -33,8 +33,16 @@ class AdminController extends Controller
                 AVG(CASE WHEN cached = 0 THEN response_time_ms ELSE NULL END) as avg_ms,
                 SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END) as rate_limited,
                 COUNT(DISTINCT user_id) as unique_auth,
-                COUNT(DISTINCT CASE WHEN user_id IS NULL THEN visitor_hash END) as unique_anon
+                COUNT(DISTINCT CASE WHEN user_id IS NULL THEN visitor_hash END) as unique_anon,
+                SUM(CASE WHEN bot IS NOT NULL THEN 1 ELSE 0 END) as bot_total
             ')->whereDate('created_at', $today)->first();
+
+            $tmdb['bots_today'] = TmdbRequestLog::selectRaw('bot, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNotNull('bot')
+                ->groupBy('bot')
+                ->orderByDesc('total')
+                ->get();
 
             // Short-window live request counts for rate limit monitoring
             $tmdb['last_60s']  = TmdbRequestLog::where('cached', false)

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageView;
 use App\Models\Roulette;
 use App\Models\Setting;
 use App\Models\TmdbRequestLog;
+use App\Models\User;
 
 class AdminController extends Controller
 {
@@ -141,6 +143,32 @@ class AdminController extends Controller
                 ]);
 
             $tmdb['top_users'] = $topAuth->concat($topAnon)->sortByDesc('total')->take(10)->values();
+
+            // Page views: top pages today (human only)
+            $tmdb['top_pages'] = PageView::selectRaw('route, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNull('bot')
+                ->groupBy('route')
+                ->orderByDesc('total')
+                ->limit(10)
+                ->get();
+
+            // Page views: recent unique visitors in last 24h
+            $recentVisitorRows = PageView::selectRaw('visitor_hash, user_id, bot, COUNT(*) as page_count, MAX(created_at) as last_seen')
+                ->where('created_at', '>=', now()->subHours(24))
+                ->groupBy('visitor_hash', 'user_id', 'bot')
+                ->orderByDesc('last_seen')
+                ->limit(20)
+                ->get();
+
+            // Eager-load users separately
+            $userIds = $recentVisitorRows->pluck('user_id')->filter()->unique()->values();
+            $usersById = User::whereIn('id', $userIds)->get()->keyBy('id');
+
+            $tmdb['recent_visitors'] = $recentVisitorRows->map(function ($row) use ($usersById) {
+                $row->user = isset($row->user_id) ? ($usersById[$row->user_id] ?? null) : null;
+                return $row;
+            });
 
             $tmdb['recent'] = TmdbRequestLog::with('user')
                 ->orderByDesc('id')

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -41,10 +41,14 @@ class AdminUserController extends Controller
             }
         }
 
+        $tmdbLogsTotal = TmdbRequestLog::where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->count();
+
         $tmdbLogs = TmdbRequestLog::where('user_id', $user->id)
             ->where('created_at', '>=', now()->subDays(30))
             ->orderByDesc('created_at')
-            ->limit(100)
+            ->limit(25)
             ->get();
 
         $pageViewRows = PageView::where('user_id', $user->id)
@@ -87,7 +91,7 @@ class AdminUserController extends Controller
             ];
         }
 
-        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions'));
+        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'tmdbLogsTotal', 'processedSessions'));
     }
 
     public function destroyRoulette(User $user, Roulette $roulette)

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -41,15 +41,11 @@ class AdminUserController extends Controller
             }
         }
 
-        $tmdbLogsTotal = TmdbRequestLog::where('user_id', $user->id)
-            ->where('created_at', '>=', now()->subDays(30))
-            ->count();
-
         $tmdbLogs = TmdbRequestLog::where('user_id', $user->id)
             ->where('created_at', '>=', now()->subDays(30))
             ->orderByDesc('created_at')
-            ->limit(25)
-            ->get();
+            ->paginate(25)
+            ->withQueryString();
 
         $pageViewRows = PageView::where('user_id', $user->id)
             ->where('created_at', '>=', now()->subDays(30))
@@ -91,7 +87,7 @@ class AdminUserController extends Controller
             ];
         }
 
-        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'tmdbLogsTotal', 'processedSessions'));
+        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions'));
     }
 
     public function destroyRoulette(User $user, Roulette $roulette)

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -87,7 +87,46 @@ class AdminUserController extends Controller
             ];
         }
 
-        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions'));
+        // External referrers for this user
+        $referrerCounts = [];
+        foreach ($processedSessions as $session) {
+            foreach ($session->pages as $page) {
+                if ($page->referrer && !str_starts_with($page->referrer, '/')) {
+                    $referrerCounts[$page->referrer] = ($referrerCounts[$page->referrer] ?? 0) + 1;
+                }
+            }
+        }
+        arsort($referrerCounts);
+        $referrers = array_slice($referrerCounts, 0, 5, true);
+
+        // A→B transitions for this user
+        $transCounts = [];
+        foreach ($processedSessions as $session) {
+            for ($j = 0; $j < count($session->pages) - 1; $j++) {
+                $from = $session->pages[$j]->route;
+                $to   = $session->pages[$j + 1]->route;
+                if ($from !== $to) {
+                    $key = $from . ' → ' . $to;
+                    $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
+                }
+            }
+        }
+        arsort($transCounts);
+        $transitions = array_slice($transCounts, 0, 10, true);
+
+        // Hourly activity for this user (last 30 days)
+        $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
+            ->where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->groupByRaw('HOUR(created_at)')
+            ->get()
+            ->keyBy('hour');
+        $hourly = collect(range(0, 23))->map(fn($h) => (object)[
+            'hour'  => $h,
+            'total' => $hourlyRows->get($h)?->total ?? 0,
+        ]);
+
+        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions', 'referrers', 'transitions', 'hourly'));
     }
 
     public function destroyRoulette(User $user, Roulette $roulette)

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageView;
 use App\Models\Roulette;
 use App\Models\Setting;
+use App\Models\TmdbRequestLog;
 use App\Models\User;
 
 class AdminUserController extends Controller
@@ -39,7 +41,53 @@ class AdminUserController extends Controller
             }
         }
 
-        return view('admin.users.show', compact('user', 'ordered', 'roulettes'));
+        $tmdbLogs = TmdbRequestLog::where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->orderByDesc('created_at')
+            ->limit(100)
+            ->get();
+
+        $pageViewRows = PageView::where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->orderBy('created_at')
+            ->get();
+
+        $sessions = [];
+        $current  = [];
+        foreach ($pageViewRows as $view) {
+            if (empty($current)) {
+                $current[] = $view;
+            } else {
+                $gap = $view->created_at->diffInSeconds(end($current)->created_at);
+                if ($gap > 1800) { $sessions[] = $current; $current = []; }
+                $current[] = $view;
+            }
+        }
+        if (!empty($current)) $sessions[] = $current;
+
+        $processedSessions = [];
+        foreach ($sessions as $session) {
+            $pages = [];
+            foreach ($session as $j => $view) {
+                $pages[] = (object)[
+                    'route'        => $view->route,
+                    'referrer'     => $view->referrer,
+                    'created_at'   => $view->created_at,
+                    'time_on_page' => isset($session[$j + 1])
+                        ? $view->created_at->diffInSeconds($session[$j + 1]->created_at)
+                        : null,
+                ];
+            }
+            $start = $session[0]->created_at;
+            $end   = end($session)->created_at;
+            $processedSessions[] = (object)[
+                'start'    => $start,
+                'duration' => $start->diffInSeconds($end),
+                'pages'    => $pages,
+            ];
+        }
+
+        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions'));
     }
 
     public function destroyRoulette(User $user, Roulette $roulette)

--- a/app/Http/Controllers/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Admin/AdminUserController.php
@@ -99,21 +99,6 @@ class AdminUserController extends Controller
         arsort($referrerCounts);
         $referrers = array_slice($referrerCounts, 0, 5, true);
 
-        // A→B transitions for this user
-        $transCounts = [];
-        foreach ($processedSessions as $session) {
-            for ($j = 0; $j < count($session->pages) - 1; $j++) {
-                $from = $session->pages[$j]->route;
-                $to   = $session->pages[$j + 1]->route;
-                if ($from !== $to) {
-                    $key = $from . ' → ' . $to;
-                    $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
-                }
-            }
-        }
-        arsort($transCounts);
-        $transitions = array_slice($transCounts, 0, 10, true);
-
         // Hourly activity for this user (last 30 days)
         $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
             ->where('user_id', $user->id)
@@ -126,7 +111,7 @@ class AdminUserController extends Controller
             'total' => $hourlyRows->get($h)?->total ?? 0,
         ]);
 
-        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions', 'referrers', 'transitions', 'hourly'));
+        return view('admin.users.show', compact('user', 'ordered', 'roulettes', 'tmdbLogs', 'processedSessions', 'referrers', 'hourly'));
     }
 
     public function destroyRoulette(User $user, Roulette $roulette)

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -74,15 +74,11 @@ class AdminVisitorController extends Controller
         $bot   = $views->first()?->bot;
         $total = $views->count();
 
-        $tmdbLogsTotal = TmdbRequestLog::where('visitor_hash', $hash)
-            ->where('created_at', '>=', now()->subDays(30))
-            ->count();
-
         $tmdbLogs = TmdbRequestLog::where('visitor_hash', $hash)
             ->where('created_at', '>=', now()->subDays(30))
             ->orderByDesc('created_at')
-            ->limit(25)
-            ->get();
+            ->paginate(25)
+            ->withQueryString();
 
         // Resolve bot/user from tmdb logs if page_views had none
         if (!$bot && !$user) {
@@ -93,6 +89,6 @@ class AdminVisitorController extends Controller
             }
         }
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'tmdbLogsTotal'));
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs'));
     }
 }

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -74,10 +74,14 @@ class AdminVisitorController extends Controller
         $bot   = $views->first()?->bot;
         $total = $views->count();
 
+        $tmdbLogsTotal = TmdbRequestLog::where('visitor_hash', $hash)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->count();
+
         $tmdbLogs = TmdbRequestLog::where('visitor_hash', $hash)
             ->where('created_at', '>=', now()->subDays(30))
             ->orderByDesc('created_at')
-            ->limit(100)
+            ->limit(25)
             ->get();
 
         // Resolve bot/user from tmdb logs if page_views had none
@@ -89,6 +93,6 @@ class AdminVisitorController extends Controller
             }
         }
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs'));
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'tmdbLogsTotal'));
     }
 }

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -101,21 +101,6 @@ class AdminVisitorController extends Controller
         arsort($referrerCounts);
         $referrers = array_slice($referrerCounts, 0, 5, true);
 
-        // A→B transitions for this visitor
-        $transCounts = [];
-        foreach ($processedSessions as $session) {
-            for ($j = 0; $j < count($session->pages) - 1; $j++) {
-                $from = $session->pages[$j]->route;
-                $to   = $session->pages[$j + 1]->route;
-                if ($from !== $to) {
-                    $key = $from . ' → ' . $to;
-                    $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
-                }
-            }
-        }
-        arsort($transCounts);
-        $transitions = array_slice($transCounts, 0, 10, true);
-
         // Hourly activity for this visitor (last 30 days)
         $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
             ->where('visitor_hash', $hash)
@@ -128,6 +113,6 @@ class AdminVisitorController extends Controller
             'total' => $hourlyRows->get($h)?->total ?? 0,
         ]);
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'transitions', 'hourly'));
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'hourly'));
     }
 }

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\PageView;
+use App\Models\User;
+
+class AdminVisitorController extends Controller
+{
+    public function show(string $hash)
+    {
+        $views = PageView::where('visitor_hash', $hash)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->orderBy('created_at')
+            ->get();
+
+        // Group into sessions: gap > 30 min = new session
+        $sessions    = [];
+        $currentSession = [];
+
+        foreach ($views as $i => $view) {
+            if (empty($currentSession)) {
+                $currentSession[] = $view;
+            } else {
+                $prev = end($currentSession);
+                $gap  = $view->created_at->diffInSeconds($prev->created_at);
+                if ($gap > 1800) {
+                    $sessions[]     = $currentSession;
+                    $currentSession = [$view];
+                } else {
+                    $currentSession[] = $view;
+                }
+            }
+        }
+        if (!empty($currentSession)) {
+            $sessions[] = $currentSession;
+        }
+
+        // Compute time_on_page for each view within each session
+        $processedSessions = [];
+        foreach ($sessions as $session) {
+            $processed = [];
+            foreach ($session as $j => $view) {
+                $timeOnPage = null;
+                if (isset($session[$j + 1])) {
+                    $timeOnPage = $view->created_at->diffInSeconds($session[$j + 1]->created_at);
+                }
+                $processed[] = (object)[
+                    'route'       => $view->route,
+                    'referrer'    => $view->referrer,
+                    'created_at'  => $view->created_at,
+                    'time_on_page' => $timeOnPage,
+                ];
+            }
+
+            $start    = $session[0]->created_at;
+            $end      = end($session)->created_at;
+            $duration = $start->diffInSeconds($end);
+
+            $processedSessions[] = (object)[
+                'start'    => $start,
+                'duration' => $duration,
+                'pages'    => $processed,
+            ];
+        }
+
+        // Resolve user from first record that has a user_id
+        $userRecord = $views->firstWhere('user_id', '!=', null);
+        $user       = $userRecord ? User::find($userRecord->user_id) : null;
+
+        // Bot from first record
+        $bot   = $views->first()?->bot;
+        $total = $views->count();
+
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total'));
+    }
+}

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -89,6 +89,45 @@ class AdminVisitorController extends Controller
             }
         }
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs'));
+        // External referrers for this visitor
+        $referrerCounts = [];
+        foreach ($processedSessions as $session) {
+            foreach ($session->pages as $page) {
+                if ($page->referrer && !str_starts_with($page->referrer, '/')) {
+                    $referrerCounts[$page->referrer] = ($referrerCounts[$page->referrer] ?? 0) + 1;
+                }
+            }
+        }
+        arsort($referrerCounts);
+        $referrers = array_slice($referrerCounts, 0, 5, true);
+
+        // A→B transitions for this visitor
+        $transCounts = [];
+        foreach ($processedSessions as $session) {
+            for ($j = 0; $j < count($session->pages) - 1; $j++) {
+                $from = $session->pages[$j]->route;
+                $to   = $session->pages[$j + 1]->route;
+                if ($from !== $to) {
+                    $key = $from . ' → ' . $to;
+                    $transCounts[$key] = ($transCounts[$key] ?? 0) + 1;
+                }
+            }
+        }
+        arsort($transCounts);
+        $transitions = array_slice($transCounts, 0, 10, true);
+
+        // Hourly activity for this visitor (last 30 days)
+        $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
+            ->where('visitor_hash', $hash)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->groupByRaw('HOUR(created_at)')
+            ->get()
+            ->keyBy('hour');
+        $hourly = collect(range(0, 23))->map(fn($h) => (object)[
+            'hour'  => $h,
+            'total' => $hourlyRows->get($h)?->total ?? 0,
+        ]);
+
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'transitions', 'hourly'));
     }
 }

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\PageView;
+use App\Models\TmdbRequestLog;
 use App\Models\User;
 
 class AdminVisitorController extends Controller
@@ -73,6 +74,21 @@ class AdminVisitorController extends Controller
         $bot   = $views->first()?->bot;
         $total = $views->count();
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total'));
+        $tmdbLogs = TmdbRequestLog::where('visitor_hash', $hash)
+            ->where('created_at', '>=', now()->subDays(30))
+            ->orderByDesc('created_at')
+            ->limit(100)
+            ->get();
+
+        // Resolve bot/user from tmdb logs if page_views had none
+        if (!$bot && !$user) {
+            $firstLog = $tmdbLogs->first();
+            $bot      = $bot ?? $firstLog?->bot;
+            if (!$user && $firstLog?->user_id) {
+                $user = User::find($firstLog->user_id);
+            }
+        }
+
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs'));
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\LogPageView::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/LogPageView.php
+++ b/app/Http/Middleware/LogPageView.php
@@ -42,7 +42,7 @@ class LogPageView
             $rawRef   = $request->header('Referer', '');
             if ($rawRef !== '') {
                 $parsed  = parse_url($rawRef);
-                $appHost = parse_url(config('app.url', ''), PHP_URL_HOST);
+                $appHost = $request->getHost();
                 $refHost = $parsed['host'] ?? '';
 
                 if ($refHost !== '' && $refHost === $appHost) {

--- a/app/Http/Middleware/LogPageView.php
+++ b/app/Http/Middleware/LogPageView.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\PageView;
+use App\Support\BotDetector;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogPageView
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        try {
+            // Only log GET requests
+            if (!$request->isMethod('GET')) return;
+
+            // Skip AJAX / JSON requests
+            if ($request->ajax()) return;
+            if (str_contains($request->header('Accept', ''), 'application/json')) return;
+
+            // Skip internal/admin/framework routes
+            $path = ltrim($request->path(), '/');
+            foreach (['admin', '_ignition', 'livewire'] as $prefix) {
+                if (str_starts_with($path, $prefix)) return;
+            }
+
+            // Skip error responses
+            if ($response->getStatusCode() >= 400) return;
+
+            $bot         = BotDetector::detect($request);
+            $visitorHash = BotDetector::visitorHash($request);
+
+            // Resolve referrer
+            $referrer = null;
+            $rawRef   = $request->header('Referer', '');
+            if ($rawRef !== '') {
+                $parsed  = parse_url($rawRef);
+                $appHost = parse_url(config('app.url', ''), PHP_URL_HOST);
+                $refHost = $parsed['host'] ?? '';
+
+                if ($refHost !== '' && $refHost === $appHost) {
+                    // Same-site referrer: keep only the path
+                    $referrer = ($parsed['path'] ?? '/') ?: '/';
+                } elseif ($refHost !== '') {
+                    // External referrer: keep domain only
+                    $referrer = $refHost;
+                }
+            }
+
+            $route = $request->path() === '/' ? '/' : '/' . ltrim($request->path(), '/');
+
+            PageView::create([
+                'visitor_hash' => $visitorHash ?: null,
+                'user_id'      => auth()->id(),
+                'bot'          => $bot,
+                'route'        => $route,
+                'referrer'     => $referrer,
+            ]);
+        } catch (\Throwable) {
+            // Never break requests
+        }
+    }
+}

--- a/app/Models/PageView.php
+++ b/app/Models/PageView.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PageView extends Model
+{
+    const UPDATED_AT = null;
+
+    protected $fillable = [
+        'visitor_hash',
+        'user_id',
+        'bot',
+        'route',
+        'referrer',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/TmdbRequestLog.php
+++ b/app/Models/TmdbRequestLog.php
@@ -16,6 +16,7 @@ class TmdbRequestLog extends Model
         'response_time_ms',
         'user_id',
         'visitor_hash',
+        'bot',
     ];
 
     protected $casts = [

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -461,6 +461,7 @@ class TmdbClient implements ApiMovie
                 'response_time_ms' => $ms,
                 'user_id'          => auth()->id(),
                 'visitor_hash'     => $this->visitorHash(),
+                'bot'              => $this->detectBot(),
             ]);
         } catch (\Throwable) {
             // Never let logging break a request
@@ -485,6 +486,57 @@ class TmdbClient implements ApiMovie
             return substr(hash('sha256', $ip . $ua), 0, 16);
         } catch (\Throwable) {
             return '';
+        }
+    }
+
+    private function detectBot(): ?string
+    {
+        try {
+            $req = request();
+            $ua  = $req->userAgent() ?? '';
+
+            if ($ua === '') {
+                return 'no-ua';
+            }
+
+            $patterns = [
+                '/Googlebot/i'           => 'Googlebot',
+                '/Bingbot/i'             => 'Bingbot',
+                '/DuckDuckBot/i'         => 'DuckDuckBot',
+                '/YandexBot/i'           => 'YandexBot',
+                '/Baiduspider/i'         => 'Baiduspider',
+                '/Slurp/i'               => 'Yahoo-Slurp',
+                '/facebookexternalhit/i' => 'FacebookBot',
+                '/Twitterbot/i'          => 'Twitterbot',
+                '/LinkedInBot/i'         => 'LinkedInBot',
+                '/Slackbot/i'            => 'Slackbot',
+                '/Discordbot/i'          => 'Discordbot',
+                '/python-requests/i'     => 'python-requests',
+                '/curl\//i'              => 'curl',
+                '/wget\//i'              => 'wget',
+                '/Go-http-client/i'      => 'Go-http-client',
+                '/Java\//i'              => 'Java-client',
+                '/Scrapy/i'              => 'Scrapy',
+                '/PostmanRuntime/i'      => 'Postman',
+                '/HeadlessChrome/i'      => 'HeadlessChrome',
+                '/PhantomJS/i'           => 'PhantomJS',
+                '/bot|crawler|spider|scraper/i' => 'crawler',
+            ];
+
+            foreach ($patterns as $pattern => $name) {
+                if (preg_match($pattern, $ua)) {
+                    return $name;
+                }
+            }
+
+            // Real browsers always send Accept-Language
+            if (($req->header('Accept-Language') ?? '') === '') {
+                return 'no-accept-language';
+            }
+
+            return null;
+        } catch (\Throwable) {
+            return null;
         }
     }
 }

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Interfaces\MovieApiInterface as ApiMovie;
 use App\Models\TmdbRequestLog;
+use App\Support\BotDetector;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
@@ -481,9 +482,7 @@ class TmdbClient implements ApiMovie
     private function visitorHash(): string
     {
         try {
-            $ip = request()->ip() ?? '';
-            $ua = request()->userAgent() ?? '';
-            return substr(hash('sha256', $ip . $ua), 0, 16);
+            return BotDetector::visitorHash(request());
         } catch (\Throwable) {
             return '';
         }
@@ -492,49 +491,7 @@ class TmdbClient implements ApiMovie
     private function detectBot(): ?string
     {
         try {
-            $req = request();
-            $ua  = $req->userAgent() ?? '';
-
-            if ($ua === '') {
-                return 'no-ua';
-            }
-
-            $patterns = [
-                '/Googlebot/i'           => 'Googlebot',
-                '/Bingbot/i'             => 'Bingbot',
-                '/DuckDuckBot/i'         => 'DuckDuckBot',
-                '/YandexBot/i'           => 'YandexBot',
-                '/Baiduspider/i'         => 'Baiduspider',
-                '/Slurp/i'               => 'Yahoo-Slurp',
-                '/facebookexternalhit/i' => 'FacebookBot',
-                '/Twitterbot/i'          => 'Twitterbot',
-                '/LinkedInBot/i'         => 'LinkedInBot',
-                '/Slackbot/i'            => 'Slackbot',
-                '/Discordbot/i'          => 'Discordbot',
-                '/python-requests/i'     => 'python-requests',
-                '/curl\//i'              => 'curl',
-                '/wget\//i'              => 'wget',
-                '/Go-http-client/i'      => 'Go-http-client',
-                '/Java\//i'              => 'Java-client',
-                '/Scrapy/i'              => 'Scrapy',
-                '/PostmanRuntime/i'      => 'Postman',
-                '/HeadlessChrome/i'      => 'HeadlessChrome',
-                '/PhantomJS/i'           => 'PhantomJS',
-                '/bot|crawler|spider|scraper/i' => 'crawler',
-            ];
-
-            foreach ($patterns as $pattern => $name) {
-                if (preg_match($pattern, $ua)) {
-                    return $name;
-                }
-            }
-
-            // Real browsers always send Accept-Language
-            if (($req->header('Accept-Language') ?? '') === '') {
-                return 'no-accept-language';
-            }
-
-            return null;
+            return BotDetector::detect(request());
         } catch (\Throwable) {
             return null;
         }

--- a/app/Support/BotDetector.php
+++ b/app/Support/BotDetector.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Request;
+
+class BotDetector
+{
+    public static function detect(Request $request): ?string
+    {
+        try {
+            $ua = $request->userAgent() ?? '';
+            if ($ua === '') return 'no-ua';
+
+            $patterns = [
+                '/Googlebot/i'           => 'Googlebot',
+                '/Bingbot/i'             => 'Bingbot',
+                '/DuckDuckBot/i'         => 'DuckDuckBot',
+                '/YandexBot/i'           => 'YandexBot',
+                '/Baiduspider/i'         => 'Baiduspider',
+                '/Slurp/i'               => 'Yahoo-Slurp',
+                '/facebookexternalhit/i' => 'FacebookBot',
+                '/Twitterbot/i'          => 'Twitterbot',
+                '/LinkedInBot/i'         => 'LinkedInBot',
+                '/Slackbot/i'            => 'Slackbot',
+                '/Discordbot/i'          => 'Discordbot',
+                '/python-requests/i'     => 'python-requests',
+                '/curl\//i'              => 'curl',
+                '/wget\//i'              => 'wget',
+                '/Go-http-client/i'      => 'Go-http-client',
+                '/Java\//i'              => 'Java-client',
+                '/Scrapy/i'              => 'Scrapy',
+                '/PostmanRuntime/i'      => 'Postman',
+                '/HeadlessChrome/i'      => 'HeadlessChrome',
+                '/PhantomJS/i'           => 'PhantomJS',
+                '/bot|crawler|spider|scraper/i' => 'crawler',
+            ];
+
+            foreach ($patterns as $pattern => $name) {
+                if (preg_match($pattern, $ua)) return $name;
+            }
+
+            if (($request->header('Accept-Language') ?? '') === '') return 'no-accept-language';
+
+            return null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    public static function visitorHash(Request $request): string
+    {
+        try {
+            return substr(hash('sha256', ($request->ip() ?? '') . ($request->userAgent() ?? '')), 0, 16);
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+}

--- a/database/migrations/2026_06_15_000000_add_bot_to_tmdb_request_logs_table.php
+++ b/database/migrations/2026_06_15_000000_add_bot_to_tmdb_request_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->string('bot', 50)->nullable()->after('visitor_hash');
+            $table->index('bot');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->dropIndex(['bot']);
+            $table->dropColumn('bot');
+        });
+    }
+};

--- a/database/migrations/2026_06_15_200000_create_page_views_table.php
+++ b/database/migrations/2026_06_15_200000_create_page_views_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('page_views', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('visitor_hash', 16)->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('bot', 50)->nullable();
+            $table->string('route', 255);
+            $table->string('referrer', 255)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index('created_at');
+            $table->index('visitor_hash');
+            $table->index(['visitor_hash', 'created_at']);
+            $table->index('bot');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('page_views');
+    }
+};

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -274,6 +274,78 @@
 
         </div>
 
+        {{-- Top Pages Today --}}
+        @if(!empty($tmdb['top_pages']) && $tmdb['top_pages']->isNotEmpty())
+        <div class="mt-8">
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Pages — Today (Human)</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Views</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($tmdb['top_pages'] as $page)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-200">{{ $page->route }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($page->total) }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+        {{-- Recent Visitors --}}
+        @if(!empty($tmdb['recent_visitors']) && $tmdb['recent_visitors']->isNotEmpty())
+        <div class="mt-8">
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Recent Visitors — Last 24h</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Visitor</th>
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
+                            <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Pages</th>
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Last Seen</th>
+                            <th class="px-4 py-2.5"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($tmdb['recent_visitors'] as $v)
+                        <tr>
+                            <td class="px-4 py-2.5">
+                                <span class="font-mono text-xs text-gray-300">{{ substr($v->visitor_hash ?? '--------', 0, 8) }}</span>
+                                @if($v->user)
+                                    <span class="ml-2 text-xs text-gray-500">{{ $v->user->name }}</span>
+                                @endif
+                            </td>
+                            <td class="px-4 py-2.5">
+                                @if($v->bot)
+                                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono">{{ $v->bot }}</span>
+                                @else
+                                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">human</span>
+                                @endif
+                            </td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($v->page_count) }}</td>
+                            <td class="px-4 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ \Carbon\Carbon::parse($v->last_seen)->diffForHumans() }}</td>
+                            <td class="px-4 py-2.5 text-right">
+                                @if($v->visitor_hash)
+                                <a href="{{ route('admin.visitor.show', $v->visitor_hash) }}"
+                                   class="text-xs text-accent hover:underline">View →</a>
+                                @endif
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
     {{-- ================================================================ --}}
     {{-- TMDB TAB                                                          --}}
     {{-- ================================================================ --}}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -255,7 +255,15 @@
                         <tbody class="divide-y divide-white/5">
                             @foreach($tmdb['top_users'] as $u)
                             <tr>
-                                <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ $u->label }}</td>
+                                <td class="px-4 py-2.5 font-mono text-xs">
+                                    @if($u->type === 'auth' && $u->user_id)
+                                        <a href="{{ route('admin.users.show', $u->user_id) }}" class="text-gray-300 hover:text-accent transition-colors">{{ $u->label }}</a>
+                                    @elseif($u->hash)
+                                        <a href="{{ route('admin.visitor.show', $u->hash) }}" class="text-gray-300 hover:text-accent transition-colors">{{ $u->label }}</a>
+                                    @else
+                                        <span class="text-gray-500">{{ $u->label }}</span>
+                                    @endif
+                                </td>
                                 <td class="px-4 py-2.5">
                                     @if($u->type === 'auth')
                                         <span class="text-xs px-1.5 py-0.5 rounded-full bg-orange-500/10 text-orange-400 border border-orange-500/20">logged in</span>
@@ -311,33 +319,33 @@
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
                             <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Pages</th>
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Last Seen</th>
-                            <th class="px-4 py-2.5"></th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/5">
                         @foreach($tmdb['recent_visitors'] as $v)
                         <tr>
                             <td class="px-4 py-2.5">
-                                <span class="font-mono text-xs text-gray-300">{{ substr($v->visitor_hash ?? '--------', 0, 8) }}</span>
-                                @if($v->user)
-                                    <span class="ml-2 text-xs text-gray-500">{{ $v->user->name }}</span>
+                                @if($v->visitor_hash)
+                                <a href="{{ route('admin.visitor.show', $v->visitor_hash) }}" class="group flex items-baseline gap-2">
+                                    <span class="font-mono text-xs text-gray-300 group-hover:text-accent transition-colors">{{ substr($v->visitor_hash, 0, 8) }}</span>
+                                    @if($v->user)
+                                        <span class="text-xs text-gray-500 group-hover:text-gray-300 transition-colors">{{ $v->user->name }}</span>
+                                    @endif
+                                </a>
+                                @else
+                                    <span class="font-mono text-xs text-gray-600">unknown</span>
                                 @endif
                             </td>
                             <td class="px-4 py-2.5">
                                 @if($v->bot)
-                                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono">{{ $v->bot }}</span>
+                                    <a href="{{ $v->visitor_hash ? route('admin.visitor.show', $v->visitor_hash) : '#' }}"
+                                       class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono hover:bg-red-500/20 transition-colors">{{ $v->bot }}</a>
                                 @else
                                     <span class="text-xs px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">human</span>
                                 @endif
                             </td>
                             <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($v->page_count) }}</td>
                             <td class="px-4 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ \Carbon\Carbon::parse($v->last_seen)->diffForHumans() }}</td>
-                            <td class="px-4 py-2.5 text-right">
-                                @if($v->visitor_hash)
-                                <a href="{{ route('admin.visitor.show', $v->visitor_hash) }}"
-                                   class="text-xs text-accent hover:underline">View →</a>
-                                @endif
-                            </td>
                         </tr>
                         @endforeach
                     </tbody>
@@ -580,9 +588,18 @@
                         <td class="px-4 py-2 text-right text-xs text-gray-500">{{ $log->response_time_ms ?? '—' }}</td>
                         <td class="px-4 py-2 text-xs text-gray-400">
                             @if($log->bot)
+                                @if($log->visitor_hash)
+                                <a href="{{ route('admin.visitor.show', $log->visitor_hash) }}"
+                                   class="px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono hover:bg-red-500/20 transition-colors">{{ $log->bot }}</a>
+                                @else
                                 <span class="px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono">{{ $log->bot }}</span>
+                                @endif
+                            @elseif($log->user)
+                                <a href="{{ route('admin.users.show', $log->user_id) }}" class="hover:text-accent transition-colors">{{ $log->user->name }}</a>
+                            @elseif($log->visitor_hash)
+                                <a href="{{ route('admin.visitor.show', $log->visitor_hash) }}" class="font-mono hover:text-accent transition-colors">{{ $log->visitor_hash }}</a>
                             @else
-                                {{ $log->user?->name ?? $log->visitor_hash ?? '—' }}
+                                —
                             @endif
                         </td>
                     </tr>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -14,8 +14,13 @@
     <div class="flex gap-1 mb-8 border-b border-white/5 pb-0">
         <a href="{{ route('admin.dashboard') }}"
            class="px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors -mb-px
-                  {{ $activeTab === 'overview' ? 'border-accent text-white' : 'border-transparent text-gray-500 hover:text-white' }}">
-            Overview
+                  {{ $activeTab === 'roulettes' ? 'border-accent text-white' : 'border-transparent text-gray-500 hover:text-white' }}">
+            Roulettes
+        </a>
+        <a href="{{ route('admin.dashboard', ['tab' => 'traffic']) }}"
+           class="px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors -mb-px
+                  {{ $activeTab === 'traffic' ? 'border-accent text-white' : 'border-transparent text-gray-500 hover:text-white' }}">
+            Traffic
         </a>
         <a href="{{ route('admin.dashboard', ['tab' => 'tmdb']) }}"
            class="px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors -mb-px
@@ -24,9 +29,11 @@
         </a>
     </div>
 
-    @if($activeTab === 'overview')
+    {{-- ================================================================ --}}
+    {{-- ROULETTES TAB                                                     --}}
+    {{-- ================================================================ --}}
+    @if($activeTab === 'roulettes')
 
-        {{-- Stats --}}
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
             <div class="bg-white/3 border border-white/5 rounded-xl p-5">
                 <div class="text-3xl font-bold text-white mb-1">{{ $stats['total'] }}</div>
@@ -46,7 +53,6 @@
             </div>
         </div>
 
-        {{-- Quick links --}}
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <a href="{{ route('admin.roulettes.index') }}"
                class="group bg-white/3 border border-white/5 hover:border-white/10 rounded-xl p-6 transition-colors">
@@ -77,91 +83,25 @@
             </a>
         </div>
 
-    @else
+    {{-- ================================================================ --}}
+    {{-- TRAFFIC TAB                                                        --}}
+    {{-- ================================================================ --}}
+    @elseif($activeTab === 'traffic')
 
         @php
-            $today   = $tmdb['today'];
-            $hitRate = $today->total > 0 ? round(($today->hits / $today->total) * 100) : 0;
-            $rps     = $tmdb['req_per_sec'];
-            $pct     = $tmdb['rate_pct'];
-            $barColor = $pct >= 75 ? '#ef4444' : ($pct >= 40 ? '#f59e0b' : '#22c55e');
-            $labelColor = $pct >= 75 ? 'text-red-400' : ($pct >= 40 ? 'text-yellow-400' : 'text-green-400');
-            $status = $pct >= 75 ? 'High' : ($pct >= 40 ? 'Moderate' : 'Safe');
+            $today        = $tmdb['today'];
+            $humanTotal   = $today->human_total ?? 0;
+            $botTotal     = $today->bot_total ?? 0;
+            $botPct       = ($today->total ?? 0) > 0 ? round(($botTotal / $today->total) * 100) : 0;
+            $humanHitRate = $humanTotal > 0 ? round((($today->human_hits ?? 0) / $humanTotal) * 100) : 0;
+            $uniqueTotal  = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
+            $projected    = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0;
         @endphp
 
-        {{-- 429 warning --}}
-        @if($today->rate_limited > 0)
-        <div class="mb-6 flex items-center gap-3 bg-red-500/10 border border-red-500/30 rounded-xl px-5 py-4">
-            <span class="text-red-400 text-xl">⚠</span>
-            <div>
-                <div class="text-sm font-semibold text-red-400">Rate limit hit today</div>
-                <div class="text-xs text-red-400/70 mt-0.5">{{ $today->rate_limited }} request{{ $today->rate_limited > 1 ? 's' : '' }} returned 429. TMDB allows ~40 req/sec.</div>
-            </div>
-        </div>
-        @endif
-
-        {{-- Rate limit gauge --}}
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Rate Limit</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-6">
-            <div class="flex items-end justify-between mb-2">
-                <div>
-                    <span class="text-3xl font-bold {{ $labelColor }}">{{ $rps }}</span>
-                    <span class="text-sm text-gray-500 ml-1">req/sec</span>
-                    <span class="ml-3 text-xs font-medium px-2 py-0.5 rounded-full {{ $pct >= 75 ? 'bg-red-500/15 text-red-400 border border-red-500/20' : ($pct >= 40 ? 'bg-yellow-500/15 text-yellow-400 border border-yellow-500/20' : 'bg-green-500/15 text-green-400 border border-green-500/20') }}">{{ $status }}</span>
-                </div>
-                <div class="text-right">
-                    <div class="text-xs text-gray-500">Peak last 30 min</div>
-                    <div class="text-sm font-semibold text-gray-300">{{ $tmdb['peak_req_per_sec'] }} req/sec</div>
-                </div>
-            </div>
-            <div class="relative h-2.5 bg-white/5 rounded-full overflow-hidden">
-                <div class="absolute inset-y-0 left-0 rounded-full transition-all" style="width: {{ $pct }}%; background: {{ $barColor }}"></div>
-                {{-- Danger marker at 75% (30 req/sec) --}}
-                <div class="absolute inset-y-0 w-px bg-red-500/40" style="left: 75%"></div>
-            </div>
-            <div class="flex justify-between mt-1.5 text-xs text-gray-600">
-                <span>0</span>
-                <span class="text-red-500/50">30/s danger zone</span>
-                <span>40/s limit</span>
-            </div>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4 pt-4 border-t border-white/5">
-                <div>
-                    <div class="text-lg font-bold text-white">{{ $tmdb['last_60s'] }}</div>
-                    <div class="text-xs text-gray-500">Live last 60s</div>
-                </div>
-                <div>
-                    <div class="text-lg font-bold text-white">{{ $tmdb['last_5min'] }}</div>
-                    <div class="text-xs text-gray-500">Live last 5 min</div>
-                </div>
-                <div>
-                    <div class="text-lg font-bold text-white">{{ round($tmdb['last_5min'] / 5, 1) }}</div>
-                    <div class="text-xs text-gray-500">Avg/min (5 min)</div>
-                </div>
-                <div>
-                    <div class="text-lg font-bold {{ ($today->rate_limited ?? 0) > 0 ? 'text-red-400' : 'text-white' }}">{{ $today->rate_limited ?? 0 }}</div>
-                    <div class="text-xs text-gray-500">429s today</div>
-                </div>
-            </div>
-        </div>
-
-        {{-- Today's summary --}}
-        @php
-            $humanTotal    = $today->human_total ?? 0;
-            $botTotal      = $today->bot_total ?? 0;
-            $botPct        = ($today->total ?? 0) > 0 ? round(($botTotal / $today->total) * 100) : 0;
-            $humanHitRate  = $humanTotal > 0 ? round((($today->human_hits ?? 0) / $humanTotal) * 100) : 0;
-            $uniqueTotal   = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
-        @endphp
-
-        {{-- Revenue estimate --}}
-        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-6">
-            <div class="flex items-center justify-between mb-3">
-                <div>
-                    <div class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Estimated Ad Revenue</div>
-                    <div class="text-xs text-gray-600 mt-0.5">Human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM</div>
-                </div>
-                <div class="text-xs text-gray-600">{{ number_format($humanTotal) }} human requests today</div>
-            </div>
+        {{-- Revenue --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Estimated Ad Revenue</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-8">
+            <div class="text-xs text-gray-600 mb-4">Human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM &middot; {{ number_format($humanTotal) }} human requests today</div>
             <div class="grid grid-cols-3 gap-4">
                 <div>
                     <div class="text-2xl font-bold text-accent mb-1">${{ number_format($tmdb['revenue_today'], 2) }}</div>
@@ -172,13 +112,13 @@
                     <div class="text-xs text-gray-500">Last 7 days</div>
                 </div>
                 <div>
-                    @php $projected = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0; @endphp
                     <div class="text-2xl font-bold text-gray-400 mb-1">${{ number_format($projected, 2) }}</div>
                     <div class="text-xs text-gray-500">Projected / month</div>
                 </div>
             </div>
         </div>
 
+        {{-- Today: human --}}
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Human Traffic</h2>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-3">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
@@ -202,7 +142,7 @@
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
             </div>
         </div>
-        <div class="grid grid-cols-3 gap-3 mb-6">
+        <div class="grid grid-cols-3 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
@@ -217,8 +157,9 @@
             </div>
         </div>
 
+        {{-- Today: bots --}}
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Bot Traffic</h2>
-        <div class="grid grid-cols-2 gap-3 mb-10">
+        <div class="grid grid-cols-2 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-red-400 mb-1">{{ number_format($botTotal) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Bot Requests</div>
@@ -229,73 +170,9 @@
             </div>
         </div>
 
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-10">
-
-            {{-- By endpoint — human --}}
-            <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Human</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                    @if($tmdb['by_endpoint']->isEmpty())
-                        <div class="px-5 py-6 text-sm text-gray-500">No requests yet today.</div>
-                    @else
-                    <table class="w-full text-sm min-w-[380px]">
-                        <thead>
-                            <tr class="border-b border-white/5">
-                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Total</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Live</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Avg ms</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-white/5">
-                            @foreach($tmdb['by_endpoint'] as $row)
-                            <tr>
-                                <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
-                                <td class="px-4 py-2.5 text-right text-white">{{ $row->total }}</td>
-                                <td class="px-4 py-2.5 text-right text-blue-400">{{ $row->live }}</td>
-                                <td class="px-4 py-2.5 text-right text-green-400">{{ $row->hits }}</td>
-                                <td class="px-4 py-2.5 text-right text-gray-400">{{ $row->avg_ms ? round($row->avg_ms) : '—' }}</td>
-                            </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                    @endif
-                </div>
-            </div>
-
-            {{-- By endpoint — bots --}}
-            <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Bots</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                    @if($tmdb['by_endpoint_bots']->isEmpty())
-                        <div class="px-5 py-6 text-sm text-gray-500">No bot requests today.</div>
-                    @else
-                    <table class="w-full text-sm min-w-[280px]">
-                        <thead>
-                            <tr class="border-b border-white/5">
-                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-white/5">
-                            @foreach($tmdb['by_endpoint_bots'] as $row)
-                            <tr>
-                                <td class="px-4 py-2.5 text-red-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
-                                <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->total) }}</td>
-                            </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                    @endif
-                </div>
-            </div>
-
-        </div>
-
         {{-- Last 7 days --}}
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Last 7 Days</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-10">
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-8">
             @if($tmdb['daily']->isEmpty())
                 <div class="px-5 py-6 text-sm text-gray-500">No data yet.</div>
             @else
@@ -336,16 +213,205 @@
             @endif
         </div>
 
-        {{-- Per-minute activity (last 30 min) --}}
+        {{-- Bots breakdown + Top users side by side --}}
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+
+            @if($tmdb['bots_today']->isNotEmpty())
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Bots — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Bot</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['bots_today'] as $b)
+                            <tr>
+                                <td class="px-4 py-2.5 font-mono text-xs text-red-300">{{ $b->bot }}</td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($b->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+
+            @if($tmdb['top_users']->isNotEmpty())
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Users — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">User</th>
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['top_users'] as $u)
+                            <tr>
+                                <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ $u->label }}</td>
+                                <td class="px-4 py-2.5">
+                                    @if($u->type === 'auth')
+                                        <span class="text-xs px-1.5 py-0.5 rounded-full bg-orange-500/10 text-orange-400 border border-orange-500/20">logged in</span>
+                                    @else
+                                        <span class="text-xs px-1.5 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">anon</span>
+                                    @endif
+                                </td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($u->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+
+        </div>
+
+    {{-- ================================================================ --}}
+    {{-- TMDB TAB                                                          --}}
+    {{-- ================================================================ --}}
+    @else
+
+        @php
+            $today    = $tmdb['today'];
+            $hitRate  = $today->total > 0 ? round(($today->hits / $today->total) * 100) : 0;
+            $rps      = $tmdb['req_per_sec'];
+            $pct      = $tmdb['rate_pct'];
+            $barColor   = $pct >= 75 ? '#ef4444' : ($pct >= 40 ? '#f59e0b' : '#22c55e');
+            $labelColor = $pct >= 75 ? 'text-red-400' : ($pct >= 40 ? 'text-yellow-400' : 'text-green-400');
+            $status     = $pct >= 75 ? 'High' : ($pct >= 40 ? 'Moderate' : 'Safe');
+        @endphp
+
+        {{-- 429 warning --}}
+        @if($today->rate_limited > 0)
+        <div class="mb-6 flex items-center gap-3 bg-red-500/10 border border-red-500/30 rounded-xl px-5 py-4">
+            <span class="text-red-400 text-xl">⚠</span>
+            <div>
+                <div class="text-sm font-semibold text-red-400">Rate limit hit today</div>
+                <div class="text-xs text-red-400/70 mt-0.5">{{ $today->rate_limited }} request{{ $today->rate_limited > 1 ? 's' : '' }} returned 429. TMDB allows ~40 req/sec.</div>
+            </div>
+        </div>
+        @endif
+
+        {{-- Rate limit gauge --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Rate Limit</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-8">
+            <div class="flex items-end justify-between mb-2">
+                <div>
+                    <span class="text-3xl font-bold {{ $labelColor }}">{{ $rps }}</span>
+                    <span class="text-sm text-gray-500 ml-1">req/sec</span>
+                    <span class="ml-3 text-xs font-medium px-2 py-0.5 rounded-full {{ $pct >= 75 ? 'bg-red-500/15 text-red-400 border border-red-500/20' : ($pct >= 40 ? 'bg-yellow-500/15 text-yellow-400 border border-yellow-500/20' : 'bg-green-500/15 text-green-400 border border-green-500/20') }}">{{ $status }}</span>
+                </div>
+                <div class="text-right">
+                    <div class="text-xs text-gray-500">Peak last 30 min</div>
+                    <div class="text-sm font-semibold text-gray-300">{{ $tmdb['peak_req_per_sec'] }} req/sec</div>
+                </div>
+            </div>
+            <div class="relative h-2.5 bg-white/5 rounded-full overflow-hidden">
+                <div class="absolute inset-y-0 left-0 rounded-full transition-all" style="width: {{ $pct }}%; background: {{ $barColor }}"></div>
+                <div class="absolute inset-y-0 w-px bg-red-500/40" style="left: 75%"></div>
+            </div>
+            <div class="flex justify-between mt-1.5 text-xs text-gray-600">
+                <span>0</span>
+                <span class="text-red-500/50">30/s danger zone</span>
+                <span>40/s limit</span>
+            </div>
+            <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4 pt-4 border-t border-white/5">
+                <div>
+                    <div class="text-lg font-bold text-white">{{ $tmdb['last_60s'] }}</div>
+                    <div class="text-xs text-gray-500">Live last 60s</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold text-white">{{ $tmdb['last_5min'] }}</div>
+                    <div class="text-xs text-gray-500">Live last 5 min</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold text-white">{{ round($tmdb['last_5min'] / 5, 1) }}</div>
+                    <div class="text-xs text-gray-500">Avg/min (5 min)</div>
+                </div>
+                <div>
+                    <div class="text-lg font-bold {{ ($today->rate_limited ?? 0) > 0 ? 'text-red-400' : 'text-white' }}">{{ $today->rate_limited ?? 0 }}</div>
+                    <div class="text-xs text-gray-500">429s today</div>
+                </div>
+            </div>
+        </div>
+
+        {{-- By endpoint --}}
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Human</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    @if($tmdb['by_endpoint']->isEmpty())
+                        <div class="px-5 py-6 text-sm text-gray-500">No requests yet today.</div>
+                    @else
+                    <table class="w-full text-sm min-w-[380px]">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Total</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Live</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Avg ms</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['by_endpoint'] as $row)
+                            <tr>
+                                <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
+                                <td class="px-4 py-2.5 text-right text-white">{{ $row->total }}</td>
+                                <td class="px-4 py-2.5 text-right text-blue-400">{{ $row->live }}</td>
+                                <td class="px-4 py-2.5 text-right text-green-400">{{ $row->hits }}</td>
+                                <td class="px-4 py-2.5 text-right text-gray-400">{{ $row->avg_ms ? round($row->avg_ms) : '—' }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @endif
+                </div>
+            </div>
+
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Bots</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    @if($tmdb['by_endpoint_bots']->isEmpty())
+                        <div class="px-5 py-6 text-sm text-gray-500">No bot requests today.</div>
+                    @else
+                    <table class="w-full text-sm min-w-[280px]">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['by_endpoint_bots'] as $row)
+                            <tr>
+                                <td class="px-4 py-2.5 text-red-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
+                                <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        {{-- Activity chart --}}
         @if($tmdb['per_minute']->isNotEmpty())
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3 mt-8">Activity — Last 30 Minutes <span class="normal-case font-normal text-gray-600">(live requests only)</span></h2>
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity — Last 30 Minutes <span class="normal-case font-normal text-gray-600">(live requests only)</span></h2>
         <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-8">
             @php
                 $sorted  = $tmdb['per_minute']->sortBy('minute')->values();
                 $maxLive = $sorted->max('live') ?: 1;
             @endphp
-
-            {{-- Bar chart --}}
             <div class="flex items-end gap-1" style="height: 80px">
                 @foreach($sorted as $m)
                 @php
@@ -356,13 +422,10 @@
                 <div class="flex-1 flex flex-col items-center justify-end gap-0.5 group relative" style="height: 80px">
                     <span class="text-[9px] text-gray-500 group-hover:text-white transition-colors leading-none">{{ $m->live }}</span>
                     <div class="w-full rounded-sm opacity-60 group-hover:opacity-100 transition-opacity"
-                         style="height: {{ $barH }}px; background: {{ $barC }}">
-                    </div>
+                         style="height: {{ $barH }}px; background: {{ $barC }}"></div>
                 </div>
                 @endforeach
             </div>
-
-            {{-- Time labels — show every ~5th to avoid crowding --}}
             @php $total = $sorted->count(); @endphp
             <div class="flex gap-1 mt-1">
                 @foreach($sorted as $i => $m)
@@ -373,15 +436,11 @@
                 </div>
                 @endforeach
             </div>
-
-            {{-- Legend --}}
             <div class="flex items-center gap-4 mt-3 pt-3 border-t border-white/5 text-xs text-gray-500">
                 <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#3b82f6"></span> Safe (&lt;15/min)</span>
                 <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#f59e0b"></span> Moderate (15–30/min)</span>
                 <span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm" style="background:#ef4444"></span> High (&gt;30/min = &gt;0.5/sec)</span>
             </div>
-
-            {{-- Mini table --}}
             <div class="mt-4 overflow-x-auto">
                 <table class="w-full text-xs">
                     <thead>
@@ -403,60 +462,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
-        @endif
-
-        {{-- Bot Breakdown --}}
-        @if($tmdb['bots_today']->isNotEmpty())
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Bots — Today</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-8">
-            <table class="w-full text-sm min-w-[280px]">
-                <thead>
-                    <tr class="border-b border-white/5">
-                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Bot</th>
-                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-white/5">
-                    @foreach($tmdb['bots_today'] as $b)
-                    <tr>
-                        <td class="px-4 py-2.5 font-mono text-xs text-red-300">{{ $b->bot }}</td>
-                        <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($b->total) }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
-        @endif
-
-        {{-- Top Users Today --}}
-        @if($tmdb['top_users']->isNotEmpty())
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Users — Today</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-8">
-            <table class="w-full text-sm min-w-[320px]">
-                <thead>
-                    <tr class="border-b border-white/5">
-                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">User</th>
-                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
-                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-white/5">
-                    @foreach($tmdb['top_users'] as $u)
-                    <tr>
-                        <td class="px-4 py-2.5 text-gray-300 font-mono text-xs">{{ $u->label }}</td>
-                        <td class="px-4 py-2.5">
-                            @if($u->type === 'auth')
-                                <span class="text-xs px-1.5 py-0.5 rounded-full bg-orange-500/10 text-orange-400 border border-orange-500/20">logged in</span>
-                            @else
-                                <span class="text-xs px-1.5 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">anon</span>
-                            @endif
-                        </td>
-                        <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($u->total) }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
         </div>
         @endif
 

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -171,7 +171,7 @@
         @php
             $uniqueTotal = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
         @endphp
-        <div class="grid grid-cols-3 gap-3 mb-10">
+        <div class="grid grid-cols-4 gap-3 mb-10">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
@@ -183,6 +183,10 @@
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-200 mb-1">{{ $today->unique_anon ?? 0 }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Anonymous</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-red-400 mb-1">{{ $today->bot_total ?? 0 }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Bot Requests</div>
             </div>
         </div>
 
@@ -332,6 +336,29 @@
         </div>
         @endif
 
+        {{-- Bot Breakdown --}}
+        @if($tmdb['bots_today']->isNotEmpty())
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Bots — Today</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-8">
+            <table class="w-full text-sm min-w-[280px]">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Bot</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdb['bots_today'] as $b)
+                    <tr>
+                        <td class="px-4 py-2.5 font-mono text-xs text-red-300">{{ $b->bot }}</td>
+                        <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($b->total) }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @endif
+
         {{-- Top Users Today --}}
         @if($tmdb['top_users']->isNotEmpty())
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Users — Today</h2>
@@ -405,7 +432,11 @@
                         </td>
                         <td class="px-4 py-2 text-right text-xs text-gray-500">{{ $log->response_time_ms ?? '—' }}</td>
                         <td class="px-4 py-2 text-xs text-gray-400">
-                            {{ $log->user?->name ?? $log->visitor_hash ?? '—' }}
+                            @if($log->bot)
+                                <span class="px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono">{{ $log->bot }}</span>
+                            @else
+                                {{ $log->user?->name ?? $log->visitor_hash ?? '—' }}
+                            @endif
                         </td>
                     </tr>
                     @endforeach

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -154,27 +154,27 @@
         @endphp
 
         {{-- Revenue estimate --}}
-        <div class="bg-emerald-500/5 border border-emerald-500/20 rounded-xl p-5 mb-6">
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-6">
             <div class="flex items-center justify-between mb-3">
                 <div>
-                    <div class="text-xs font-semibold text-emerald-400 uppercase tracking-widest">Estimated Ad Revenue</div>
-                    <div class="text-xs text-gray-500 mt-0.5">Based on human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM</div>
+                    <div class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Estimated Ad Revenue</div>
+                    <div class="text-xs text-gray-600 mt-0.5">Human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM</div>
                 </div>
                 <div class="text-xs text-gray-600">{{ number_format($humanTotal) }} human requests today</div>
             </div>
             <div class="grid grid-cols-3 gap-4">
                 <div>
-                    <div class="text-2xl font-bold text-emerald-400">${{ number_format($tmdb['revenue_today'], 2) }}</div>
-                    <div class="text-xs text-gray-500 mt-0.5">Today</div>
+                    <div class="text-2xl font-bold text-accent mb-1">${{ number_format($tmdb['revenue_today'], 2) }}</div>
+                    <div class="text-xs text-gray-500">Today</div>
                 </div>
                 <div>
-                    <div class="text-2xl font-bold text-emerald-300">${{ number_format($tmdb['revenue_week'], 2) }}</div>
-                    <div class="text-xs text-gray-500 mt-0.5">Last 7 days</div>
+                    <div class="text-2xl font-bold text-white mb-1">${{ number_format($tmdb['revenue_week'], 2) }}</div>
+                    <div class="text-xs text-gray-500">Last 7 days</div>
                 </div>
                 <div>
                     @php $projected = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0; @endphp
-                    <div class="text-2xl font-bold text-emerald-200">${{ number_format($projected, 2) }}</div>
-                    <div class="text-xs text-gray-500 mt-0.5">Projected / month</div>
+                    <div class="text-2xl font-bold text-gray-400 mb-1">${{ number_format($projected, 2) }}</div>
+                    <div class="text-xs text-gray-500">Projected / month</div>
                 </div>
             </div>
         </div>
@@ -219,12 +219,12 @@
 
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Bot Traffic</h2>
         <div class="grid grid-cols-2 gap-3 mb-10">
-            <div class="bg-red-500/5 border border-red-500/10 rounded-xl p-4">
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-red-400 mb-1">{{ number_format($botTotal) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Bot Requests</div>
             </div>
-            <div class="bg-red-500/5 border border-red-500/10 rounded-xl p-4">
-                <div class="text-2xl font-bold text-red-300 mb-1">{{ $botPct }}%</div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-red-400 mb-1">{{ $botPct }}%</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">% of All Traffic</div>
             </div>
         </div>
@@ -328,7 +328,7 @@
                         <td class="px-4 py-2.5 text-right text-green-400">{{ number_format($row->hits) }}</td>
                         <td class="px-4 py-2.5 text-right text-purple-400">{{ $pct }}%</td>
                         <td class="px-4 py-2.5 text-right text-orange-400">{{ $uniq }}</td>
-                        <td class="px-4 py-2.5 text-right text-emerald-400">${{ number_format($estRev, 2) }}</td>
+                        <td class="px-4 py-2.5 text-right text-accent">${{ number_format($estRev, 2) }}</td>
                     </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -145,33 +145,64 @@
         </div>
 
         {{-- Today's summary --}}
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today</h2>
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-4">
+        @php
+            $humanTotal    = $today->human_total ?? 0;
+            $botTotal      = $today->bot_total ?? 0;
+            $botPct        = ($today->total ?? 0) > 0 ? round(($botTotal / $today->total) * 100) : 0;
+            $humanHitRate  = $humanTotal > 0 ? round((($today->human_hits ?? 0) / $humanTotal) * 100) : 0;
+            $uniqueTotal   = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
+        @endphp
+
+        {{-- Revenue estimate --}}
+        <div class="bg-emerald-500/5 border border-emerald-500/20 rounded-xl p-5 mb-6">
+            <div class="flex items-center justify-between mb-3">
+                <div>
+                    <div class="text-xs font-semibold text-emerald-400 uppercase tracking-widest">Estimated Ad Revenue</div>
+                    <div class="text-xs text-gray-500 mt-0.5">Based on human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM</div>
+                </div>
+                <div class="text-xs text-gray-600">{{ number_format($humanTotal) }} human requests today</div>
+            </div>
+            <div class="grid grid-cols-3 gap-4">
+                <div>
+                    <div class="text-2xl font-bold text-emerald-400">${{ number_format($tmdb['revenue_today'], 2) }}</div>
+                    <div class="text-xs text-gray-500 mt-0.5">Today</div>
+                </div>
+                <div>
+                    <div class="text-2xl font-bold text-emerald-300">${{ number_format($tmdb['revenue_week'], 2) }}</div>
+                    <div class="text-xs text-gray-500 mt-0.5">Last 7 days</div>
+                </div>
+                <div>
+                    @php $projected = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0; @endphp
+                    <div class="text-2xl font-bold text-emerald-200">${{ number_format($projected, 2) }}</div>
+                    <div class="text-xs text-gray-500 mt-0.5">Projected / month</div>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Human Traffic</h2>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-3">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-white mb-1">{{ number_format($today->total ?? 0) }}</div>
+                <div class="text-2xl font-bold text-white mb-1">{{ number_format($humanTotal) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Total</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-blue-400 mb-1">{{ number_format($today->live ?? 0) }}</div>
+                <div class="text-2xl font-bold text-blue-400 mb-1">{{ number_format($today->human_live ?? 0) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Live</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-green-400 mb-1">{{ number_format($today->hits ?? 0) }}</div>
+                <div class="text-2xl font-bold text-green-400 mb-1">{{ number_format($today->human_hits ?? 0) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Cached</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-purple-400 mb-1">{{ $hitRate }}%</div>
+                <div class="text-2xl font-bold text-purple-400 mb-1">{{ $humanHitRate }}%</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Hit Rate</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-yellow-400 mb-1">{{ $today->avg_ms ? round($today->avg_ms) . 'ms' : '—' }}</div>
+                <div class="text-2xl font-bold text-yellow-400 mb-1">{{ $today->human_avg_ms ? round($today->human_avg_ms) . 'ms' : '—' }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
             </div>
         </div>
-        @php
-            $uniqueTotal = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
-        @endphp
-        <div class="grid grid-cols-4 gap-3 mb-10">
+        <div class="grid grid-cols-3 gap-3 mb-6">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
@@ -184,17 +215,25 @@
                 <div class="text-2xl font-bold text-orange-200 mb-1">{{ $today->unique_anon ?? 0 }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Anonymous</div>
             </div>
-            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-red-400 mb-1">{{ $today->bot_total ?? 0 }}</div>
+        </div>
+
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Bot Traffic</h2>
+        <div class="grid grid-cols-2 gap-3 mb-10">
+            <div class="bg-red-500/5 border border-red-500/10 rounded-xl p-4">
+                <div class="text-2xl font-bold text-red-400 mb-1">{{ number_format($botTotal) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Bot Requests</div>
+            </div>
+            <div class="bg-red-500/5 border border-red-500/10 rounded-xl p-4">
+                <div class="text-2xl font-bold text-red-300 mb-1">{{ $botPct }}%</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">% of All Traffic</div>
             </div>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-10">
 
-            {{-- By endpoint --}}
+            {{-- By endpoint — human --}}
             <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Today</h2>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Human</h2>
                 <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
                     @if($tmdb['by_endpoint']->isEmpty())
                         <div class="px-5 py-6 text-sm text-gray-500">No requests yet today.</div>
@@ -225,37 +264,25 @@
                 </div>
             </div>
 
-            {{-- Last 7 days --}}
+            {{-- By endpoint — bots --}}
             <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Last 7 Days</h2>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">By Endpoint — Bots</h2>
                 <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                    @if($tmdb['daily']->isEmpty())
-                        <div class="px-5 py-6 text-sm text-gray-500">No data yet.</div>
+                    @if($tmdb['by_endpoint_bots']->isEmpty())
+                        <div class="px-5 py-6 text-sm text-gray-500">No bot requests today.</div>
                     @else
-                    <table class="w-full text-sm min-w-[380px]">
+                    <table class="w-full text-sm min-w-[280px]">
                         <thead>
                             <tr class="border-b border-white/5">
-                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Date</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Total</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Live</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Hit %</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Uniq</th>
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-white/5">
-                            @foreach($tmdb['daily'] as $row)
-                            @php
-                                $pct   = $row->total > 0 ? round(($row->hits / $row->total) * 100) : 0;
-                                $uniq  = ($row->unique_auth ?? 0) + ($row->unique_anon ?? 0);
-                            @endphp
+                            @foreach($tmdb['by_endpoint_bots'] as $row)
                             <tr>
-                                <td class="px-4 py-2.5 text-gray-300">{{ \Carbon\Carbon::parse($row->date)->format('M j') }}</td>
+                                <td class="px-4 py-2.5 text-red-300 font-mono text-xs">{{ str_replace('_', '/', $row->endpoint) }}</td>
                                 <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->total) }}</td>
-                                <td class="px-4 py-2.5 text-right text-blue-400">{{ number_format($row->live) }}</td>
-                                <td class="px-4 py-2.5 text-right text-green-400">{{ number_format($row->hits) }}</td>
-                                <td class="px-4 py-2.5 text-right text-purple-400">{{ $pct }}%</td>
-                                <td class="px-4 py-2.5 text-right text-orange-400">{{ $uniq }}</td>
                             </tr>
                             @endforeach
                         </tbody>
@@ -264,6 +291,49 @@
                 </div>
             </div>
 
+        </div>
+
+        {{-- Last 7 days --}}
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Last 7 Days</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-10">
+            @if($tmdb['daily']->isEmpty())
+                <div class="px-5 py-6 text-sm text-gray-500">No data yet.</div>
+            @else
+            <table class="w-full text-sm min-w-[520px]">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Date</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Human</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Bots</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Bot %</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Hit %</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Uniq</th>
+                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Est. $</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdb['daily'] as $row)
+                    @php
+                        $pct       = $row->total > 0 ? round(($row->hits / $row->total) * 100) : 0;
+                        $botPctDay = $row->total > 0 ? round((($row->bot_count ?? 0) / $row->total) * 100) : 0;
+                        $uniq      = ($row->unique_auth ?? 0) + ($row->unique_anon ?? 0);
+                        $estRev    = round((($row->human_total ?? 0) / 1000) * $tmdb['rpm'], 2);
+                    @endphp
+                    <tr>
+                        <td class="px-4 py-2.5 text-gray-300">{{ \Carbon\Carbon::parse($row->date)->format('M j') }}</td>
+                        <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->human_total ?? 0) }}</td>
+                        <td class="px-4 py-2.5 text-right text-red-400">{{ number_format($row->bot_count ?? 0) }}</td>
+                        <td class="px-4 py-2.5 text-right {{ $botPctDay >= 40 ? 'text-red-400' : 'text-gray-500' }}">{{ $botPctDay }}%</td>
+                        <td class="px-4 py-2.5 text-right text-green-400">{{ number_format($row->hits) }}</td>
+                        <td class="px-4 py-2.5 text-right text-purple-400">{{ $pct }}%</td>
+                        <td class="px-4 py-2.5 text-right text-orange-400">{{ $uniq }}</td>
+                        <td class="px-4 py-2.5 text-right text-emerald-400">${{ number_format($estRev, 2) }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+            @endif
         </div>
 
         {{-- Per-minute activity (last 30 min) --}}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -407,58 +407,30 @@
             </div>
         </div>
 
-        {{-- Referrers + Transitions side by side --}}
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
-
-            @if($tmdb['referrers']->isNotEmpty())
-            <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Referrers — Today</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                    <table class="w-full text-sm">
-                        <thead>
-                            <tr class="border-b border-white/5">
-                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Source</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Visits</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-white/5">
-                            @foreach($tmdb['referrers'] as $ref)
-                            <tr>
-                                <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $ref->referrer }}</td>
-                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($ref->total) }}</td>
-                            </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                </div>
+        {{-- Top Referrers --}}
+        @if($tmdb['referrers']->isNotEmpty())
+        <div class="mt-8">
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Referrers — Today</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Source</th>
+                            <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Visits</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($tmdb['referrers'] as $ref)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $ref->referrer }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($ref->total) }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
-            @endif
-
-            @if(!empty($tmdb['transitions']))
-            <div>
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top A→B Transitions — Last 7 Days</h2>
-                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                    <table class="w-full text-sm">
-                        <thead>
-                            <tr class="border-b border-white/5">
-                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Flow</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Count</th>
-                            </tr>
-                        </thead>
-                        <tbody class="divide-y divide-white/5">
-                            @foreach($tmdb['transitions'] as $flow => $count)
-                            <tr>
-                                <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
-                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($count) }}</td>
-                            </tr>
-                            @endforeach
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-            @endif
-
         </div>
+        @endif
 
     {{-- ================================================================ --}}
     {{-- TMDB TAB                                                          --}}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -96,6 +96,8 @@
             $humanHitRate = $humanTotal > 0 ? round((($today->human_hits ?? 0) / $humanTotal) * 100) : 0;
             $uniqueTotal  = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
             $projected    = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0;
+            $avgSecs      = $tmdb['avg_session_secs'];
+            $avgDisplay   = $avgSecs !== null ? ($avgSecs >= 60 ? floor($avgSecs/60).'m '.($avgSecs%60).'s' : $avgSecs.'s') : '—';
         @endphp
 
         {{-- Revenue --}}
@@ -119,7 +121,15 @@
         </div>
 
         {{-- Today: human --}}
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Today — Human Traffic</h2>
+        <div class="flex items-center justify-between mb-3">
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Today — Human Traffic</h2>
+            @if($tmdb['active_now'] > 0)
+                <span class="flex items-center gap-1.5 text-xs text-green-400">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></span>
+                    {{ $tmdb['active_now'] }} {{ Str::plural('visitor', $tmdb['active_now']) }} now
+                </span>
+            @endif
+        </div>
         <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-3">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-white mb-1">{{ number_format($humanTotal) }}</div>
@@ -142,7 +152,7 @@
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
             </div>
         </div>
-        <div class="grid grid-cols-3 gap-3 mb-8">
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
@@ -154,6 +164,14 @@
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-200 mb-1">{{ $today->unique_anon ?? 0 }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Anonymous</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-white mb-1">{{ $tmdb['bounce_rate'] !== null ? $tmdb['bounce_rate'].'%' : '—' }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Bounce Rate</div>
+            </div>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
+                <div class="text-2xl font-bold text-white mb-1">{{ $avgDisplay }}</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Session</div>
             </div>
         </div>
 
@@ -353,6 +371,94 @@
             </div>
         </div>
         @endif
+
+        {{-- Hourly heatmap --}}
+        <div class="mt-8">
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity by Hour — Today (Human)</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+                @php
+                    $hourlyMax = $tmdb['hourly']->max('total') ?: 1;
+                    $currentHour = now()->hour;
+                @endphp
+                <div class="flex gap-1 items-end" style="height:60px">
+                    @foreach($tmdb['hourly'] as $h)
+                    @php
+                        $barH   = $h->total > 0 ? max(4, round(($h->total / $hourlyMax) * 52)) : 2;
+                        $isNow  = $h->hour === $currentHour;
+                        $color  = $isNow ? 'var(--color-accent)' : 'rgba(255,255,255,0.15)';
+                        $opacity = $h->total > 0 ? 1 : 0.3;
+                    @endphp
+                    <div class="flex-1 flex flex-col items-center justify-end gap-0.5 group relative" style="height:60px" title="{{ $h->hour }}:00 — {{ $h->total }} views">
+                        <div class="w-full rounded-sm transition-opacity group-hover:opacity-100"
+                             style="height:{{ $barH }}px; background:{{ $color }}; opacity:{{ $opacity }}"></div>
+                    </div>
+                    @endforeach
+                </div>
+                <div class="flex gap-1 mt-1">
+                    @foreach($tmdb['hourly'] as $h)
+                    <div class="flex-1 text-center">
+                        @if($h->hour % 6 === 0)
+                            <span class="text-[9px] text-gray-600">{{ str_pad($h->hour, 2, '0', STR_PAD_LEFT) }}</span>
+                        @endif
+                    </div>
+                    @endforeach
+                </div>
+                <div class="mt-2 text-xs text-gray-600">Current hour highlighted in red · hover bars for counts</div>
+            </div>
+        </div>
+
+        {{-- Referrers + Transitions side by side --}}
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
+
+            @if($tmdb['referrers']->isNotEmpty())
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Referrers — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Source</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Visits</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['referrers'] as $ref)
+                            <tr>
+                                <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $ref->referrer }}</td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($ref->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+
+            @if(!empty($tmdb['transitions']))
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top A→B Transitions — Last 7 Days</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Flow</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Count</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['transitions'] as $flow => $count)
+                            <tr>
+                                <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($count) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+
+        </div>
 
     {{-- ================================================================ --}}
     {{-- TMDB TAB                                                          --}}

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -29,48 +29,6 @@
         </div>
     @endif
 
-    {{-- TMDB Requests (collapsible) --}}
-    @if($tmdbLogs->isNotEmpty())
-    <div class="mb-8">
-        <details class="group">
-            <summary class="flex items-center justify-between cursor-pointer list-none mb-3">
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest">TMDB Requests — Last 30 Days</h2>
-                <div class="flex items-center gap-3 text-xs text-gray-600">
-                    <span>{{ number_format($tmdbLogsTotal) }} total · showing {{ $tmdbLogs->count() }}</span>
-                    <span class="group-open:rotate-180 transition-transform">▾</span>
-                </div>
-            </summary>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                <table class="w-full text-sm">
-                    <thead>
-                        <tr class="border-b border-white/5">
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
-                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($tmdbLogs as $log)
-                        <tr>
-                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
-                            <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
-                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
-                            <td class="px-5 py-2 text-xs">
-                                @if($log->cached)<span class="text-blue-400">hit</span>
-                                @else<span class="text-gray-500">live</span>@endif
-                            </td>
-                            <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </details>
-    </div>
-    @endif
-
     {{-- Page Flow --}}
     @if(!empty($processedSessions))
     <div class="mb-8">
@@ -127,6 +85,44 @@
             </details>
             @endforeach
         </div>
+    </div>
+    @endif
+
+    {{-- TMDB Requests --}}
+    @if($tmdbLogs->isNotEmpty())
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
+            TMDB Requests — Last 30 Days
+            <span class="ml-2 normal-case font-normal text-gray-600">{{ number_format($tmdbLogs->total()) }} total</span>
+        </h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-4">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                        <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdbLogs as $log)
+                    <tr>
+                        <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                        <td class="px-5 py-2 text-xs">
+                            @if($log->cached)<span class="text-blue-400">hit</span>
+                            @else<span class="text-gray-500">live</span>@endif
+                        </td>
+                        <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        {{ $tmdbLogs->links('admin.pagination') }}
     </div>
     @endif
 

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -29,81 +29,90 @@
         </div>
     @endif
 
-    {{-- TMDB Requests --}}
+    {{-- TMDB Requests (collapsible) --}}
     @if($tmdbLogs->isNotEmpty())
     <div class="mb-8">
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">TMDB Requests — Last 30 Days</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-            <table class="w-full text-sm">
-                <thead>
-                    <tr class="border-b border-white/5">
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
-                        <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-white/5">
-                    @foreach($tmdbLogs as $log)
-                    <tr>
-                        <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
-                        <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
-                        <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
-                        <td class="px-5 py-2 text-xs">
-                            @if($log->cached)
-                                <span class="text-blue-400">hit</span>
-                            @else
-                                <span class="text-gray-500">live</span>
-                            @endif
-                        </td>
-                        <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
+        <details class="group">
+            <summary class="flex items-center justify-between cursor-pointer list-none mb-3">
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest">TMDB Requests — Last 30 Days</h2>
+                <div class="flex items-center gap-3 text-xs text-gray-600">
+                    <span>{{ number_format($tmdbLogsTotal) }} total · showing {{ $tmdbLogs->count() }}</span>
+                    <span class="group-open:rotate-180 transition-transform">▾</span>
+                </div>
+            </summary>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($tmdbLogs as $log)
+                        <tr>
+                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                            <td class="px-5 py-2 text-xs">
+                                @if($log->cached)<span class="text-blue-400">hit</span>
+                                @else<span class="text-gray-500">live</span>@endif
+                            </td>
+                            <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </details>
     </div>
     @endif
 
     {{-- Page Flow --}}
     @if(!empty($processedSessions))
     <div class="mb-8">
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Page Flow — Last 30 Days</h2>
-        <div class="space-y-4">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
+            Page Flow — Last 30 Days
+            <span class="ml-2 normal-case font-normal text-gray-600">{{ count($processedSessions) }} {{ Str::plural('session', count($processedSessions)) }}</span>
+        </h2>
+        <div class="space-y-2">
             @foreach($processedSessions as $i => $session)
             @php
                 $mins = floor($session->duration / 60);
                 $secs = $session->duration % 60;
                 $durationStr = $mins > 0 ? "{$mins}m {$secs}s" : "{$secs}s";
             @endphp
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                <div class="px-5 py-3 border-b border-white/5 flex items-center justify-between">
-                    <div>
-                        <span class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Session {{ $i + 1 }}</span>
-                        <span class="ml-3 text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
+            <details class="group bg-white/3 border border-white/5 rounded-xl overflow-hidden" {{ $i === 0 ? 'open' : '' }}>
+                <summary class="flex items-center justify-between px-5 py-3 cursor-pointer list-none hover:bg-white/2 transition-colors">
+                    <div class="flex items-center gap-3">
+                        <span class="text-xs text-gray-600 w-16">Session {{ count($processedSessions) - $i }}</span>
+                        <span class="text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
                     </div>
-                    <div class="flex gap-4 text-xs text-gray-500">
+                    <div class="flex items-center gap-4 text-xs text-gray-500">
                         <span>{{ count($session->pages) }} {{ Str::plural('page', count($session->pages)) }}</span>
                         @if($session->duration > 0)<span>{{ $durationStr }}</span>@endif
+                        <span class="group-open:rotate-180 transition-transform text-gray-600">▾</span>
                     </div>
-                </div>
-                <table class="w-full text-sm">
+                </summary>
+                <table class="w-full text-sm border-t border-white/5">
                     <thead>
                         <tr class="border-b border-white/5">
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Referrer</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">Time on Page</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Referrer</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-right px-5 py-2 text-xs text-gray-500 font-medium">Time on Page</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/5">
                         @foreach($session->pages as $page)
                         <tr>
-                            <td class="px-5 py-2.5 font-mono text-xs text-gray-200">{{ $page->route }}</td>
-                            <td class="px-5 py-2.5 font-mono text-xs text-gray-500">{{ $page->referrer ?? '—' }}</td>
-                            <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
-                            <td class="px-5 py-2.5 text-right text-xs">
+                            <td class="px-5 py-2 font-mono text-xs text-gray-200">{{ $page->route }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $page->referrer ?? '—' }}</td>
+                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
+                            <td class="px-5 py-2 text-right text-xs">
                                 @if($page->time_on_page !== null)
                                     @php $t = $page->time_on_page; @endphp
                                     <span class="text-gray-400">{{ $t >= 60 ? floor($t/60).'m '.($t%60).'s' : $t.'s' }}</span>
@@ -115,7 +124,7 @@
                         @endforeach
                     </tbody>
                 </table>
-            </div>
+            </details>
             @endforeach
         </div>
     </div>

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -29,47 +29,25 @@
         </div>
     @endif
 
-    {{-- Referrers + Transitions + Hourly --}}
-    @if(!empty($referrers) || !empty($transitions) || $hourly->max('total') > 0)
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-
-        @if(!empty($referrers))
-        <div>
-            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                <table class="w-full text-sm">
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($referrers as $domain => $count)
-                        <tr>
-                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
-                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
+    {{-- Referrers + Hourly --}}
+    @if(!empty($referrers) || $hourly->max('total') > 0)
+    @if(!empty($referrers))
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+            <table class="w-full text-sm">
+                <tbody class="divide-y divide-white/5">
+                    @foreach($referrers as $domain => $count)
+                    <tr>
+                        <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
+                        <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
         </div>
-        @endif
-
-        @if(!empty($transitions))
-        <div>
-            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">A→B Transitions</h2>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                <table class="w-full text-sm">
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($transitions as $flow => $count)
-                        <tr>
-                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
-                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        @endif
-
     </div>
+    @endif
 
     @if($hourly->max('total') > 0)
     <div class="mb-8">

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -29,6 +29,98 @@
         </div>
     @endif
 
+    {{-- TMDB Requests --}}
+    @if($tmdbLogs->isNotEmpty())
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">TMDB Requests — Last 30 Days</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                        <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdbLogs as $log)
+                    <tr>
+                        <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                        <td class="px-5 py-2 text-xs">
+                            @if($log->cached)
+                                <span class="text-blue-400">hit</span>
+                            @else
+                                <span class="text-gray-500">live</span>
+                            @endif
+                        </td>
+                        <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @endif
+
+    {{-- Page Flow --}}
+    @if(!empty($processedSessions))
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Page Flow — Last 30 Days</h2>
+        <div class="space-y-4">
+            @foreach($processedSessions as $i => $session)
+            @php
+                $mins = floor($session->duration / 60);
+                $secs = $session->duration % 60;
+                $durationStr = $mins > 0 ? "{$mins}m {$secs}s" : "{$secs}s";
+            @endphp
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <div class="px-5 py-3 border-b border-white/5 flex items-center justify-between">
+                    <div>
+                        <span class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Session {{ $i + 1 }}</span>
+                        <span class="ml-3 text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
+                    </div>
+                    <div class="flex gap-4 text-xs text-gray-500">
+                        <span>{{ count($session->pages) }} {{ Str::plural('page', count($session->pages)) }}</span>
+                        @if($session->duration > 0)<span>{{ $durationStr }}</span>@endif
+                    </div>
+                </div>
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Referrer</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">Time on Page</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($session->pages as $page)
+                        <tr>
+                            <td class="px-5 py-2.5 font-mono text-xs text-gray-200">{{ $page->route }}</td>
+                            <td class="px-5 py-2.5 font-mono text-xs text-gray-500">{{ $page->referrer ?? '—' }}</td>
+                            <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
+                            <td class="px-5 py-2.5 text-right text-xs">
+                                @if($page->time_on_page !== null)
+                                    @php $t = $page->time_on_page; @endphp
+                                    <span class="text-gray-400">{{ $t >= 60 ? floor($t/60).'m '.($t%60).'s' : $t.'s' }}</span>
+                                @else
+                                    <span class="text-gray-600">—</span>
+                                @endif
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
     @if($ordered->flatten()->isEmpty())
         <p class="text-gray-500 text-sm">This user has no roulettes.</p>
     @else

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -29,6 +29,74 @@
         </div>
     @endif
 
+    {{-- Referrers + Transitions + Hourly --}}
+    @if(!empty($referrers) || !empty($transitions) || $hourly->max('total') > 0)
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+
+        @if(!empty($referrers))
+        <div>
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($referrers as $domain => $count)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+        @if(!empty($transitions))
+        <div>
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">A→B Transitions</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($transitions as $flow => $count)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+    </div>
+
+    @if($hourly->max('total') > 0)
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity by Hour — Last 30 Days</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+            @php $hourlyMax = $hourly->max('total') ?: 1; @endphp
+            <div class="flex gap-1 items-end" style="height:48px">
+                @foreach($hourly as $h)
+                @php $barH = $h->total > 0 ? max(3, round(($h->total / $hourlyMax) * 40)) : 2; @endphp
+                <div class="flex-1 rounded-sm" style="height:{{ $barH }}px; background:rgba(255,255,255,{{ $h->total > 0 ? 0.25 : 0.05 }})"
+                     title="{{ $h->hour }}:00 — {{ $h->total }}"></div>
+                @endforeach
+            </div>
+            <div class="flex gap-1 mt-1">
+                @foreach($hourly as $h)
+                <div class="flex-1 text-center">
+                    @if($h->hour % 6 === 0)
+                        <span class="text-[9px] text-gray-600">{{ str_pad($h->hour, 2, '0', STR_PAD_LEFT) }}</span>
+                    @endif
+                </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+    @endif
+    @endif
+
     {{-- Page Flow --}}
     @if(!empty($processedSessions))
     <div class="mb-8">

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -51,7 +51,7 @@
 
     @if($hourly->max('total') > 0)
     <div class="mb-8">
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity by Hour — Last 30 Days</h2>
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Typical Active Hours — Last 30 Days</h2>
         <div class="bg-white/3 border border-white/5 rounded-xl p-5">
             @php $hourlyMax = $hourly->max('total') ?: 1; @endphp
             <div class="flex gap-1 items-end" style="height:48px">

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -75,7 +75,7 @@
 
     @if($hourly->max('total') > 0)
     <div class="mb-8">
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity by Hour — Last 30 Days</h2>
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Typical Active Hours — Last 30 Days</h2>
         <div class="bg-white/3 border border-white/5 rounded-xl p-5">
             @php $hourlyMax = $hourly->max('total') ?: 1; @endphp
             <div class="flex gap-1 items-end" style="height:48px">

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -53,94 +53,101 @@
         </div>
     </div>
 
-    {{-- TMDB Requests --}}
+    {{-- TMDB Requests (collapsible) --}}
     @if($tmdbLogs->isNotEmpty())
     <div class="mb-10">
-        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">TMDB Requests — Last 30 Days</h2>
-        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-            <table class="w-full text-sm">
-                <thead>
-                    <tr class="border-b border-white/5">
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
-                        <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-white/5">
-                    @foreach($tmdbLogs as $log)
-                    <tr>
-                        <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
-                        <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
-                        <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
-                        <td class="px-5 py-2 text-xs">
-                            @if($log->cached)
-                                <span class="text-blue-400">hit</span>
-                            @else
-                                <span class="text-gray-500">live</span>
-                            @endif
-                        </td>
-                        <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
-                    </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
+        <details class="group">
+            <summary class="flex items-center justify-between cursor-pointer list-none mb-3">
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest">TMDB Requests — Last 30 Days</h2>
+                <div class="flex items-center gap-3 text-xs text-gray-600">
+                    <span>{{ number_format($tmdbLogsTotal) }} total · showing {{ $tmdbLogs->count() }}</span>
+                    <span class="group-open:rotate-180 transition-transform">▾</span>
+                </div>
+            </summary>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($tmdbLogs as $log)
+                        <tr>
+                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                            <td class="px-5 py-2 text-xs">
+                                @if($log->cached)<span class="text-blue-400">hit</span>
+                                @else<span class="text-gray-500">live</span>@endif
+                            </td>
+                            <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </details>
     </div>
     @endif
 
-    {{-- Sessions --}}
+    {{-- Page Flow --}}
+    <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
+        Page Flow — Last 30 Days
+        @if(!empty($processedSessions))
+            <span class="ml-2 normal-case font-normal text-gray-600">{{ count($processedSessions) }} {{ Str::plural('session', count($processedSessions)) }}</span>
+        @endif
+    </h2>
+
     @if(empty($processedSessions))
         <div class="bg-white/3 border border-white/5 rounded-xl px-5 py-8 text-sm text-gray-500">
             No page flow recorded yet — page view tracking started recently.
         </div>
     @else
-        <div class="space-y-6">
+        <div class="space-y-2">
             @foreach($processedSessions as $i => $session)
             @php
                 $mins = floor($session->duration / 60);
                 $secs = $session->duration % 60;
                 $durationStr = $mins > 0 ? "{$mins}m {$secs}s" : "{$secs}s";
+                $isFirst = $i === 0;
             @endphp
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                {{-- Session header --}}
-                <div class="px-5 py-3 border-b border-white/5 flex items-center justify-between gap-4">
-                    <div>
-                        <span class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Session {{ $i + 1 }}</span>
-                        <span class="ml-3 text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
+            <details class="group bg-white/3 border border-white/5 rounded-xl overflow-hidden" {{ $isFirst ? 'open' : '' }}>
+                <summary class="flex items-center justify-between px-5 py-3 cursor-pointer list-none hover:bg-white/2 transition-colors">
+                    <div class="flex items-center gap-3">
+                        <span class="text-xs text-gray-600 w-16">Session {{ count($processedSessions) - $i }}</span>
+                        <span class="text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
                     </div>
                     <div class="flex items-center gap-4 text-xs text-gray-500">
                         <span>{{ count($session->pages) }} {{ Str::plural('page', count($session->pages)) }}</span>
-                        @if($session->duration > 0)
-                            <span>{{ $durationStr }}</span>
-                        @endif
+                        @if($session->duration > 0)<span>{{ $durationStr }}</span>@endif
+                        <span class="group-open:rotate-180 transition-transform text-gray-600">▾</span>
                     </div>
-                </div>
+                </summary>
 
-                {{-- Pages table --}}
-                <table class="w-full text-sm">
+                <table class="w-full text-sm border-t border-white/5">
                     <thead>
                         <tr class="border-b border-white/5">
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Referrer</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">Time on Page</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Referrer</th>
+                            <th class="text-left px-5 py-2 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-right px-5 py-2 text-xs text-gray-500 font-medium">Time on Page</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/5">
                         @foreach($session->pages as $page)
                         <tr>
-                            <td class="px-5 py-2.5 font-mono text-xs text-gray-200">{{ $page->route }}</td>
-                            <td class="px-5 py-2.5 text-xs text-gray-500 font-mono">{{ $page->referrer ?? '—' }}</td>
-                            <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
-                            <td class="px-5 py-2.5 text-right text-xs">
+                            <td class="px-5 py-2 font-mono text-xs text-gray-200">{{ $page->route }}</td>
+                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $page->referrer ?? '—' }}</td>
+                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
+                            <td class="px-5 py-2 text-right text-xs">
                                 @if($page->time_on_page !== null)
-                                    @php
-                                        $t = $page->time_on_page;
-                                        $display = $t >= 60 ? floor($t/60) . 'm ' . ($t%60) . 's' : $t . 's';
-                                    @endphp
-                                    <span class="text-gray-400">{{ $display }}</span>
+                                    @php $t = $page->time_on_page; @endphp
+                                    <span class="text-gray-400">{{ $t >= 60 ? floor($t/60).'m '.($t%60).'s' : $t.'s' }}</span>
                                 @else
                                     <span class="text-gray-600">—</span>
                                 @endif
@@ -149,7 +156,7 @@
                         @endforeach
                     </tbody>
                 </table>
-            </div>
+            </details>
             @endforeach
         </div>
     @endif

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -53,10 +53,47 @@
         </div>
     </div>
 
+    {{-- TMDB Requests --}}
+    @if($tmdbLogs->isNotEmpty())
+    <div class="mb-10">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">TMDB Requests — Last 30 Days</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-white/5">
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                        <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                        <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-white/5">
+                    @foreach($tmdbLogs as $log)
+                    <tr>
+                        <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                        <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                        <td class="px-5 py-2 text-xs">
+                            @if($log->cached)
+                                <span class="text-blue-400">hit</span>
+                            @else
+                                <span class="text-gray-500">live</span>
+                            @endif
+                        </td>
+                        <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @endif
+
     {{-- Sessions --}}
     @if(empty($processedSessions))
         <div class="bg-white/3 border border-white/5 rounded-xl px-5 py-8 text-sm text-gray-500">
-            No page views recorded in the last 30 days.
+            No page flow recorded yet — page view tracking started recently.
         </div>
     @else
         <div class="space-y-6">

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -53,47 +53,25 @@
         </div>
     </div>
 
-    {{-- Referrers + Transitions + Hourly --}}
-    @if(!empty($referrers) || !empty($transitions) || $hourly->max('total') > 0)
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-
-        @if(!empty($referrers))
-        <div>
-            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                <table class="w-full text-sm">
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($referrers as $domain => $count)
-                        <tr>
-                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
-                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
+    {{-- Referrers + Hourly --}}
+    @if(!empty($referrers) || $hourly->max('total') > 0)
+    @if(!empty($referrers))
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+            <table class="w-full text-sm">
+                <tbody class="divide-y divide-white/5">
+                    @foreach($referrers as $domain => $count)
+                    <tr>
+                        <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
+                        <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
         </div>
-        @endif
-
-        @if(!empty($transitions))
-        <div>
-            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">A→B Transitions</h2>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
-                <table class="w-full text-sm">
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($transitions as $flow => $count)
-                        <tr>
-                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
-                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        @endif
-
     </div>
+    @endif
 
     @if($hourly->max('total') > 0)
     <div class="mb-8">

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -53,6 +53,74 @@
         </div>
     </div>
 
+    {{-- Referrers + Transitions + Hourly --}}
+    @if(!empty($referrers) || !empty($transitions) || $hourly->max('total') > 0)
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+
+        @if(!empty($referrers))
+        <div>
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">External Referrers</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($referrers as $domain => $count)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $domain }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+        @if(!empty($transitions))
+        <div>
+            <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">A→B Transitions</h2>
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($transitions as $flow => $count)
+                        <tr>
+                            <td class="px-4 py-2.5 font-mono text-xs text-gray-300">{{ $flow }}</td>
+                            <td class="px-4 py-2.5 text-right text-white font-semibold">{{ $count }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @endif
+
+    </div>
+
+    @if($hourly->max('total') > 0)
+    <div class="mb-8">
+        <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Activity by Hour — Last 30 Days</h2>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+            @php $hourlyMax = $hourly->max('total') ?: 1; @endphp
+            <div class="flex gap-1 items-end" style="height:48px">
+                @foreach($hourly as $h)
+                @php $barH = $h->total > 0 ? max(3, round(($h->total / $hourlyMax) * 40)) : 2; @endphp
+                <div class="flex-1 rounded-sm" style="height:{{ $barH }}px; background:rgba(255,255,255,{{ $h->total > 0 ? 0.25 : 0.05 }})"
+                     title="{{ $h->hour }}:00 — {{ $h->total }}"></div>
+                @endforeach
+            </div>
+            <div class="flex gap-1 mt-1">
+                @foreach($hourly as $h)
+                <div class="flex-1 text-center">
+                    @if($h->hour % 6 === 0)
+                        <span class="text-[9px] text-gray-600">{{ str_pad($h->hour, 2, '0', STR_PAD_LEFT) }}</span>
+                    @endif
+                </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+    @endif
+    @endif
+
     {{-- Page Flow --}}
     <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
         Page Flow — Last 30 Days

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -27,8 +27,8 @@
 
     {{-- Summary stats --}}
     @php
-        $sessionCount   = count($processedSessions);
-        $routeCounts    = [];
+        $sessionCount = count($processedSessions);
+        $routeCounts  = [];
         foreach ($processedSessions as $session) {
             foreach ($session->pages as $page) {
                 $routeCounts[$page->route] = ($routeCounts[$page->route] ?? 0) + 1;
@@ -53,73 +53,30 @@
         </div>
     </div>
 
-    {{-- TMDB Requests (collapsible) --}}
-    @if($tmdbLogs->isNotEmpty())
-    <div class="mb-10">
-        <details class="group">
-            <summary class="flex items-center justify-between cursor-pointer list-none mb-3">
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest">TMDB Requests — Last 30 Days</h2>
-                <div class="flex items-center gap-3 text-xs text-gray-600">
-                    <span>{{ number_format($tmdbLogsTotal) }} total · showing {{ $tmdbLogs->count() }}</span>
-                    <span class="group-open:rotate-180 transition-transform">▾</span>
-                </div>
-            </summary>
-            <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                <table class="w-full text-sm">
-                    <thead>
-                        <tr class="border-b border-white/5">
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
-                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
-                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/5">
-                        @foreach($tmdbLogs as $log)
-                        <tr>
-                            <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
-                            <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
-                            <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
-                            <td class="px-5 py-2 text-xs">
-                                @if($log->cached)<span class="text-blue-400">hit</span>
-                                @else<span class="text-gray-500">live</span>@endif
-                            </td>
-                            <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
-                        </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        </details>
-    </div>
-    @endif
-
     {{-- Page Flow --}}
     <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
         Page Flow — Last 30 Days
-        @if(!empty($processedSessions))
-            <span class="ml-2 normal-case font-normal text-gray-600">{{ count($processedSessions) }} {{ Str::plural('session', count($processedSessions)) }}</span>
+        @if($sessionCount)
+            <span class="ml-2 normal-case font-normal text-gray-600">{{ $sessionCount }} {{ Str::plural('session', $sessionCount) }}</span>
         @endif
     </h2>
 
     @if(empty($processedSessions))
-        <div class="bg-white/3 border border-white/5 rounded-xl px-5 py-8 text-sm text-gray-500">
+        <div class="bg-white/3 border border-white/5 rounded-xl px-5 py-8 text-sm text-gray-500 mb-10">
             No page flow recorded yet — page view tracking started recently.
         </div>
     @else
-        <div class="space-y-2">
+        <div class="space-y-2 mb-10">
             @foreach($processedSessions as $i => $session)
             @php
                 $mins = floor($session->duration / 60);
                 $secs = $session->duration % 60;
                 $durationStr = $mins > 0 ? "{$mins}m {$secs}s" : "{$secs}s";
-                $isFirst = $i === 0;
             @endphp
-            <details class="group bg-white/3 border border-white/5 rounded-xl overflow-hidden" {{ $isFirst ? 'open' : '' }}>
+            <details class="group bg-white/3 border border-white/5 rounded-xl overflow-hidden" {{ $i === 0 ? 'open' : '' }}>
                 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer list-none hover:bg-white/2 transition-colors">
                     <div class="flex items-center gap-3">
-                        <span class="text-xs text-gray-600 w-16">Session {{ count($processedSessions) - $i }}</span>
+                        <span class="text-xs text-gray-600 w-16">Session {{ $sessionCount - $i }}</span>
                         <span class="text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
                     </div>
                     <div class="flex items-center gap-4 text-xs text-gray-500">
@@ -128,7 +85,6 @@
                         <span class="group-open:rotate-180 transition-transform text-gray-600">▾</span>
                     </div>
                 </summary>
-
                 <table class="w-full text-sm border-t border-white/5">
                     <thead>
                         <tr class="border-b border-white/5">
@@ -159,6 +115,42 @@
             </details>
             @endforeach
         </div>
+    @endif
+
+    {{-- TMDB Requests --}}
+    @if($tmdbLogs->isNotEmpty())
+    <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">
+        TMDB Requests — Last 30 Days
+        <span class="ml-2 normal-case font-normal text-gray-600">{{ number_format($tmdbLogs->total()) }} total</span>
+    </h2>
+    <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto mb-4">
+        <table class="w-full text-sm">
+            <thead>
+                <tr class="border-b border-white/5">
+                    <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                    <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Endpoint</th>
+                    <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                    <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Cache</th>
+                    <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">ms</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-white/5">
+                @foreach($tmdbLogs as $log)
+                <tr>
+                    <td class="px-5 py-2 text-xs text-gray-500 whitespace-nowrap">{{ $log->created_at->format('M j H:i:s') }}</td>
+                    <td class="px-5 py-2 font-mono text-xs text-gray-300">{{ $log->endpoint }}</td>
+                    <td class="px-5 py-2 font-mono text-xs text-gray-500">{{ $log->route }}</td>
+                    <td class="px-5 py-2 text-xs">
+                        @if($log->cached)<span class="text-blue-400">hit</span>
+                        @else<span class="text-gray-500">live</span>@endif
+                    </td>
+                    <td class="px-5 py-2 text-right text-xs text-gray-500">{{ $log->cached ? '—' : $log->response_time_ms }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+    {{ $tmdbLogs->links('admin.pagination') }}
     @endif
 
 </div>

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -1,0 +1,121 @@
+@extends('layouts.app')
+@section('page_title', 'Visitor ' . substr($hash, 0, 8))
+@section('content')
+<div class="max-w-5xl mx-auto px-4 py-10">
+
+    <div class="mb-6">
+        <a href="{{ route('admin.dashboard', ['tab' => 'traffic']) }}"
+           class="text-xs text-gray-500 hover:text-white transition-colors">
+            ← Back to Traffic
+        </a>
+    </div>
+
+    {{-- Header --}}
+    <div class="mb-8 flex items-center gap-4 flex-wrap">
+        <h1 class="text-2xl font-bold text-white font-mono">{{ $hash }}</h1>
+
+        @if($user)
+            <span class="text-sm text-gray-300">{{ $user->name }}</span>
+        @endif
+
+        @if($bot)
+            <span class="text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400 border border-red-500/20 font-mono">{{ $bot }}</span>
+        @else
+            <span class="text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">human</span>
+        @endif
+    </div>
+
+    {{-- Summary stats --}}
+    @php
+        $sessionCount   = count($processedSessions);
+        $routeCounts    = [];
+        foreach ($processedSessions as $session) {
+            foreach ($session->pages as $page) {
+                $routeCounts[$page->route] = ($routeCounts[$page->route] ?? 0) + 1;
+            }
+        }
+        arsort($routeCounts);
+        $topRoute = array_key_first($routeCounts) ?? '—';
+    @endphp
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+            <div class="text-3xl font-bold text-white mb-1">{{ number_format($total) }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-widest">Total Page Views</div>
+        </div>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+            <div class="text-3xl font-bold text-accent mb-1">{{ $sessionCount }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-widest">Sessions</div>
+        </div>
+        <div class="bg-white/3 border border-white/5 rounded-xl p-5">
+            <div class="text-lg font-bold text-blue-400 mb-1 font-mono truncate">{{ $topRoute }}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-widest">Most Visited Route</div>
+        </div>
+    </div>
+
+    {{-- Sessions --}}
+    @if(empty($processedSessions))
+        <div class="bg-white/3 border border-white/5 rounded-xl px-5 py-8 text-sm text-gray-500">
+            No page views recorded in the last 30 days.
+        </div>
+    @else
+        <div class="space-y-6">
+            @foreach($processedSessions as $i => $session)
+            @php
+                $mins = floor($session->duration / 60);
+                $secs = $session->duration % 60;
+                $durationStr = $mins > 0 ? "{$mins}m {$secs}s" : "{$secs}s";
+            @endphp
+            <div class="bg-white/3 border border-white/5 rounded-xl overflow-hidden">
+                {{-- Session header --}}
+                <div class="px-5 py-3 border-b border-white/5 flex items-center justify-between gap-4">
+                    <div>
+                        <span class="text-xs font-semibold text-gray-500 uppercase tracking-widest">Session {{ $i + 1 }}</span>
+                        <span class="ml-3 text-sm text-gray-300">{{ $session->start->format('M j, Y · H:i') }}</span>
+                    </div>
+                    <div class="flex items-center gap-4 text-xs text-gray-500">
+                        <span>{{ count($session->pages) }} {{ Str::plural('page', count($session->pages)) }}</span>
+                        @if($session->duration > 0)
+                            <span>{{ $durationStr }}</span>
+                        @endif
+                    </div>
+                </div>
+
+                {{-- Pages table --}}
+                <table class="w-full text-sm">
+                    <thead>
+                        <tr class="border-b border-white/5">
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Route</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Referrer</th>
+                            <th class="text-left px-5 py-2.5 text-xs text-gray-500 font-medium">Time</th>
+                            <th class="text-right px-5 py-2.5 text-xs text-gray-500 font-medium">Time on Page</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-white/5">
+                        @foreach($session->pages as $page)
+                        <tr>
+                            <td class="px-5 py-2.5 font-mono text-xs text-gray-200">{{ $page->route }}</td>
+                            <td class="px-5 py-2.5 text-xs text-gray-500 font-mono">{{ $page->referrer ?? '—' }}</td>
+                            <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">{{ $page->created_at->format('H:i:s') }}</td>
+                            <td class="px-5 py-2.5 text-right text-xs">
+                                @if($page->time_on_page !== null)
+                                    @php
+                                        $t = $page->time_on_page;
+                                        $display = $t >= 60 ? floor($t/60) . 'm ' . ($t%60) . 's' : $t . 's';
+                                    @endphp
+                                    <span class="text-gray-400">{{ $display }}</span>
+                                @else
+                                    <span class="text-gray-600">—</span>
+                                @endif
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endforeach
+        </div>
+    @endif
+
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\SwipeController;
 use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Admin\AdminRouletteController;
 use App\Http\Controllers\Admin\AdminUserController;
+use App\Http\Controllers\Admin\AdminVisitorController;
 use App\Http\Controllers\Admin\RowOrderController;
 
 // ── Public pages ─────────────────────────────────────────────────────────────
@@ -152,6 +153,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::get('users/{user}', [AdminUserController::class, 'show'])->name('users.show');
     Route::delete('users/{user}/roulettes/{roulette}', [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
+    Route::get('visitor/{hash}', [AdminVisitorController::class, 'show'])->name('visitor.show');
 });
 
 // ── Dev only ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Bot detection** — UA pattern matching stored on every TMDB request log; human vs bot traffic split throughout the dashboard
- **Admin tab restructure** — Overview renamed to Roulettes, traffic analytics moved to a dedicated Traffic tab, TMDB tab kept for rate-limit/endpoint detail
- **Page view tracking** — `LogPageView` terminable middleware logs all GET requests (humans and bots) to a new `page_views` table; 30-day retention via nightly `analytics:prune` command
- **Visitor detail pages** — `/admin/visitor/{hash}` shows page flow grouped into sessions with time-on-page, TMDB request history, external referrers, A→B transitions, and hourly activity heatmap; all hashes and user names across the dashboard are clickable
- **User profile enriched** — same session/TMDB/referrer/transition data added to `/admin/users/{id}`
- **Traffic tab additions** — active now indicator, bounce rate, avg session length, hourly heatmap, top referrers, A→B transitions, estimated ad revenue (human requests as page view proxy)

## Test plan

- [ ] Run `php artisan migrate` for the two new migrations (`bot` column on `tmdb_request_logs`, `page_views` table)
- [ ] Browse the site and verify page views appear in Traffic → Recent Visitors
- [ ] Check bot badges appear on TMDB → Recent Requests for known crawlers
- [ ] Click a visitor hash from Traffic tab → verify visitor detail page loads with TMDB history
- [ ] Click a user name from TMDB → verify user profile shows TMDB logs and page flow sections
- [ ] Confirm `analytics:prune` is scheduled (`php artisan schedule:list`)