### PR TITLE
Exclude Vitals-Monitor uptime pings from page view tracking

### DIFF
--- a/app/Http/Middleware/LogPageView.php
+++ b/app/Http/Middleware/LogPageView.php
@@ -57,6 +57,9 @@ class LogPageView
             // Skip admin user from traffic stats
             if (auth()->check() && auth()->user()->email === config('api.admin_email')) return;
 
+            // Skip internal uptime monitors
+            if (str_contains($request->userAgent() ?? '', 'Vitals-Monitor')) return;
+
             $route = $request->path() === '/' ? '/' : '/' . ltrim($request->path(), '/');
 
             PageView::create([


### PR DESCRIPTION
## Summary
- Adds a User-Agent check in `LogPageView` middleware to skip requests from `Vitals-Monitor`
- Prevents uptime monitor pings from polluting traffic analytics