### PR TITLE
Decouple traffic tab from TMDB logs

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -24,7 +24,7 @@ class AdminController extends Controller
         $activeTab  = request('tab', 'roulettes');
         $tmdb       = [];
 
-        if (in_array($activeTab, ['tmdb', 'traffic'])) {
+        if ($activeTab === 'tmdb') {
             $today     = now()->toDateString();
             $sevenDays = now()->subDays(6)->startOfDay();
 
@@ -57,19 +57,16 @@ class AdminController extends Controller
                 ->orderByDesc('total')
                 ->get();
 
-            // Short-window live request counts for rate limit monitoring
             $tmdb['last_60s']  = TmdbRequestLog::where('cached', false)
                 ->where('created_at', '>=', now()->subSeconds(60))->count();
 
             $tmdb['last_5min'] = TmdbRequestLog::where('cached', false)
                 ->where('created_at', '>=', now()->subMinutes(5))->count();
 
-            // Current avg req/sec (live only, over last 60s) vs TMDB limit of 40/s
             $tmdb['req_per_sec']    = round($tmdb['last_60s'] / 60, 2);
             $tmdb['rate_limit_max'] = 40;
             $tmdb['rate_pct']       = min(100, round(($tmdb['req_per_sec'] / 40) * 100));
 
-            // Per-minute breakdown for last 30 minutes (live requests only)
             $tmdb['per_minute'] = TmdbRequestLog::selectRaw("
                 DATE_FORMAT(created_at, '%H:%i') as minute,
                 COUNT(*) as live
@@ -79,7 +76,6 @@ class AdminController extends Controller
               ->orderByDesc('minute')
               ->get();
 
-            // Peak req/sec in last 30 min (max live requests in any single minute / 60)
             $tmdb['peak_req_per_sec'] = $tmdb['per_minute']->max('live')
                 ? round($tmdb['per_minute']->max('live') / 60, 2)
                 : 0;
@@ -108,11 +104,6 @@ class AdminController extends Controller
               ->groupByRaw('DATE(created_at)')
               ->orderByDesc('date')
               ->get();
-
-            $rpm = 1.50;
-            $tmdb['rpm']           = $rpm;
-            $tmdb['revenue_today'] = round((($tmdb['today']->human_total ?? 0) / 1000) * $rpm, 2);
-            $tmdb['revenue_week']  = round(($tmdb['daily']->sum('human_total') / 1000) * $rpm, 2);
 
             $topAuth = TmdbRequestLog::selectRaw('user_id, COUNT(*) as total')
                 ->whereDate('created_at', $today)
@@ -149,11 +140,87 @@ class AdminController extends Controller
 
             $tmdb['top_users'] = $topAuth->concat($topAnon)->sortByDesc('total')->take(10)->values();
 
-            // Bot page views today (from page_views, not tmdb_request_logs)
+            $tmdb['recent'] = TmdbRequestLog::with('user')
+                ->orderByDesc('id')
+                ->paginate(25)
+                ->appends(['tab' => 'tmdb']);
+        }
+
+        if ($activeTab === 'traffic') {
+            $today     = now()->toDateString();
+            $sevenDays = now()->subDays(6)->startOfDay();
+            $rpm = 1.50;
+            $tmdb['rpm'] = $rpm;
+
+            $tmdb['traffic_today'] = PageView::selectRaw('
+                SUM(CASE WHEN bot IS NULL THEN 1 ELSE 0 END) as human_total,
+                SUM(CASE WHEN bot IS NOT NULL THEN 1 ELSE 0 END) as bot_total,
+                COUNT(DISTINCT CASE WHEN bot IS NULL AND user_id IS NOT NULL THEN user_id END) as unique_auth,
+                COUNT(DISTINCT CASE WHEN bot IS NULL AND user_id IS NULL THEN visitor_hash END) as unique_anon
+            ')->whereDate('created_at', $today)->first();
+
+            $tmdb['revenue_today'] = round((($tmdb['traffic_today']->human_total ?? 0) / 1000) * $rpm, 2);
+
+            $tmdb['daily'] = PageView::selectRaw('
+                DATE(created_at) as date,
+                SUM(CASE WHEN bot IS NULL THEN 1 ELSE 0 END) as human_total,
+                SUM(CASE WHEN bot IS NOT NULL THEN 1 ELSE 0 END) as bot_count,
+                COUNT(DISTINCT CASE WHEN bot IS NULL AND user_id IS NOT NULL THEN user_id END) as unique_auth,
+                COUNT(DISTINCT CASE WHEN bot IS NULL AND user_id IS NULL THEN visitor_hash END) as unique_anon
+            ')->where('created_at', '>=', $sevenDays)
+              ->groupByRaw('DATE(created_at)')
+              ->orderByDesc('date')
+              ->get();
+
+            $tmdb['revenue_week'] = round(($tmdb['daily']->sum('human_total') / 1000) * $rpm, 2);
+
+            $tmdb['bots_today'] = PageView::selectRaw('bot, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNotNull('bot')
+                ->groupBy('bot')
+                ->orderByDesc('total')
+                ->get();
+
+            $topAuth = PageView::selectRaw('user_id, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNotNull('user_id')
+                ->whereNull('bot')
+                ->groupBy('user_id')
+                ->orderByDesc('total')
+                ->limit(10)
+                ->get();
+
+            $authUsers = User::whereIn('id', $topAuth->pluck('user_id'))->get()->keyBy('id');
+            $topAuth = $topAuth->map(fn($r) => (object)[
+                'label'   => $authUsers[$r->user_id]?->name ?? "User #{$r->user_id}",
+                'type'    => 'auth',
+                'total'   => $r->total,
+                'user_id' => $r->user_id,
+                'hash'    => null,
+            ]);
+
+            $topAnon = PageView::selectRaw('visitor_hash, COUNT(*) as total')
+                ->whereDate('created_at', $today)
+                ->whereNull('user_id')
+                ->whereNull('bot')
+                ->whereNotNull('visitor_hash')
+                ->groupBy('visitor_hash')
+                ->orderByDesc('total')
+                ->limit(10)
+                ->get()
+                ->map(fn($r) => (object)[
+                    'label'   => $r->visitor_hash,
+                    'type'    => 'anon',
+                    'total'   => $r->total,
+                    'user_id' => null,
+                    'hash'    => $r->visitor_hash,
+                ]);
+
+            $tmdb['top_users'] = $topAuth->concat($topAnon)->sortByDesc('total')->take(10)->values();
+
             $tmdb['bot_pages_today']   = PageView::whereDate('created_at', $today)->whereNotNull('bot')->count();
             $tmdb['human_pages_today'] = PageView::whereDate('created_at', $today)->whereNull('bot')->count();
 
-            // Page views: top pages today (human only)
             $tmdb['top_pages'] = PageView::selectRaw('route, COUNT(*) as total')
                 ->whereDate('created_at', $today)
                 ->whereNull('bot')
@@ -162,7 +229,6 @@ class AdminController extends Controller
                 ->limit(10)
                 ->get();
 
-            // Page views: recent unique visitors in last 24h
             $recentVisitorRows = PageView::selectRaw('visitor_hash, user_id, bot, COUNT(*) as page_count, MAX(created_at) as last_seen')
                 ->where('created_at', '>=', now()->subHours(24))
                 ->groupBy('visitor_hash', 'user_id', 'bot')
@@ -170,8 +236,7 @@ class AdminController extends Controller
                 ->limit(20)
                 ->get();
 
-            // Eager-load users separately
-            $userIds = $recentVisitorRows->pluck('user_id')->filter()->unique()->values();
+            $userIds   = $recentVisitorRows->pluck('user_id')->filter()->unique()->values();
             $usersById = User::whereIn('id', $userIds)->get()->keyBy('id');
 
             $tmdb['recent_visitors'] = $recentVisitorRows->map(function ($row) use ($usersById) {
@@ -179,13 +244,11 @@ class AdminController extends Controller
                 return $row;
             });
 
-            // Active now: unique human visitors in last 10 minutes
             $tmdb['active_now'] = PageView::whereNull('bot')
                 ->where('created_at', '>=', now()->subMinutes(10))
                 ->distinct('visitor_hash')
                 ->count('visitor_hash');
 
-            // Hourly traffic today (human only) — fill all 24 hours
             $hourlyRows = PageView::selectRaw('HOUR(created_at) as hour, COUNT(*) as total')
                 ->whereDate('created_at', $today)
                 ->whereNull('bot')
@@ -197,7 +260,6 @@ class AdminController extends Controller
                 'total' => $hourlyRows->get($h)?->total ?? 0,
             ]);
 
-            // Top external referrers today (external = stored as domain, not /path)
             $tmdb['referrers'] = PageView::selectRaw('referrer, COUNT(*) as total')
                 ->whereDate('created_at', $today)
                 ->whereNull('bot')
@@ -208,7 +270,6 @@ class AdminController extends Controller
                 ->limit(10)
                 ->get();
 
-            // Bounce rate + avg session length from today's page views
             $todayViews = PageView::whereDate('created_at', $today)
                 ->whereNull('bot')
                 ->whereNotNull('visitor_hash')
@@ -235,11 +296,6 @@ class AdminController extends Controller
             $bounced   = count(array_filter($sessionStats, fn($s) => $s['pages'] === 1));
             $tmdb['bounce_rate']      = $totalSess > 0 ? round(($bounced / $totalSess) * 100) : null;
             $tmdb['avg_session_secs'] = $totalSess > 0 ? (int) round(array_sum(array_column($sessionStats, 'secs')) / $totalSess) : null;
-
-            $tmdb['recent'] = TmdbRequestLog::with('user')
-                ->orderByDesc('id')
-                ->paginate(25)
-                ->appends(['tab' => 'tmdb']);
         }
 
         return view('admin.dashboard', compact('stats', 'rowOrder', 'activeTab', 'tmdb'));

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -89,12 +89,10 @@
     @elseif($activeTab === 'traffic')
 
         @php
-            $today        = $tmdb['today'];
+            $today        = $tmdb['traffic_today'];
             $humanTotal   = $today->human_total ?? 0;
-            $botTotal     = $today->bot_total ?? 0;
             $botPageTotal  = $tmdb['bot_pages_today'] + $tmdb['human_pages_today'];
             $botPct        = $botPageTotal > 0 ? number_format(($tmdb['bot_pages_today'] / $botPageTotal) * 100, 2) : '0.00';
-            $humanHitRate = $humanTotal > 0 ? round((($today->human_hits ?? 0) / $humanTotal) * 100) : 0;
             $uniqueTotal  = ($today->unique_auth ?? 0) + ($today->unique_anon ?? 0);
             $projected    = $tmdb['revenue_week'] > 0 ? round(($tmdb['revenue_week'] / 7) * 30, 2) : 0;
             $avgSecs      = $tmdb['avg_session_secs'];
@@ -104,7 +102,7 @@
         {{-- Revenue --}}
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Estimated Ad Revenue</h2>
         <div class="bg-white/3 border border-white/5 rounded-xl p-5 mb-8">
-            <div class="text-xs text-gray-600 mb-4">Human requests as page view proxy @ ${{ $tmdb['rpm'] }} RPM &middot; {{ number_format($humanTotal) }} human requests today</div>
+            <div class="text-xs text-gray-600 mb-4">Human page views @ ${{ $tmdb['rpm'] }} RPM &middot; {{ number_format($humanTotal) }} human page views today</div>
             <div class="grid grid-cols-3 gap-4">
                 <div>
                     <div class="text-2xl font-bold text-accent mb-1">${{ number_format($tmdb['revenue_today'], 2) }}</div>
@@ -131,30 +129,14 @@
                 </span>
             @endif
         </div>
-        <div class="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-8">
+        <div class="grid grid-cols-2 lg:grid-cols-3 gap-3 mb-8">
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-white mb-1">{{ number_format($humanTotal) }}</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Total</div>
-            </div>
-            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-blue-400 mb-1">{{ number_format($today->human_live ?? 0) }}</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Live</div>
-            </div>
-            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-green-400 mb-1">{{ number_format($today->human_hits ?? 0) }}</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Cached</div>
-            </div>
-            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-purple-400 mb-1">{{ $humanHitRate }}%</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Hit Rate</div>
-            </div>
-            <div class="bg-white/3 border border-white/5 rounded-xl p-4">
-                <div class="text-2xl font-bold text-yellow-400 mb-1">{{ $today->human_avg_ms ? round($today->human_avg_ms) . 'ms' : '—' }}</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Avg Response</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Page Views</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-400 mb-1">{{ $uniqueTotal }}</div>
-                <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Users</div>
+                <div class="text-xs text-gray-500 uppercase tracking-widest">Unique Visitors</div>
             </div>
             <div class="bg-white/3 border border-white/5 rounded-xl p-4">
                 <div class="text-2xl font-bold text-orange-300 mb-1">{{ $today->unique_auth ?? 0 }}</div>
@@ -200,8 +182,6 @@
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Human</th>
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Bots</th>
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Bot %</th>
-                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Cached</th>
-                        <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Hit %</th>
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Uniq</th>
                         <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Est. $</th>
                     </tr>
@@ -209,8 +189,8 @@
                 <tbody class="divide-y divide-white/5">
                     @foreach($tmdb['daily'] as $row)
                     @php
-                        $pct       = $row->total > 0 ? round(($row->hits / $row->total) * 100) : 0;
-                        $botPctDay = $row->total > 0 ? round((($row->bot_count ?? 0) / $row->total) * 100) : 0;
+                        $rowTotal  = ($row->human_total ?? 0) + ($row->bot_count ?? 0);
+                        $botPctDay = $rowTotal > 0 ? round((($row->bot_count ?? 0) / $rowTotal) * 100) : 0;
                         $uniq      = ($row->unique_auth ?? 0) + ($row->unique_anon ?? 0);
                         $estRev    = round((($row->human_total ?? 0) / 1000) * $tmdb['rpm'], 2);
                     @endphp
@@ -219,8 +199,6 @@
                         <td class="px-4 py-2.5 text-right text-white">{{ number_format($row->human_total ?? 0) }}</td>
                         <td class="px-4 py-2.5 text-right text-red-400">{{ number_format($row->bot_count ?? 0) }}</td>
                         <td class="px-4 py-2.5 text-right {{ $botPctDay >= 40 ? 'text-red-400' : 'text-gray-500' }}">{{ $botPctDay }}%</td>
-                        <td class="px-4 py-2.5 text-right text-green-400">{{ number_format($row->hits) }}</td>
-                        <td class="px-4 py-2.5 text-right text-purple-400">{{ $pct }}%</td>
                         <td class="px-4 py-2.5 text-right text-orange-400">{{ $uniq }}</td>
                         <td class="px-4 py-2.5 text-right text-accent">${{ number_format($estRev, 2) }}</td>
                     </tr>
@@ -241,7 +219,7 @@
                         <thead>
                             <tr class="border-b border-white/5">
                                 <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Bot</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Page Views</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-white/5">
@@ -266,7 +244,7 @@
                             <tr class="border-b border-white/5">
                                 <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">User</th>
                                 <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
-                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Pages</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-white/5">
@@ -625,6 +603,73 @@
             </div>
         </div>
         @endif
+
+        {{-- Bots + Top users --}}
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+            @if($tmdb['bots_today']->isNotEmpty())
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Bots — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Bot</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['bots_today'] as $b)
+                            <tr>
+                                <td class="px-4 py-2.5 font-mono text-xs text-red-300">{{ $b->bot }}</td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($b->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+
+            @if($tmdb['top_users']->isNotEmpty())
+            <div>
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Top Users — Today</h2>
+                <div class="bg-white/3 border border-white/5 rounded-xl overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-white/5">
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">User</th>
+                                <th class="text-left px-4 py-2.5 text-xs text-gray-500 font-medium">Type</th>
+                                <th class="text-right px-4 py-2.5 text-xs text-gray-500 font-medium">Requests</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach($tmdb['top_users'] as $u)
+                            <tr>
+                                <td class="px-4 py-2.5 font-mono text-xs">
+                                    @if($u->type === 'auth' && $u->user_id)
+                                        <a href="{{ route('admin.users.show', $u->user_id) }}" class="text-gray-300 hover:text-accent transition-colors">{{ $u->label }}</a>
+                                    @elseif($u->hash)
+                                        <a href="{{ route('admin.visitor.show', $u->hash) }}" class="text-gray-300 hover:text-accent transition-colors">{{ $u->label }}</a>
+                                    @else
+                                        <span class="text-gray-500">{{ $u->label }}</span>
+                                    @endif
+                                </td>
+                                <td class="px-4 py-2.5">
+                                    @if($u->type === 'auth')
+                                        <span class="text-xs px-1.5 py-0.5 rounded-full bg-orange-500/10 text-orange-400 border border-orange-500/20">logged in</span>
+                                    @else
+                                        <span class="text-xs px-1.5 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">anon</span>
+                                    @endif
+                                </td>
+                                <td class="px-4 py-2.5 text-right text-white font-semibold">{{ number_format($u->total) }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            @endif
+        </div>
 
         {{-- Recent requests --}}
         <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Recent Requests</h2>


### PR DESCRIPTION
## Summary
- Traffic tab now uses `page_views` exclusively — no more TMDB request log proxying
- Removed TMDB-specific stat cards (Live, Cached, Hit Rate, Avg Response) from traffic tab
- Last 7 Days table drops Cached/Hit% columns, uses page view human/bot counts
- Bots and Top Users in traffic tab now sourced from page views (labels updated accordingly)
- TMDB tab gains its own Bots Today and Top Users sections by TMDB request count
- Controller split into separate `if ($activeTab === 'tmdb')` and `if ($activeTab === 'traffic')` blocks

## Test plan
- [x] Visit /admin?tab=traffic — verify stats show page view counts, no TMDB cache metrics
- [x] Visit /admin?tab=tmdb — verify Bots Today and Top Users sections appear with request counts
- [x] Last 7 Days table on traffic tab has no Cached/Hit% columns