### PR TITLE
Admin: sortable Recent Visitors with AJAX and mobile stat card fix

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -266,7 +266,7 @@ class AdminController extends Controller
                 'hash'       => $row->visitor_hash,
                 'bot'        => $row->bot,
                 'page_count' => $row->page_count,
-                'last_seen'  => $row->last_seen,
+                'last_seen'  => \Carbon\Carbon::parse($row->last_seen)->timestamp,
                 'user_name'  => $user?->name,
                 'user_id'    => $row->user_id,
             ];

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -163,10 +163,11 @@ class AdminController extends Controller
                 ->get();
 
             // Page views: recent unique visitors in last 24h
+            $visitorSort = request('visitor_sort', 'last_seen');
             $recentVisitorRows = PageView::selectRaw('visitor_hash, user_id, bot, COUNT(*) as page_count, MAX(created_at) as last_seen')
                 ->where('created_at', '>=', now()->subHours(24))
                 ->groupBy('visitor_hash', 'user_id', 'bot')
-                ->orderByDesc('last_seen')
+                ->orderByDesc($visitorSort === 'pages' ? 'page_count' : 'last_seen')
                 ->limit(20)
                 ->get();
 

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -163,11 +163,10 @@ class AdminController extends Controller
                 ->get();
 
             // Page views: recent unique visitors in last 24h
-            $visitorSort = request('visitor_sort', 'last_seen');
             $recentVisitorRows = PageView::selectRaw('visitor_hash, user_id, bot, COUNT(*) as page_count, MAX(created_at) as last_seen')
                 ->where('created_at', '>=', now()->subHours(24))
                 ->groupBy('visitor_hash', 'user_id', 'bot')
-                ->orderByDesc($visitorSort === 'pages' ? 'page_count' : 'last_seen')
+                ->orderByDesc('last_seen')
                 ->limit(20)
                 ->get();
 

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -244,4 +244,32 @@ class AdminController extends Controller
 
         return view('admin.dashboard', compact('stats', 'rowOrder', 'activeTab', 'tmdb'));
     }
+
+    public function visitorsData()
+    {
+        $sort    = request('sort', 'last_seen');
+        $orderBy = $sort === 'pages' ? 'page_count' : 'last_seen';
+
+        $rows = PageView::selectRaw('visitor_hash, user_id, bot, COUNT(*) as page_count, MAX(created_at) as last_seen')
+            ->where('created_at', '>=', now()->subHours(24))
+            ->groupBy('visitor_hash', 'user_id', 'bot')
+            ->orderByDesc($orderBy)
+            ->limit(20)
+            ->get();
+
+        $userIds  = $rows->pluck('user_id')->filter()->unique();
+        $usersById = User::whereIn('id', $userIds)->get()->keyBy('id');
+
+        return response()->json($rows->map(function ($row) use ($usersById) {
+            $user = $row->user_id ? ($usersById[$row->user_id] ?? null) : null;
+            return [
+                'hash'       => $row->visitor_hash,
+                'bot'        => $row->bot,
+                'page_count' => $row->page_count,
+                'last_seen'  => $row->last_seen,
+                'user_name'  => $user?->name,
+                'user_id'    => $row->user_id,
+            ];
+        })->values());
+    }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -326,30 +326,25 @@
 
         {{-- Recent Visitors --}}
         @if(!empty($tmdb['recent_visitors']) && $tmdb['recent_visitors']->isNotEmpty())
-        @php
-            $visitorSort = request('visitor_sort', 'last_seen');
-            $sortByPages   = route('admin.dashboard', ['tab' => 'traffic', 'visitor_sort' => 'pages']);
-            $sortByLastSeen = route('admin.dashboard', ['tab' => 'traffic', 'visitor_sort' => 'last_seen']);
-        @endphp
         <div class="mt-8">
             <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Recent Visitors — Last 24h</h2>
             <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
-                <table class="w-full text-sm">
+                <table class="w-full text-sm" id="visitors-table">
                     <thead>
                         <tr class="border-b border-white/5">
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Visitor</th>
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
                             <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">
-                                <a href="{{ $sortByPages }}" class="{{ $visitorSort === 'pages' ? 'text-accent' : 'text-gray-500 hover:text-white' }} transition-colors">Pages ↓</a>
+                                <button type="button" data-sort="pages" class="visitor-sort text-accent transition-colors">Pages ↓</button>
                             </th>
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">
-                                <a href="{{ $sortByLastSeen }}" class="{{ $visitorSort === 'last_seen' ? 'text-accent' : 'text-gray-500 hover:text-white' }} transition-colors">Last Seen ↓</a>
+                                <button type="button" data-sort="last_seen" class="visitor-sort text-gray-500 hover:text-white transition-colors">Last Seen ↓</button>
                             </th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/5">
                         @foreach($tmdb['recent_visitors'] as $v)
-                        <tr>
+                        <tr data-pages="{{ $v->page_count }}" data-ts="{{ \Carbon\Carbon::parse($v->last_seen)->timestamp }}">
                             <td class="px-4 py-2.5">
                                 @if($v->visitor_hash)
                                 <a href="{{ route('admin.visitor.show', $v->visitor_hash) }}" class="group flex items-baseline gap-2">
@@ -699,4 +694,40 @@
     @endif
 
 </div>
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var table = document.getElementById('visitors-table');
+    if (!table) return;
+
+    var activeSort = 'pages';
+
+    document.querySelectorAll('.visitor-sort').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            activeSort = this.dataset.sort;
+
+            document.querySelectorAll('.visitor-sort').forEach(function (b) {
+                b.classList.toggle('text-accent', b.dataset.sort === activeSort);
+                b.classList.toggle('text-gray-500', b.dataset.sort !== activeSort);
+                b.classList.toggle('hover:text-white', b.dataset.sort !== activeSort);
+            });
+
+            var tbody = table.querySelector('tbody');
+            var rows  = Array.from(tbody.querySelectorAll('tr'));
+
+            rows.sort(function (a, b) {
+                if (activeSort === 'pages') {
+                    return parseInt(b.dataset.pages, 10) - parseInt(a.dataset.pages, 10);
+                } else {
+                    return parseInt(b.dataset.ts, 10) - parseInt(a.dataset.ts, 10);
+                }
+            });
+
+            rows.forEach(function (row) { tbody.appendChild(row); });
+        });
+    });
+});
+</script>
+@endsection
 @endsection

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -705,8 +705,8 @@ document.addEventListener('DOMContentLoaded', function () {
     var visitorBase = '{{ url('admin/visitor') }}/';
     var activeSort  = 'last_seen';
 
-    function humanTime(isoString) {
-        var diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+    function humanTime(unixTs) {
+        var diff = Math.floor(Date.now() / 1000) - unixTs;
         if (diff < 60)  { return diff === 1 ? '1 second ago' : diff + ' seconds ago'; }
         var mins = Math.floor(diff / 60);
         if (mins < 60)  { return mins === 1 ? '1 minute ago' : mins + ' minutes ago'; }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -344,7 +344,7 @@
                     </thead>
                     <tbody class="divide-y divide-white/5">
                         @foreach($tmdb['recent_visitors'] as $v)
-                        <tr data-pages="{{ $v->page_count }}" data-ts="{{ \Carbon\Carbon::parse($v->last_seen)->timestamp }}">
+                        <tr>
                             <td class="px-4 py-2.5">
                                 @if($v->visitor_hash)
                                 <a href="{{ route('admin.visitor.show', $v->visitor_hash) }}" class="group flex items-baseline gap-2">
@@ -701,30 +701,66 @@ document.addEventListener('DOMContentLoaded', function () {
     var table = document.getElementById('visitors-table');
     if (!table) return;
 
-    var activeSort = 'pages';
+    var dataUrl     = '{{ route('admin.visitors.data') }}';
+    var visitorBase = '{{ url('admin/visitor') }}/';
+    var activeSort  = 'last_seen';
+
+    function humanTime(isoString) {
+        var diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+        if (diff < 60)   return diff + 's ago';
+        if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+        if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+        return Math.floor(diff / 86400) + 'd ago';
+    }
+
+    function buildRow(v) {
+        var visitorCell;
+        if (v.hash) {
+            var nameSpan = v.user_name
+                ? '<span class="text-xs text-gray-500 group-hover:text-gray-300 transition-colors">' + v.user_name + '</span>'
+                : '';
+            visitorCell = '<a href="' + visitorBase + v.hash + '" class="group flex items-baseline gap-2">'
+                + '<span class="font-mono text-xs text-gray-300 group-hover:text-accent transition-colors">' + v.hash.slice(0, 8) + '</span>'
+                + nameSpan + '</a>';
+        } else {
+            visitorCell = '<span class="font-mono text-xs text-gray-600">unknown</span>';
+        }
+
+        var typeCell;
+        if (v.bot) {
+            var href = v.hash ? visitorBase + v.hash : '#';
+            typeCell = '<a href="' + href + '" class="text-xs px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 border border-red-500/20 font-mono hover:bg-red-500/20 transition-colors">' + v.bot + '</a>';
+        } else {
+            typeCell = '<span class="text-xs px-1.5 py-0.5 rounded-full bg-green-500/10 text-green-400 border border-green-500/20">human</span>';
+        }
+
+        return '<tr>'
+            + '<td class="px-4 py-2.5">' + visitorCell + '</td>'
+            + '<td class="px-4 py-2.5">' + typeCell + '</td>'
+            + '<td class="px-4 py-2.5 text-right text-white font-semibold">' + v.page_count.toLocaleString() + '</td>'
+            + '<td class="px-4 py-2.5 text-xs text-gray-500 whitespace-nowrap">' + humanTime(v.last_seen) + '</td>'
+            + '</tr>';
+    }
+
+    function loadVisitors(sort) {
+        activeSort = sort;
+
+        document.querySelectorAll('.visitor-sort').forEach(function (b) {
+            b.classList.toggle('text-accent',      b.dataset.sort === sort);
+            b.classList.toggle('text-gray-500',    b.dataset.sort !== sort);
+            b.classList.toggle('hover:text-white', b.dataset.sort !== sort);
+        });
+
+        fetch(dataUrl + '?sort=' + sort)
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                table.querySelector('tbody').innerHTML = data.map(buildRow).join('');
+            });
+    }
 
     document.querySelectorAll('.visitor-sort').forEach(function (btn) {
         btn.addEventListener('click', function () {
-            activeSort = this.dataset.sort;
-
-            document.querySelectorAll('.visitor-sort').forEach(function (b) {
-                b.classList.toggle('text-accent', b.dataset.sort === activeSort);
-                b.classList.toggle('text-gray-500', b.dataset.sort !== activeSort);
-                b.classList.toggle('hover:text-white', b.dataset.sort !== activeSort);
-            });
-
-            var tbody = table.querySelector('tbody');
-            var rows  = Array.from(tbody.querySelectorAll('tr'));
-
-            rows.sort(function (a, b) {
-                if (activeSort === 'pages') {
-                    return parseInt(b.dataset.pages, 10) - parseInt(a.dataset.pages, 10);
-                } else {
-                    return parseInt(b.dataset.ts, 10) - parseInt(a.dataset.ts, 10);
-                }
-            });
-
-            rows.forEach(function (row) { tbody.appendChild(row); });
+            loadVisitors(this.dataset.sort);
         });
     });
 });

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -707,10 +707,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function humanTime(isoString) {
         var diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
-        if (diff < 60)   return diff + 's ago';
-        if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
-        if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
-        return Math.floor(diff / 86400) + 'd ago';
+        if (diff < 60)  { return diff === 1 ? '1 second ago' : diff + ' seconds ago'; }
+        var mins = Math.floor(diff / 60);
+        if (mins < 60)  { return mins === 1 ? '1 minute ago' : mins + ' minutes ago'; }
+        var hrs = Math.floor(mins / 60);
+        if (hrs < 24)   { return hrs === 1 ? '1 hour ago' : hrs + ' hours ago'; }
+        var days = Math.floor(hrs / 24);
+        return days === 1 ? '1 day ago' : days + ' days ago';
     }
 
     function buildRow(v) {

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -131,7 +131,7 @@
                 </span>
             @endif
         </div>
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-3">
+        <div class="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-white mb-1">{{ number_format($humanTotal) }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Total</div>
@@ -152,8 +152,6 @@
                 <div class="text-2xl font-bold text-yellow-400 mb-1">{{ $today->human_avg_ms ? round($today->human_avg_ms) . 'ms' : '—' }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
             </div>
-        </div>
-        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
                 <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
@@ -328,6 +326,11 @@
 
         {{-- Recent Visitors --}}
         @if(!empty($tmdb['recent_visitors']) && $tmdb['recent_visitors']->isNotEmpty())
+        @php
+            $visitorSort = request('visitor_sort', 'last_seen');
+            $sortByPages   = route('admin.dashboard', ['tab' => 'traffic', 'visitor_sort' => 'pages']);
+            $sortByLastSeen = route('admin.dashboard', ['tab' => 'traffic', 'visitor_sort' => 'last_seen']);
+        @endphp
         <div class="mt-8">
             <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Recent Visitors — Last 24h</h2>
             <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
@@ -336,8 +339,12 @@
                         <tr class="border-b border-white/5">
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Visitor</th>
                             <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
-                            <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Pages</th>
-                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Last Seen</th>
+                            <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">
+                                <a href="{{ $sortByPages }}" class="{{ $visitorSort === 'pages' ? 'text-accent' : 'text-gray-500 hover:text-white' }} transition-colors">Pages ↓</a>
+                            </th>
+                            <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">
+                                <a href="{{ $sortByLastSeen }}" class="{{ $visitorSort === 'last_seen' ? 'text-accent' : 'text-gray-500 hover:text-white' }} transition-colors">Last Seen ↓</a>
+                            </th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/5">

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,6 +154,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
     Route::get('users/{user}', [AdminUserController::class, 'show'])->name('users.show');
     Route::delete('users/{user}/roulettes/{roulette}', [AdminUserController::class, 'destroyRoulette'])->name('users.roulettes.destroy');
     Route::get('visitor/{hash}', [AdminVisitorController::class, 'show'])->name('visitor.show');
+    Route::get('visitors/data', [AdminController::class, 'visitorsData'])->name('visitors.data');
 });
 
 // ── Dev only ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Recent Visitors table columns (Pages, Last Seen) are now sortable without a page reload — clicking a header fetches fresh data from `/admin/visitors/data?sort=` so the top-20 is correct for the chosen sort, not just the last-seen 20 re-ordered client-side
- Fixed "Last Seen" showing wrong time after sort (raw DB datetime parsed as local time in JS) — server now sends a Unix timestamp to avoid timezone ambiguity
- Merged two separate 5-card stat grids into one 10-card grid (`grid-cols-2 lg:grid-cols-5`) to fix orphaned cards on tablet/mobile

## Test plan
- [ ] Traffic tab → Recent Visitors: click "Pages ↓" — table updates without reload, rows sorted by page count
- [ ] Click "Last Seen ↓" — rows re-sort by recency, active header highlights in accent color
- [ ] "Last Seen" column shows consistent format ("X minutes ago") on load and after sort
- [ ] On mobile/tablet the 10 stat cards display as a clean 2-column grid with no orphaned cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)