### PR TITLE
Analytics: save and display User-Agent on visitor profiles

### DIFF
--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -71,8 +71,9 @@ class AdminVisitorController extends Controller
         $user       = $userRecord ? User::find($userRecord->user_id) : null;
 
         // Bot from first record
-        $bot   = $views->first()?->bot;
-        $total = $views->count();
+        $bot       = $views->first()?->bot;
+        $userAgent = $views->first()?->user_agent;
+        $total     = $views->count();
 
         $tmdbLogs = TmdbRequestLog::where('visitor_hash', $hash)
             ->where('created_at', '>=', now()->subDays(30))
@@ -80,10 +81,11 @@ class AdminVisitorController extends Controller
             ->paginate(25)
             ->withQueryString();
 
-        // Resolve bot/user from tmdb logs if page_views had none
+        // Resolve bot/user/UA from tmdb logs if page_views had none
         if (!$bot && !$user) {
-            $firstLog = $tmdbLogs->first();
-            $bot      = $bot ?? $firstLog?->bot;
+            $firstLog  = $tmdbLogs->first();
+            $bot       = $bot ?? $firstLog?->bot;
+            $userAgent = $userAgent ?? $firstLog?->user_agent;
             if (!$user && $firstLog?->user_id) {
                 $user = User::find($firstLog->user_id);
             }
@@ -113,6 +115,6 @@ class AdminVisitorController extends Controller
             'total' => $hourlyRows->get($h)?->total ?? 0,
         ]);
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'hourly'));
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'userAgent', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'hourly'));
     }
 }

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -81,14 +81,21 @@ class AdminVisitorController extends Controller
             ->paginate(25)
             ->withQueryString();
 
-        // Resolve bot/user/UA from tmdb logs if page_views had none
+        // Resolve bot/user from tmdb logs if page_views had none
         if (!$bot && !$user) {
-            $firstLog  = $tmdbLogs->first();
-            $bot       = $bot ?? $firstLog?->bot;
-            $userAgent = $userAgent ?? $firstLog?->user_agent;
+            $firstLog = $tmdbLogs->first();
+            $bot      = $bot ?? $firstLog?->bot;
             if (!$user && $firstLog?->user_id) {
                 $user = User::find($firstLog->user_id);
             }
+        }
+
+        // UA: always fall back to tmdb logs if page_views didn't have one
+        if (!$userAgent) {
+            $userAgent = TmdbRequestLog::where('visitor_hash', $hash)
+                ->whereNotNull('user_agent')
+                ->orderByDesc('created_at')
+                ->value('user_agent');
         }
 
         // External referrers for this visitor

--- a/app/Http/Controllers/Admin/AdminVisitorController.php
+++ b/app/Http/Controllers/Admin/AdminVisitorController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\PageView;
 use App\Models\TmdbRequestLog;
 use App\Models\User;
+use App\Support\UAParser;
 
 class AdminVisitorController extends Controller
 {
@@ -122,6 +123,8 @@ class AdminVisitorController extends Controller
             'total' => $hourlyRows->get($h)?->total ?? 0,
         ]);
 
-        return view('admin.visitor', compact('hash', 'user', 'bot', 'userAgent', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'hourly'));
+        $parsedUA = UAParser::parse($userAgent);
+
+        return view('admin.visitor', compact('hash', 'user', 'bot', 'userAgent', 'parsedUA', 'processedSessions', 'total', 'tmdbLogs', 'referrers', 'hourly'));
     }
 }

--- a/app/Http/Middleware/LogPageView.php
+++ b/app/Http/Middleware/LogPageView.php
@@ -62,6 +62,7 @@ class LogPageView
                 'bot'          => $bot,
                 'route'        => $route,
                 'referrer'     => $referrer,
+                'user_agent'   => substr($request->userAgent() ?? '', 0, 512) ?: null,
             ]);
         } catch (\Throwable) {
             // Never break requests

--- a/app/Models/PageView.php
+++ b/app/Models/PageView.php
@@ -14,6 +14,7 @@ class PageView extends Model
         'bot',
         'route',
         'referrer',
+        'user_agent',
     ];
 
     public function user()

--- a/app/Models/TmdbRequestLog.php
+++ b/app/Models/TmdbRequestLog.php
@@ -17,6 +17,7 @@ class TmdbRequestLog extends Model
         'user_id',
         'visitor_hash',
         'bot',
+        'user_agent',
     ];
 
     protected $casts = [

--- a/app/Services/TmdbClient.php
+++ b/app/Services/TmdbClient.php
@@ -463,6 +463,7 @@ class TmdbClient implements ApiMovie
                 'user_id'          => auth()->id(),
                 'visitor_hash'     => $this->visitorHash(),
                 'bot'              => $this->detectBot(),
+                'user_agent'       => substr(request()->userAgent() ?? '', 0, 512) ?: null,
             ]);
         } catch (\Throwable) {
             // Never let logging break a request

--- a/app/Support/UAParser.php
+++ b/app/Support/UAParser.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Support;
+
+class UAParser
+{
+    public static function parse(?string $ua): ?object
+    {
+        if (!$ua) return null;
+
+        return (object) [
+            'browser' => self::browser($ua),
+            'os'      => self::os($ua),
+            'device'  => self::device($ua),
+            'raw'     => $ua,
+        ];
+    }
+
+    private static function browser(string $ua): string
+    {
+        if (preg_match('/Edg\/(\d+)/', $ua, $m))             return 'Edge ' . $m[1];
+        if (preg_match('/OPR\/(\d+)/', $ua, $m))             return 'Opera ' . $m[1];
+        if (preg_match('/SamsungBrowser\/(\d+)/', $ua, $m))  return 'Samsung Browser ' . $m[1];
+        if (preg_match('/Firefox\/(\d+)/', $ua, $m))         return 'Firefox ' . $m[1];
+        if (preg_match('/Chrome\/(\d+)/', $ua, $m))          return 'Chrome ' . $m[1];
+        if (preg_match('/Version\/(\d+).*Safari/', $ua, $m)) return 'Safari ' . $m[1];
+        if (preg_match('/curl\/([^\s]+)/', $ua, $m))         return 'curl ' . $m[1];
+        if (preg_match('/python-requests\/([^\s]+)/', $ua, $m)) return 'python-requests ' . $m[1];
+        if (preg_match('/Go-http-client\/([^\s]+)/', $ua, $m))  return 'Go HTTP ' . $m[1];
+        if (preg_match('/axios\/([^\s]+)/', $ua, $m))           return 'axios ' . $m[1];
+        if (preg_match('/node-fetch\/([^\s]+)/', $ua, $m))      return 'node-fetch ' . $m[1];
+
+        // Truncate unknown UAs to first meaningful token
+        $first = explode(' ', trim($ua))[0];
+        return strlen($first) > 30 ? substr($first, 0, 30) . '…' : $first;
+    }
+
+    private static function os(string $ua): string
+    {
+        if (preg_match('/Windows NT (\d+\.\d+)/', $ua, $m)) {
+            $map = ['10.0' => 'Windows 10/11', '6.3' => 'Windows 8.1', '6.2' => 'Windows 8', '6.1' => 'Windows 7'];
+            return $map[$m[1]] ?? 'Windows';
+        }
+        if (preg_match('/iPhone OS ([\d_]+)/', $ua, $m))   return 'iOS ' . str_replace('_', '.', $m[1]);
+        if (preg_match('/CPU OS ([\d_]+)/', $ua, $m))      return 'iOS ' . str_replace('_', '.', $m[1]);
+        if (preg_match('/Android (\d+)/', $ua, $m))        return 'Android ' . $m[1];
+        if (preg_match('/Mac OS X ([\d_]+)/', $ua, $m))    return 'macOS ' . str_replace('_', '.', $m[1]);
+        if (str_contains($ua, 'Linux'))                     return 'Linux';
+        return '';
+    }
+
+    private static function device(string $ua): string
+    {
+        if (str_contains($ua, 'iPad'))                              return 'Tablet';
+        if (str_contains($ua, 'iPhone'))                            return 'Mobile';
+        if (preg_match('/Android/', $ua) && str_contains($ua, 'Mobile')) return 'Mobile';
+        if (preg_match('/Android/', $ua))                           return 'Tablet';
+        if (preg_match('/Windows|Macintosh|Linux/', $ua))           return 'Desktop';
+        return '';
+    }
+}

--- a/database/migrations/2026_06_15_210000_add_user_agent_to_page_views_table.php
+++ b/database/migrations/2026_06_15_210000_add_user_agent_to_page_views_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('page_views', function (Blueprint $table) {
+            $table->string('user_agent', 512)->nullable()->after('referrer');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('page_views', function (Blueprint $table) {
+            $table->dropColumn('user_agent');
+        });
+    }
+};

--- a/database/migrations/2026_06_15_210001_add_user_agent_to_tmdb_request_logs_table.php
+++ b/database/migrations/2026_06_15_210001_add_user_agent_to_tmdb_request_logs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->string('user_agent', 512)->nullable()->after('bot');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tmdb_request_logs', function (Blueprint $table) {
+            $table->dropColumn('user_agent');
+        });
+    }
+};

--- a/database/seeders/UserAgentSeeder.php
+++ b/database/seeders/UserAgentSeeder.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\PageView;
+use App\Models\TmdbRequestLog;
+use Illuminate\Database\Seeder;
+
+class UserAgentSeeder extends Seeder
+{
+    private array $humanUAs = [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36',
+        'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 OPR/111.0.0.0',
+    ];
+
+    private array $botUAs = [
+        'Googlebot'              => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        'Bingbot'                => 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+        'AhrefsBot'              => 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+        'SemrushBot'             => 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
+        'DotBot'                 => 'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot)',
+        'MJ12bot'                => 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)',
+        'no-accept-language'     => 'python-requests/2.31.0',
+        'no-accept-language'     => 'Go-http-client/1.1',
+        'no-accept-language'     => 'curl/8.4.0',
+        'no-accept-language'     => 'axios/1.6.8',
+    ];
+
+    public function run(): void
+    {
+        // Update page_views: assign a UA per visitor_hash so each visitor is consistent
+        $hashes = PageView::whereNull('user_agent')
+            ->select('visitor_hash', 'bot')
+            ->distinct()
+            ->get();
+
+        foreach ($hashes as $row) {
+            $ua = $this->uaForBot($row->bot);
+            PageView::where('visitor_hash', $row->visitor_hash)
+                ->whereNull('user_agent')
+                ->update(['user_agent' => $ua]);
+        }
+
+        // Also patch any null-hash rows
+        PageView::whereNull('visitor_hash')->whereNull('user_agent')->update([
+            'user_agent' => $this->randomHuman(),
+        ]);
+
+        // Update tmdb_request_logs the same way
+        $hashes = TmdbRequestLog::whereNull('user_agent')
+            ->select('visitor_hash', 'bot')
+            ->distinct()
+            ->get();
+
+        foreach ($hashes as $row) {
+            $ua = $this->uaForBot($row->bot);
+            TmdbRequestLog::where('visitor_hash', $row->visitor_hash)
+                ->whereNull('user_agent')
+                ->update(['user_agent' => $ua]);
+        }
+
+        TmdbRequestLog::whereNull('visitor_hash')->whereNull('user_agent')->update([
+            'user_agent' => $this->randomHuman(),
+        ]);
+
+        $pv  = PageView::whereNotNull('user_agent')->count();
+        $trl = TmdbRequestLog::whereNotNull('user_agent')->count();
+        $this->command->info("Seeded UAs: {$pv} page_views, {$trl} tmdb_request_logs");
+    }
+
+    private function uaForBot(?string $bot): string
+    {
+        if (!$bot) {
+            return $this->randomHuman();
+        }
+
+        foreach ($this->botUAs as $name => $ua) {
+            if (str_contains($bot, $name) || str_contains($name, $bot)) {
+                return $ua;
+            }
+        }
+
+        // Generic no-accept-language / unknown bot
+        return collect([
+            'python-requests/2.31.0',
+            'Go-http-client/1.1',
+            'curl/8.4.0',
+            'axios/1.6.8',
+            'node-fetch/3.3.2',
+        ])->random();
+    }
+
+    private function randomHuman(): string
+    {
+        return $this->humanUAs[array_rand($this->humanUAs)];
+    }
+}

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -25,6 +25,13 @@
         @endif
     </div>
 
+    @if($userAgent)
+    <div class="mb-8">
+        <div class="text-xs text-gray-600 uppercase tracking-widest mb-1">User Agent</div>
+        <div class="font-mono text-xs text-gray-400 bg-white/3 border border-white/5 rounded-lg px-4 py-2.5 break-all">{{ $userAgent }}</div>
+    </div>
+    @endif
+
     {{-- Summary stats --}}
     @php
         $sessionCount = count($processedSessions);

--- a/resources/views/admin/visitor.blade.php
+++ b/resources/views/admin/visitor.blade.php
@@ -25,10 +25,24 @@
         @endif
     </div>
 
-    @if($userAgent)
+    @if($parsedUA)
     <div class="mb-8">
-        <div class="text-xs text-gray-600 uppercase tracking-widest mb-1">User Agent</div>
-        <div class="font-mono text-xs text-gray-400 bg-white/3 border border-white/5 rounded-lg px-4 py-2.5 break-all">{{ $userAgent }}</div>
+        <div class="text-xs text-gray-600 uppercase tracking-widest mb-2">Device</div>
+        <div class="flex flex-wrap items-center gap-2 mb-2">
+            @if($parsedUA->browser)
+                <span class="text-xs px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-gray-300">{{ $parsedUA->browser }}</span>
+            @endif
+            @if($parsedUA->os)
+                <span class="text-xs px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-gray-300">{{ $parsedUA->os }}</span>
+            @endif
+            @if($parsedUA->device)
+                <span class="text-xs px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-gray-400">{{ $parsedUA->device }}</span>
+            @endif
+        </div>
+        <details class="group">
+            <summary class="text-xs text-gray-600 cursor-pointer hover:text-gray-400 transition-colors list-none">Raw UA <span class="group-open:hidden">▸</span><span class="hidden group-open:inline">▾</span></summary>
+            <div class="font-mono text-xs text-gray-600 bg-white/3 border border-white/5 rounded-lg px-4 py-2.5 break-all mt-2">{{ $parsedUA->raw }}</div>
+        </details>
     </div>
     @endif
 


### PR DESCRIPTION
## Summary
- Adds `user_agent` (varchar 512, nullable) to both `page_views` and `tmdb_request_logs`
- `LogPageView` middleware and `TmdbClient` now save the raw UA on every request
- Visitor profile page (`/admin/visitor/{hash}`) parses the UA into readable browser/OS/device pill badges with the raw string collapsible below
- Falls back to `tmdb_request_logs` for the UA if `page_views` has none (e.g. bot that never triggered a page view)
- Includes `UserAgentSeeder` to backfill existing records — run `php artisan db:seed --class=UserAgentSeeder` on prod after deploying
- User profile page intentionally excluded — a user may visit from multiple devices so a breakdown per-device makes more sense there (future)

## Test plan
- [ ] Visit any page, then open its visitor hash in the Traffic tab — UA pill badges appear (browser · OS · device)
- [ ] "Raw UA ▸" toggle expands the full UA string
- [ ] Bots show a simplified label (`curl 8.4`, `python-requests 2.31`, etc.)
- [ ] Visitor with only TMDB logs (no page views) still shows a UA